### PR TITLE
Document editable install and CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository demonstrates how to apply **differential privacy** techniques to a tabular health‑insurance dataset and measure the impact of privacy on downstream machine‑learning models.  It grew out of an academic project, but all institution‑specific content has been removed so that the work can be shared freely on GitHub.
 
+For a deeper theoretical background on differential privacy concepts, see the [report](report.md).
+
 ## Overview
 
 The included Jupyter notebook (`differential_privacy.ipynb`) walks through the following steps:
@@ -23,11 +25,13 @@ The notebook is fully executable and makes no assumptions about prior infrastruc
    cd your‑repo
    ```
 
-2. **Install the dependencies**.  A `requirements.txt` is provided for convenience:
+2. **Install the project** in editable mode so that its modules and CLI are available system‑wide:
 
    ```bash
-   python -m pip install -r requirements.txt
+   pip install -e .
    ```
+
+   This installs the package along with the required dependencies.
 
 3. **Add the dataset**.  The notebook expects a CSV file named `insurance.csv` in the repository root.  You can supply your own dataset or download a public insurance dataset such as the one from the Kaggle medical‑cost dataset.
 
@@ -42,6 +46,19 @@ Alternatively, you can execute the notebook from the command line using `nbconve
 ```bash
 jupyter nbconvert --to notebook --execute --inplace differential_privacy.ipynb
 ```
+
+## Command-line interface
+
+After installation, the pipeline can also be run as a script:
+
+```bash
+python dp_refactored.py --data insurance.csv --random-state 42
+```
+
+**Flags**
+
+* `--data` – path to the insurance CSV dataset (default: `insurance.csv`).
+* `--random-state` – random seed for reproducibility (default: `42`).
 
 ## Continuous integration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "differential-privacy"
+version = "0.1.0"
+description = "Differential Privacy Machine-Learning Pipeline"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "pandas",
+    "scikit-learn",
+    "imbalanced-learn",
+    "keras",
+    "tensorflow",
+    "fairlearn",
+]
+
+[tool.setuptools]
+py-modules = ["dp_refactored"]


### PR DESCRIPTION
## Summary
- Link README to report.md for theoretical background.
- Document editable installation with `pip install -e .`.
- Describe CLI usage and flags for running `dp_refactored.py`.
- Add `pyproject.toml` enabling editable installs.

## Testing
- `python -m pip install -e . --no-deps` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -m pip install -e . --no-deps --no-build-isolation` *(fails: Cannot import 'setuptools.build_meta')*
- `python dp_refactored.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cb1772948326b330c692d05d3a27