### PR TITLE
feat: improve geometric mechanism

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -88,8 +88,16 @@ def add_geometric_noise(
     """
     p = 1 - np.exp(-epsilon)
     rng = np.random.default_rng(random_state)
-    noise = rng.geometric(p, size=data.shape) - 1
-    return data + noise
+    # Generate signed geometric noise by subtracting two independent draws.
+    noise = rng.geometric(p, size=data.shape) - rng.geometric(p, size=data.shape)
+    noisy = data + noise
+
+    # Preserve integer dtypes by rounding and casting back to the original type.
+    int_cols = data.select_dtypes(include="integer").columns
+    for col in int_cols:
+        noisy[col] = noisy[col].round().astype(data[col].dtype)
+
+    return noisy
 
 
 def randomised_response(series: pd.Series, p: float = 0.7, random_state: int | None = None) -> pd.Series:

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -37,6 +37,15 @@ def test_geometric_noise():
     _check_noise(add_geometric_noise)
 
 
+def test_geometric_noise_centered():
+    data = pd.DataFrame(np.zeros((10000, 1), dtype=int))
+    noisy = add_geometric_noise(data, epsilon=1.0, random_state=0)
+    noise = (noisy - data).to_numpy().ravel()
+    assert abs(noise.mean()) < 0.05
+    # Integer dtypes should be preserved after adding noise
+    assert noisy.dtypes.equals(data.dtypes)
+
+
 def test_randomised_response():
     series = pd.Series(['a', 'b', 'c', 'a'])
     out1 = randomised_response(series, random_state=0)


### PR DESCRIPTION
## Summary
- generate signed geometric noise using two draws
- preserve integer column types when adding geometric noise
- test geometric noise is centered around zero

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7cbf3b5c8326a5de580749abde24