### PR TITLE
Add CLI for differential privacy mechanisms

### DIFF
--- a/dp_cli.py
+++ b/dp_cli.py
@@ -1,0 +1,95 @@
+"""Command-line interface for applying differential privacy mechanisms."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+import io_utils
+import mechanisms
+import privacy_checks as pc
+
+
+def _parse_cols(arg: str | None) -> List[str] | None:
+    if arg is None:
+        return None
+    return [c.strip() for c in arg.split(',') if c.strip()]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Apply differential privacy mechanisms")
+    parser.add_argument("--input", required=True, help="Input CSV file")
+    parser.add_argument("--output", required=True, help="Directory for output CSVs")
+    parser.add_argument("--methods", required=True, help="Comma separated list of methods")
+    parser.add_argument("--epsilon", type=float, default=1.0, help="Privacy epsilon")
+    parser.add_argument("--delta", type=float, default=1e-5, help="Delta for Gaussian noise")
+    parser.add_argument("--k", type=int, default=0, help="k for k-anonymity")
+    parser.add_argument("--truth-p", type=float, default=0.75, dest="truth_p",
+                        help="Truth probability for randomised response")
+    parser.add_argument("--cat-cols", dest="cat_cols",
+                        help="Comma separated categorical column names")
+    parser.add_argument("--num-cols", dest="num_cols",
+                        help="Comma separated numeric column names")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed")
+    parser.add_argument("--strict", action="store_true",
+                        help="Fail if k-anonymity check fails")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    df = io_utils.read_csv(args.input)
+    cat_cols = _parse_cols(args.cat_cols)
+    num_cols = _parse_cols(args.num_cols)
+    cat_cols, num_cols = io_utils.infer_columns(df, cat_cols, num_cols)
+
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    methods = [m.strip().lower() for m in args.methods.split(',') if m.strip()]
+
+    summary = []
+    for method in methods:
+        current = df.copy()
+        if method == "laplace":
+            current[num_cols] = mechanisms.add_laplace_noise(
+                current[num_cols], epsilon=args.epsilon, seed=args.seed
+            )
+        elif method == "gaussian":
+            current[num_cols] = mechanisms.add_gaussian_noise(
+                current[num_cols], epsilon=args.epsilon, delta=args.delta, seed=args.seed
+            )
+        elif method == "exponential":
+            current[num_cols] = mechanisms.add_exponential_noise(
+                current[num_cols], epsilon=args.epsilon, seed=args.seed
+            )
+        elif method == "geometric":
+            current[num_cols] = mechanisms.add_geometric_noise(
+                current[num_cols], epsilon=args.epsilon, seed=args.seed
+            )
+        elif method in {"rr", "randomised_response", "randomized_response"}:
+            for col in cat_cols:
+                current[col] = mechanisms.randomised_response(
+                    current[col], truth_p=args.truth_p, seed=args.seed
+                )
+        elif method in {"k", "k-anon", "k_anonymity", "kanonymity"}:
+            current = pc.enforce_k_anonymity(current, cat_cols, args.k)
+        else:
+            raise ValueError(f"Unknown method: {method}")
+
+        k_pass = True
+        if args.k > 0:
+            k_pass = pc.check_k_anonymity(current, cat_cols, args.k)
+            if not k_pass and args.strict:
+                raise SystemExit(f"k-anonymity check failed for {method}")
+
+        out_file = out_dir / f"{Path(args.input).stem}_{method}.csv"
+        current.to_csv(out_file, index=False)
+        summary.append({"method": method, "rows": len(current), "k_pass": k_pass})
+
+    print(pd.DataFrame(summary).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/io_utils.py
+++ b/io_utils.py
@@ -1,0 +1,24 @@
+"""Utility helpers for I/O and column type inference."""
+from __future__ import annotations
+
+from typing import List, Tuple, Optional
+
+import pandas as pd
+
+
+def read_csv(path: str) -> pd.DataFrame:
+    """Read a CSV file into a DataFrame."""
+    return pd.read_csv(path)
+
+
+def infer_columns(
+    df: pd.DataFrame,
+    cat_cols: Optional[List[str]] = None,
+    num_cols: Optional[List[str]] = None,
+) -> Tuple[List[str], List[str]]:
+    """Infer categorical and numeric columns if not provided."""
+    if cat_cols is None:
+        cat_cols = df.select_dtypes(include=["object", "category", "bool"]).columns.tolist()
+    if num_cols is None:
+        num_cols = df.select_dtypes(include=["number"]).columns.tolist()
+    return cat_cols, num_cols

--- a/mechanisms.py
+++ b/mechanisms.py
@@ -1,0 +1,70 @@
+"""Differential privacy mechanisms used by the CLI."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+
+def add_laplace_noise(
+    data: pd.DataFrame,
+    epsilon: float,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Apply Laplace noise to numeric data."""
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / epsilon
+    noise = rng.laplace(0.0, scale, size=data.shape)
+    return data + noise
+
+
+def add_gaussian_noise(
+    data: pd.DataFrame,
+    epsilon: float,
+    delta: float,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Apply Gaussian noise using the analytic mechanism."""
+    sigma = np.sqrt(2.0 * np.log(1.25 / delta)) / epsilon
+    rng = np.random.default_rng(seed)
+    noise = rng.normal(0.0, sigma, size=data.shape)
+    return data + noise
+
+
+def add_exponential_noise(
+    data: pd.DataFrame,
+    epsilon: float,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Apply exponential noise to numeric data."""
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / epsilon
+    noise = rng.exponential(scale, size=data.shape)
+    return data + noise
+
+
+def add_geometric_noise(
+    data: pd.DataFrame,
+    epsilon: float,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Apply geometric noise for integer data."""
+    p = 1 - np.exp(-epsilon)
+    rng = np.random.default_rng(seed)
+    noise = rng.geometric(p, size=data.shape) - 1
+    return data + noise
+
+
+def randomised_response(
+    series: pd.Series,
+    truth_p: float,
+    seed: Optional[int] = None,
+) -> pd.Series:
+    """Randomised response for categorical data."""
+    rng = np.random.default_rng(seed)
+    categories = series.unique()
+    report_truth = rng.random(len(series)) < truth_p
+    res = series.copy()
+    res[~report_truth] = rng.choice(categories, size=(~report_truth).sum())
+    return res

--- a/privacy_checks.py
+++ b/privacy_checks.py
@@ -1,0 +1,22 @@
+"""Anonymisation helpers such as k-anonymity checks."""
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+
+def check_k_anonymity(df: pd.DataFrame, cat_cols: List[str], k: int) -> bool:
+    """Return True if every group defined by ``cat_cols`` has at least ``k`` rows."""
+    if not cat_cols or k <= 1:
+        return True
+    group_sizes = df.groupby(cat_cols).size()
+    return (group_sizes >= k).all()
+
+
+def enforce_k_anonymity(df: pd.DataFrame, cat_cols: List[str], k: int) -> pd.DataFrame:
+    """Drop records that do not satisfy k-anonymity."""
+    if not cat_cols or k <= 1:
+        return df
+    sizes = df.groupby(cat_cols).transform("size")
+    return df[sizes >= k].reset_index(drop=True)


### PR DESCRIPTION
## Summary
- Add `dp_cli` to apply noise and k-anonymity from the command line
- Factor out DP mechanisms and anonymity helpers into separate modules
- Provide I/O utilities for CSV loading and column type inference

## Testing
- `pytest`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy==1.23.5)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb091ad48326a41eaede154a876c