### PR TITLE
Use epsilon for exponential mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For a deeper theoretical background on differential privacy concepts, see the [r
 The included Jupyter notebook (`differential_privacy.ipynb`) walks through the following steps:
 
 1. **Data loading and exploration** –  We start with a sample insurance dataset containing demographic and health‑related features (age, sex, BMI, number of children, smoker status, region and charges).  Basic exploratory analysis is performed on numeric features.
-2. **Noise injection** –  Laplace and Gaussian noise are added to the dataset at both random and fixed magnitudes to provide differential‑privacy guarantees.  The code demonstrates how to implement custom noise functions and apply them to sensitive attributes.
+2. **Noise injection** –  Laplace, Gaussian and Exponential noise are added to the dataset at both random and fixed magnitudes to provide differential‑privacy guarantees.  The noise functions accept a privacy budget ``epsilon`` (and optional ``sensitivity``), computing any required scale internally.
 3. **Anonymisation** –  We anonymise certain quasi‑identifiers by grouping continuous features into buckets (e.g. converting raw age into age groups) and binarising the number of children.  This improves privacy through *k‑anonymity*, *l‑diversity* and *t‑closeness* without destroying utility.
 4. **Machine‑learning models** –  Three classifiers are trained on the original and noised datasets: Support Vector Machines, a basic Neural Network and a Decision Tree.  The goal is to understand how privacy noise affects predictive performance.
 5. **Fairness metrics** –  For each trained model we compute demographic‑parity and equal‑opportunity metrics to see how the addition of noise impacts fairness across sensitive groups.

--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,8 @@ def main():
     parser.add_argument('--output', type=Path, required=True, help='Output CSV file')
     parser.add_argument('--mechanism', choices=MECHANISMS.keys(), default='laplace')
     parser.add_argument('--random-state', type=int, default=None)
+    parser.add_argument('--epsilon', type=float, default=0.1)
+    parser.add_argument('--sensitivity', type=float, default=1.0)
     # ``argparse`` raises an error if unexpected arguments are supplied.  The
     # tests for this repository mutate the command list in-place to change the
     # output path for a second invocation.  The mutation accidentally drops the
@@ -55,7 +57,12 @@ def main():
     df = pd.read_csv(args.input)
     numeric = df.select_dtypes(include=['number']).columns
     func = MECHANISMS[args.mechanism]
-    df.loc[:, numeric] = func(df[numeric], random_state=args.random_state)
+    kwargs = {'random_state': args.random_state}
+    if args.mechanism in {'laplace', 'gaussian', 'exponential', 'geometric'}:
+        kwargs['epsilon'] = args.epsilon
+    if args.mechanism in {'laplace', 'gaussian', 'exponential'}:
+        kwargs['sensitivity'] = args.sensitivity
+    df.loc[:, numeric] = func(df[numeric], **kwargs)
     df.to_csv(args.output, index=False)
 
 if __name__ == '__main__':

--- a/gui.py
+++ b/gui.py
@@ -32,7 +32,6 @@ def main() -> None:
     mechanism_var = tk.StringVar(value=MECHANISMS[0])
     epsilon_var = tk.StringVar()
     delta_var = tk.StringVar()
-    scale_var = tk.StringVar()
     sensitivity_var = tk.StringVar()
     seed_var = tk.StringVar()
 
@@ -63,7 +62,6 @@ def main() -> None:
         try:
             eps = float(epsilon_var.get()) if epsilon_var.get() else 0.1
             delt = float(delta_var.get()) if delta_var.get() else 1e-5
-            scale = float(scale_var.get()) if scale_var.get() else 1.0
             sens = float(sensitivity_var.get()) if sensitivity_var.get() else 1.0
             seed = int(seed_var.get()) if seed_var.get() else None
 
@@ -81,7 +79,7 @@ def main() -> None:
                 )
             elif mech == "Exponential":
                 df[numeric.columns] = add_exponential_noise(
-                    numeric, scale=scale, random_state=seed
+                    numeric, epsilon=eps, sensitivity=sens, random_state=seed
                 )
             elif mech == "Geometric":
                 df[numeric.columns] = add_geometric_noise(
@@ -116,16 +114,13 @@ def main() -> None:
     tk.Label(root, text="Delta:").grid(row=4, column=0, sticky="e")
     tk.Entry(root, textvariable=delta_var).grid(row=4, column=1, sticky="w")
 
-    tk.Label(root, text="Scale:").grid(row=5, column=0, sticky="e")
-    tk.Entry(root, textvariable=scale_var).grid(row=5, column=1, sticky="w")
+    tk.Label(root, text="Sensitivity:").grid(row=5, column=0, sticky="e")
+    tk.Entry(root, textvariable=sensitivity_var).grid(row=5, column=1, sticky="w")
 
-    tk.Label(root, text="Sensitivity:").grid(row=6, column=0, sticky="e")
-    tk.Entry(root, textvariable=sensitivity_var).grid(row=6, column=1, sticky="w")
+    tk.Label(root, text="Random seed:").grid(row=6, column=0, sticky="e")
+    tk.Entry(root, textvariable=seed_var).grid(row=6, column=1, sticky="w")
 
-    tk.Label(root, text="Random seed:").grid(row=7, column=0, sticky="e")
-    tk.Entry(root, textvariable=seed_var).grid(row=7, column=1, sticky="w")
-
-    tk.Button(root, text="Run", command=run).grid(row=8, column=1)
+    tk.Button(root, text="Run", command=run).grid(row=7, column=1)
 
     root.mainloop()
 

--- a/mechanisms.py
+++ b/mechanisms.py
@@ -18,8 +18,24 @@ def add_gaussian_noise(data: pd.DataFrame, epsilon: float = 0.1, delta: float = 
     return data + noise
 
 
-def add_exponential_noise(data: pd.DataFrame, scale: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
-    """Add exponential noise (Laplacian in L1 space)."""
+def add_exponential_noise(
+    data: pd.DataFrame,
+    epsilon: float = 0.1,
+    sensitivity: float = 1.0,
+    random_state: int | None = None,
+) -> pd.DataFrame:
+    """Add exponential noise (Laplacian in L1 space).
+
+    Args:
+        data: Data to perturb.
+        epsilon: Privacy budget controlling the noise.
+        sensitivity: Query sensitivity.
+        random_state: Seed for the random number generator.
+
+    Returns:
+        DataFrame with exponential noise added to numeric columns.
+    """
+    scale = sensitivity / epsilon
     rng = np.random.default_rng(random_state)
     noise = rng.exponential(scale, data.shape)
     return data + noise


### PR DESCRIPTION
## Summary
- Switch exponential noise to use epsilon and optional sensitivity
- Forward epsilon and sensitivity through CLI and GUI
- Clarify README on noise mechanisms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a694218832681e845fbaadfb27e