### PR TITLE
Center exponential mechanism noise around zero

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -69,7 +69,7 @@ def add_exponential_noise(
     """
     scale = sensitivity / epsilon
     rng = np.random.default_rng(random_state)
-    noise = rng.exponential(scale, data.shape)
+    noise = rng.exponential(scale, data.shape) - scale
     return data + noise
 
 

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -33,6 +33,13 @@ def test_exponential_noise():
     _check_noise(add_exponential_noise)
 
 
+def test_exponential_noise_centered():
+    data = pd.DataFrame(np.zeros((10000, 1)))
+    noisy = add_exponential_noise(data, epsilon=1.0, random_state=0)
+    noise = (noisy - data).to_numpy().ravel()
+    assert abs(noise.mean()) < 0.05
+
+
 def test_geometric_noise():
     _check_noise(add_geometric_noise)
 


### PR DESCRIPTION
## Summary
- Center exponential noise by subtracting the scale term so its mean is zero.
- Add a unit test verifying the exponential mechanism produces zero-mean noise on a zero DataFrame.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7fbc015083269ba8881b4679c981