### PR TITLE
Add randomised-response mechanism to CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,3 +23,34 @@ def test_cli_creates_deterministic_output(tmp_path):
     res2 = pd.read_csv(out2)
 
     pdt.assert_frame_equal(res1, res2)
+
+
+def test_cli_randomised_response_deterministic(tmp_path):
+    df = pd.DataFrame({'a': ['x', 'y', 'z'], 'b': ['cat', 'dog', 'cat']})
+    input_path = tmp_path / 'data.csv'
+    df.to_csv(input_path, index=False)
+
+    out1 = tmp_path / 'out1.csv'
+    cmd = [
+        sys.executable,
+        'cli.py',
+        '--input',
+        str(input_path),
+        '--output',
+        str(out1),
+        '--mechanism',
+        'randomised-response',
+        '--probability',
+        '0.6',
+        '--random-state',
+        '0',
+    ]
+    subprocess.run(cmd, check=True)
+    res1 = pd.read_csv(out1)
+
+    out2 = tmp_path / 'out2.csv'
+    cmd[-2] = str(out2)
+    subprocess.run(cmd, check=True)
+    res2 = pd.read_csv(out2)
+
+    pdt.assert_frame_equal(res1, res2)


### PR DESCRIPTION
## Summary
- support randomised response via `--mechanism randomised-response`
- add `--probability` flag to control truthful response rate
- include deterministic test for randomised response in CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae3ca933ac832686d305c06302ca89