### PR TITLE
Add Tkinter-based GUI for noise mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ python dp_refactored.py --data insurance.csv --random-state 42
 * `--data` – path to the insurance CSV dataset (default: `insurance.csv`).
 * `--random-state` – random seed for reproducibility (default: `42`).
 
+## Graphical interface
+
+A minimal Tkinter GUI is also available after installation:
+
+```bash
+dp-gui
+```
+
+The window lets you select input and output CSV files, choose a noise
+mechanism and adjust parameters before writing the transformed data.  The GUI
+depends on Python's Tkinter library which may need to be installed separately
+on some systems (e.g. `sudo apt install python3-tk`).
+
 ## Continuous integration
 
 For convenience, this repository includes a GitHub Actions workflow that will run the notebook on every push and pull request.  It sets up a Python environment, installs the dependencies and executes `differential_privacy.ipynb` using `nbconvert`.  If the notebook runs successfully, the workflow will finish with a green check mark.  You can find the workflow definition in `.github/workflows/run‑notebook.yml`.

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,134 @@
+"""Simple Tkinter GUI for applying differential privacy mechanisms to CSV files."""
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+import pandas as pd
+
+from mechanisms import (
+    add_laplace_noise,
+    add_gaussian_noise,
+    add_exponential_noise,
+    add_geometric_noise,
+    randomised_response,
+)
+
+MECHANISMS = [
+    "Laplace",
+    "Gaussian",
+    "Exponential",
+    "Geometric",
+    "Randomised Response",
+]
+
+
+def main() -> None:
+    """Launch the GUI."""
+    root = tk.Tk()
+    root.title("Differential Privacy GUI")
+
+    # Variables
+    input_var = tk.StringVar()
+    output_var = tk.StringVar()
+    mechanism_var = tk.StringVar(value=MECHANISMS[0])
+    epsilon_var = tk.StringVar()
+    delta_var = tk.StringVar()
+    scale_var = tk.StringVar()
+    sensitivity_var = tk.StringVar()
+    seed_var = tk.StringVar()
+
+    def browse_input() -> None:
+        path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
+        if path:
+            input_var.set(path)
+
+    def browse_output() -> None:
+        path = filedialog.asksaveasfilename(defaultextension=".csv", filetypes=[("CSV files", "*.csv")])
+        if path:
+            output_var.set(path)
+
+    def run() -> None:
+        """Apply the selected mechanism and save the result."""
+        inp = input_var.get()
+        out = output_var.get()
+        mech = mechanism_var.get()
+        try:
+            df = pd.read_csv(inp)
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror("Error", f"Failed to read input file: {exc}")
+            return
+
+        numeric = df.select_dtypes(include="number")
+        categorical = df.select_dtypes(exclude="number")
+
+        try:
+            eps = float(epsilon_var.get()) if epsilon_var.get() else 0.1
+            delt = float(delta_var.get()) if delta_var.get() else 1e-5
+            scale = float(scale_var.get()) if scale_var.get() else 1.0
+            sens = float(sensitivity_var.get()) if sensitivity_var.get() else 1.0
+            seed = int(seed_var.get()) if seed_var.get() else None
+
+            if mech == "Laplace":
+                df[numeric.columns] = add_laplace_noise(
+                    numeric, epsilon=eps, sensitivity=sens, random_state=seed
+                )
+            elif mech == "Gaussian":
+                df[numeric.columns] = add_gaussian_noise(
+                    numeric,
+                    epsilon=eps,
+                    delta=delt,
+                    sensitivity=sens,
+                    random_state=seed,
+                )
+            elif mech == "Exponential":
+                df[numeric.columns] = add_exponential_noise(
+                    numeric, scale=scale, random_state=seed
+                )
+            elif mech == "Geometric":
+                df[numeric.columns] = add_geometric_noise(
+                    numeric, epsilon=eps, random_state=seed
+                )
+            elif mech == "Randomised Response":
+                for col in categorical.columns:
+                    df[col] = randomised_response(categorical[col], random_state=seed)
+
+            df.to_csv(out, index=False)
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            messagebox.showerror("Error", str(exc))
+            return
+
+        messagebox.showinfo("Success", f"Saved output to {out}")
+
+    # Layout
+    tk.Label(root, text="Input CSV:").grid(row=0, column=0, sticky="e")
+    tk.Entry(root, textvariable=input_var, width=40).grid(row=0, column=1)
+    tk.Button(root, text="Browse", command=browse_input).grid(row=0, column=2)
+
+    tk.Label(root, text="Output CSV:").grid(row=1, column=0, sticky="e")
+    tk.Entry(root, textvariable=output_var, width=40).grid(row=1, column=1)
+    tk.Button(root, text="Browse", command=browse_output).grid(row=1, column=2)
+
+    tk.Label(root, text="Mechanism:").grid(row=2, column=0, sticky="e")
+    tk.OptionMenu(root, mechanism_var, *MECHANISMS).grid(row=2, column=1, sticky="w")
+
+    tk.Label(root, text="Epsilon:").grid(row=3, column=0, sticky="e")
+    tk.Entry(root, textvariable=epsilon_var).grid(row=3, column=1, sticky="w")
+
+    tk.Label(root, text="Delta:").grid(row=4, column=0, sticky="e")
+    tk.Entry(root, textvariable=delta_var).grid(row=4, column=1, sticky="w")
+
+    tk.Label(root, text="Scale:").grid(row=5, column=0, sticky="e")
+    tk.Entry(root, textvariable=scale_var).grid(row=5, column=1, sticky="w")
+
+    tk.Label(root, text="Sensitivity:").grid(row=6, column=0, sticky="e")
+    tk.Entry(root, textvariable=sensitivity_var).grid(row=6, column=1, sticky="w")
+
+    tk.Label(root, text="Random seed:").grid(row=7, column=0, sticky="e")
+    tk.Entry(root, textvariable=seed_var).grid(row=7, column=1, sticky="w")
+
+    tk.Button(root, text="Run", command=run).grid(row=8, column=1)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,8 @@ dependencies = [
     "fairlearn",
 ]
 
+[project.scripts]
+dp-gui = "gui:main"
+
 [tool.setuptools]
-py-modules = ["dp_refactored"]
+py-modules = ["dp_refactored", "cli", "mechanisms", "privacy_checks", "gui"]


### PR DESCRIPTION
## Summary
- add Tkinter GUI allowing selection of CSV paths, mechanism and parameters, writing noised output
- expose GUI via `dp-gui` console script and package module
- document GUI usage and Tkinter requirement in README

## Testing
- `pip install -q numpy pandas`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae38b3cac483268070fd44ef99f5d2