### PR TITLE
Preserve integer dtype in geometric noise

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -42,11 +42,19 @@ def add_exponential_noise(
 
 
 def add_geometric_noise(data: pd.DataFrame, epsilon: float = 0.1, random_state: int | None = None) -> pd.DataFrame:
-    """Add geometric noise for integer‑valued data."""
+    """Add geometric noise for integer‑valued data.
+
+    Noise is drawn from a geometric distribution and added to each column. If a
+    column has an integer dtype, the result is rounded and cast back to that
+    integer type after noise is added.
+    """
     p = 1 - np.exp(-epsilon)
     rng = np.random.default_rng(random_state)
     noise = rng.geometric(p, size=data.shape) - 1
-    return data + noise
+    noised = data + noise
+    for col in data.select_dtypes(include="integer").columns:
+        noised[col] = noised[col].round().astype(data[col].dtype)
+    return noised
 
 
 def randomised_response(series: pd.Series, p: float = 0.7, random_state: int | None = None) -> pd.Series:

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -37,6 +37,12 @@ def test_geometric_noise():
     _check_noise(add_geometric_noise)
 
 
+def test_geometric_noise_integer_output():
+    data = pd.DataFrame(np.zeros((10, 5), dtype=int))
+    out = add_geometric_noise(data, random_state=0)
+    assert all(pd.api.types.is_integer_dtype(dtype) for dtype in out.dtypes)
+
+
 def test_randomised_response():
     series = pd.Series(['a', 'b', 'c', 'a'])
     out1 = randomised_response(series, random_state=0)


### PR DESCRIPTION
## Summary
- round and cast geometric mechanism output to integers for integer-typed inputs
- document integer casting behavior in `add_geometric_noise`
- add test ensuring geometric noise returns integers for integer data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d99f9d08326a688a791db9cb058