### PR TITLE
Centralize DP defaults and RNG helper

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import numpy as np
+
+# Default configuration values for the differential privacy pipeline
+EPSILON: float = 0.1
+DELTA: float = 1e-5
+SENSITIVITY: float = 1.0
+TRUTH_P: float = 0.7
+K: int = 5
+
+
+def get_rng(seed: int | None = None) -> np.random.Generator:
+    """Return a NumPy random number generator initialised with ``seed``.
+
+    Parameters
+    ----------
+    seed: int | None
+        Seed for reproducibility. ``None`` yields an unpredictable generator.
+    """
+    return np.random.default_rng(seed)


### PR DESCRIPTION
## Summary
- add `defaults.py` with shared constants and `get_rng` utility
- update noise and anonymization functions to use new defaults and RNG helper

## Testing
- `python -m py_compile defaults.py dp_refactored.py`
- `python dp_refactored.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cb1033c08326b590bbeb6db4bd74