### PR TITLE
Clarify noise utilities

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -2,16 +2,48 @@ import pandas as pd
 import numpy as np
 
 
-def add_laplace_noise(data: pd.DataFrame, epsilon: float = 0.1, sensitivity: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
-    """Add Laplace noise to numeric columns."""
-    delta = sensitivity / epsilon
+def add_laplace_noise(
+    data: pd.DataFrame,
+    epsilon: float = 0.1,
+    sensitivity: float = 1.0,
+    random_state: int | None = None,
+) -> pd.DataFrame:
+    """Add Laplace noise to numeric columns.
+
+    Args:
+        data: Data to perturb.
+        epsilon: Privacy budget controlling the noise magnitude.
+        sensitivity: Query sensitivity.
+        random_state: Seed for the random number generator.
+
+    Returns:
+        DataFrame with Laplace noise added to numeric columns.
+    """
+    scale = sensitivity / epsilon
     rng = np.random.default_rng(random_state)
-    noise = rng.laplace(0, delta, data.shape)
+    noise = rng.laplace(0, scale, data.shape)
     return data + noise
 
 
-def add_gaussian_noise(data: pd.DataFrame, epsilon: float = 0.1, delta: float = 1e-5, sensitivity: float = 1.0, random_state: int | None = None) -> pd.DataFrame:
-    """Add Gaussian noise using the analytic Gaussian mechanism."""
+def add_gaussian_noise(
+    data: pd.DataFrame,
+    epsilon: float = 0.1,
+    delta: float = 1e-5,
+    sensitivity: float = 1.0,
+    random_state: int | None = None,
+) -> pd.DataFrame:
+    """Add Gaussian noise using the analytic Gaussian mechanism.
+
+    Args:
+        data: Data to perturb.
+        epsilon: Privacy budget controlling the noise magnitude.
+        delta: Probability of privacy breach in the Gaussian mechanism.
+        sensitivity: Query sensitivity.
+        random_state: Seed for the random number generator.
+
+    Returns:
+        DataFrame with Gaussian noise added to numeric columns.
+    """
     sigma = sensitivity * np.sqrt(2 * np.log(1.25 / delta)) / epsilon
     rng = np.random.default_rng(random_state)
     noise = rng.normal(0, sigma, data.shape)
@@ -24,11 +56,11 @@ def add_exponential_noise(
     sensitivity: float = 1.0,
     random_state: int | None = None,
 ) -> pd.DataFrame:
-    """Add exponential noise (Laplacian in L1 space).
+    """Add exponential noise to numeric columns.
 
     Args:
         data: Data to perturb.
-        epsilon: Privacy budget controlling the noise.
+        epsilon: Privacy budget controlling the noise magnitude.
         sensitivity: Query sensitivity.
         random_state: Seed for the random number generator.
 
@@ -41,8 +73,19 @@ def add_exponential_noise(
     return data + noise
 
 
-def add_geometric_noise(data: pd.DataFrame, epsilon: float = 0.1, random_state: int | None = None) -> pd.DataFrame:
-    """Add geometric noise for integer‑valued data."""
+def add_geometric_noise(
+    data: pd.DataFrame, epsilon: float = 0.1, random_state: int | None = None
+) -> pd.DataFrame:
+    """Add geometric noise for integer‑valued data.
+
+    Args:
+        data: Data to perturb.
+        epsilon: Privacy budget controlling the noise magnitude.
+        random_state: Seed for the random number generator.
+
+    Returns:
+        DataFrame with geometric noise added to integer‑valued columns.
+    """
     p = 1 - np.exp(-epsilon)
     rng = np.random.default_rng(random_state)
     noise = rng.geometric(p, size=data.shape) - 1


### PR DESCRIPTION
## Summary
- rename internal Laplace noise scale variable to `scale`
- expand docstrings for all noise mechanisms describing parameters, behavior, and return types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d993d5c8326811bac9e5c4d01aa