### PR TITLE
Skip randomised response for target column

### DIFF
--- a/dp_refactored.py
+++ b/dp_refactored.py
@@ -211,6 +211,8 @@ def run_pipeline(df: pd.DataFrame) -> Dict[str, ModelResult]:
     # Randomised response for categorical columns
     cat_cols = df.select_dtypes(include=['object']).columns
     for col in cat_cols:
+        if col == 'smoker':
+            continue
         datasets['RR'][col] = randomised_response(datasets['RR'][col])
     # Process each dataset
     for name, data in datasets.items():


### PR DESCRIPTION
## Summary
- Avoid applying randomised response to the `smoker` target column so only feature columns receive noise.

## Testing
- `python dp_refactored.py --data insurance.csv` *(fails: demographic_parity_difference() takes 2 positional arguments but 3 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c4ee41f8832689ccbc3662570097