### PR TITLE
Add privacy check utilities and test suite

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,40 @@
+"""Simple command line interface for noise mechanisms.
+
+Reads a CSV file, applies a selected noise mechanism to numeric columns and
+writes the result to a new CSV file.
+"""
+
+import argparse
+import pandas as pd
+from pathlib import Path
+
+from mechanisms import (
+    add_laplace_noise,
+    add_gaussian_noise,
+    add_exponential_noise,
+    add_geometric_noise,
+)
+
+MECHANISMS = {
+    'laplace': add_laplace_noise,
+    'gaussian': add_gaussian_noise,
+    'exponential': add_exponential_noise,
+    'geometric': add_geometric_noise,
+}
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply DP noise mechanism to CSV data")
+    parser.add_argument('--input', type=Path, required=True, help='Input CSV file')
+    parser.add_argument('--output', type=Path, required=True, help='Output CSV file')
+    parser.add_argument('--mechanism', choices=MECHANISMS.keys(), default='laplace')
+    parser.add_argument('--random-state', type=int, default=None)
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input)
+    numeric = df.select_dtypes(include=['number']).columns
+    func = MECHANISMS[args.mechanism]
+    df.loc[:, numeric] = func(df[numeric], random_state=args.random_state)
+    df.to_csv(args.output, index=False)
+
+if __name__ == '__main__':
+    main()

--- a/mechanisms.py
+++ b/mechanisms.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import numpy as np
+
+
+def add_laplace_noise(data: pd.DataFrame, epsilon: float = 0.1, sensitivity: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
+    """Add Laplace noise to numeric columns."""
+    delta = sensitivity / epsilon
+    rng = np.random.default_rng(random_state)
+    noise = rng.laplace(0, delta, data.shape)
+    return data + noise
+
+
+def add_gaussian_noise(data: pd.DataFrame, epsilon: float = 0.1, delta: float = 1e-5, sensitivity: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
+    """Add Gaussian noise using the analytic Gaussian mechanism."""
+    sigma = sensitivity * np.sqrt(2 * np.log(1.25 / delta)) / epsilon
+    rng = np.random.default_rng(random_state)
+    noise = rng.normal(0, sigma, data.shape)
+    return data + noise
+
+
+def add_exponential_noise(data: pd.DataFrame, scale: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
+    """Add exponential noise (Laplacian in L1 space)."""
+    rng = np.random.default_rng(random_state)
+    noise = rng.exponential(scale, data.shape)
+    return data + noise
+
+
+def add_geometric_noise(data: pd.DataFrame, epsilon: float = 0.1, random_state: int | None = None) -> pd.DataFrame:
+    """Add geometric noise for integer‑valued data."""
+    p = 1 - np.exp(-epsilon)
+    rng = np.random.default_rng(random_state)
+    noise = rng.geometric(p, size=data.shape) - 1
+    return data + noise
+
+
+def randomised_response(series: pd.Series, p: float = 0.7, random_state: int | None = None) -> pd.Series:
+    """Apply randomised response to a categorical variable."""
+    values = series.unique()
+    rng = np.random.default_rng(random_state)
+    rand = rng.random(len(series))
+    random_response = rng.choice(values, size=len(series))
+    return pd.Series(np.where(rand < p, series, random_response), index=series.index)

--- a/privacy_checks.py
+++ b/privacy_checks.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import numpy as np
+
+
+def check_k_anonymity(df: pd.DataFrame, quasi_columns: list[str], k: int) -> bool:
+    """Return True if each group defined by quasi_columns has at least k rows."""
+    group_sizes = df.groupby(quasi_columns).size()
+    return bool((group_sizes >= k).all())
+
+
+def check_l_diversity(df: pd.DataFrame, quasi_columns: list[str], sensitive_column: str, l: int) -> bool:
+    """Return True if each quasi-identifier group has at least l distinct sensitive values."""
+    diversity = df.groupby(quasi_columns)[sensitive_column].nunique()
+    return bool((diversity >= l).all())
+
+
+def check_t_closeness(df: pd.DataFrame, quasi_columns: list[str], sensitive_column: str, t: float) -> bool:
+    """Return True if distribution of sensitive column in each group is within t of overall distribution.
+
+    The distance metric used is total variation distance (half the L1 difference).
+    """
+    overall_dist = df[sensitive_column].value_counts(normalize=True)
+    for _, group in df.groupby(quasi_columns):
+        group_dist = group[sensitive_column].value_counts(normalize=True)
+        # align indices
+        aligned = overall_dist.to_frame('overall').join(group_dist.to_frame('group'), how='outer').fillna(0)
+        tvd = 0.5 * np.abs(aligned['overall'] - aligned['group']).sum()
+        if tvd > t:
+            return False
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pandas.testing as pdt
+
+
+def test_cli_creates_deterministic_output(tmp_path):
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+    input_path = tmp_path / 'data.csv'
+    df.to_csv(input_path, index=False)
+
+    out1 = tmp_path / 'out1.csv'
+    cmd = [sys.executable, 'cli.py', '--input', str(input_path), '--output', str(out1), '--mechanism', 'laplace', '--random-state', '0']
+    subprocess.run(cmd, check=True)
+    assert out1.exists()
+    res1 = pd.read_csv(out1)
+
+    out2 = tmp_path / 'out2.csv'
+    cmd[-2] = str(out2)  # replace output path
+    subprocess.run(cmd, check=True)
+    res2 = pd.read_csv(out2)
+
+    pdt.assert_frame_equal(res1, res2)

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+import pandas.testing as pdt
+
+from mechanisms import (
+    add_laplace_noise,
+    add_gaussian_noise,
+    add_exponential_noise,
+    add_geometric_noise,
+    randomised_response,
+)
+
+
+def _check_noise(func):
+    data = pd.DataFrame(np.zeros((10, 5)))
+    out1 = func(data, random_state=0)
+    out2 = func(data, random_state=0)
+    assert out1.shape == data.shape
+    pdt.assert_frame_equal(out1, out2)
+    out3 = func(data, random_state=1)
+    assert not out1.equals(out3)
+
+
+def test_laplace_noise():
+    _check_noise(add_laplace_noise)
+
+
+def test_gaussian_noise():
+    _check_noise(add_gaussian_noise)
+
+
+def test_exponential_noise():
+    _check_noise(add_exponential_noise)
+
+
+def test_geometric_noise():
+    _check_noise(add_geometric_noise)
+
+
+def test_randomised_response():
+    series = pd.Series(['a', 'b', 'c', 'a'])
+    out1 = randomised_response(series, random_state=0)
+    out2 = randomised_response(series, random_state=0)
+    assert out1.shape == series.shape
+    pdt.assert_series_equal(out1, out2)
+    out3 = randomised_response(series, random_state=1)
+    assert not out1.equals(out3)

--- a/tests/test_privacy_checks.py
+++ b/tests/test_privacy_checks.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+from privacy_checks import (
+    check_k_anonymity,
+    check_l_diversity,
+    check_t_closeness,
+)
+
+
+def test_k_anonymity():
+    df = pd.DataFrame(
+        {
+            'q1': [1, 1, 2, 2],
+            'q2': [1, 1, 2, 2],
+            's': ['a', 'b', 'a', 'b'],
+        }
+    )
+    assert check_k_anonymity(df, ['q1', 'q2'], k=2)
+    df_fail = df.copy()
+    df_fail.loc[0, 'q1'] = 3
+    assert not check_k_anonymity(df_fail, ['q1', 'q2'], k=2)
+
+
+def test_l_diversity():
+    df = pd.DataFrame(
+        {
+            'q': [1, 1, 2, 2],
+            's': ['a', 'b', 'a', 'b'],
+        }
+    )
+    assert check_l_diversity(df, ['q'], 's', l=2)
+    df_fail = pd.DataFrame(
+        {
+            'q': [1, 1, 2, 2],
+            's': ['a', 'a', 'a', 'b'],
+        }
+    )
+    assert not check_l_diversity(df_fail, ['q'], 's', l=2)
+
+
+def test_t_closeness():
+    df = pd.DataFrame(
+        {
+            'q': [1, 1, 2, 2],
+            's': ['a', 'b', 'a', 'b'],
+        }
+    )
+    assert check_t_closeness(df, ['q'], 's', t=0.1)
+    df_fail = pd.DataFrame(
+        {
+            'q': [1, 1, 2, 2],
+            's': ['a', 'a', 'a', 'b'],
+        }
+    )
+    assert not check_t_closeness(df_fail, ['q'], 's', t=0.1)


### PR DESCRIPTION
## Summary
- Introduce modular noise mechanisms and CLI for applying them to CSV data
- Add k-anonymity, l-diversity, and t-closeness helpers with accompanying unit tests
- Provide pytest coverage for noise reproducibility and CLI determinism

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install numpy pandas -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb1e39bc8326a26bce1a512fea4f