### PR TITLE
Ensure noise only added to numeric columns

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -21,8 +21,12 @@ def add_laplace_noise(
     """
     scale = sensitivity / epsilon
     rng = np.random.default_rng(random_state)
-    noise = rng.laplace(0, scale, data.shape)
-    return data + noise
+    noisy = data.copy()
+    num_cols = data.select_dtypes(include="number").columns
+    if len(num_cols):
+        noise = rng.laplace(0, scale, size=(len(data), len(num_cols)))
+        noisy[num_cols] = data[num_cols] + noise
+    return noisy
 
 
 def add_gaussian_noise(
@@ -46,8 +50,12 @@ def add_gaussian_noise(
     """
     sigma = sensitivity * np.sqrt(2 * np.log(1.25 / delta)) / epsilon
     rng = np.random.default_rng(random_state)
-    noise = rng.normal(0, sigma, data.shape)
-    return data + noise
+    noisy = data.copy()
+    num_cols = data.select_dtypes(include="number").columns
+    if len(num_cols):
+        noise = rng.normal(0, sigma, size=(len(data), len(num_cols)))
+        noisy[num_cols] = data[num_cols] + noise
+    return noisy
 
 
 def add_exponential_noise(
@@ -69,8 +77,12 @@ def add_exponential_noise(
     """
     scale = sensitivity / epsilon
     rng = np.random.default_rng(random_state)
-    noise = rng.exponential(scale, data.shape) - scale
-    return data + noise
+    noisy = data.copy()
+    num_cols = data.select_dtypes(include="number").columns
+    if len(num_cols):
+        noise = rng.exponential(scale, size=(len(data), len(num_cols))) - scale
+        noisy[num_cols] = data[num_cols] + noise
+    return noisy
 
 
 def add_geometric_noise(
@@ -88,9 +100,13 @@ def add_geometric_noise(
     """
     p = 1 - np.exp(-epsilon)
     rng = np.random.default_rng(random_state)
-    # Generate signed geometric noise by subtracting two independent draws.
-    noise = rng.geometric(p, size=data.shape) - rng.geometric(p, size=data.shape)
-    noisy = data + noise
+    noisy = data.copy()
+    num_cols = data.select_dtypes(include="number").columns
+    if len(num_cols):
+        noise = rng.geometric(p, size=(len(data), len(num_cols))) - rng.geometric(
+            p, size=(len(data), len(num_cols))
+        )
+        noisy[num_cols] = data[num_cols] + noise
 
     # Preserve integer dtypes by rounding and casting back to the original type.
     int_cols = data.select_dtypes(include="integer").columns

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -21,6 +21,19 @@ def _check_noise(func):
     assert not out1.equals(out3)
 
 
+def _check_noise_mixed(func, dtype=float, check_dtype=False):
+    data = pd.DataFrame({"num": np.zeros(10, dtype=dtype), "cat": ["x"] * 10})
+    out1 = func(data, random_state=0)
+    # Non-numeric columns should remain unchanged
+    pdt.assert_series_equal(out1["cat"], data["cat"])
+    out2 = func(data, random_state=0)
+    pdt.assert_frame_equal(out1, out2)
+    out3 = func(data, random_state=1)
+    assert not out1["num"].equals(out3["num"])
+    if check_dtype:
+        assert out1["num"].dtype == data["num"].dtype
+
+
 def test_laplace_noise():
     _check_noise(add_laplace_noise)
 
@@ -51,6 +64,22 @@ def test_geometric_noise_centered():
     assert abs(noise.mean()) < 0.05
     # Integer dtypes should be preserved after adding noise
     assert noisy.dtypes.equals(data.dtypes)
+
+
+def test_laplace_noise_mixed_types():
+    _check_noise_mixed(add_laplace_noise)
+
+
+def test_gaussian_noise_mixed_types():
+    _check_noise_mixed(add_gaussian_noise)
+
+
+def test_exponential_noise_mixed_types():
+    _check_noise_mixed(add_exponential_noise)
+
+
+def test_geometric_noise_mixed_types():
+    _check_noise_mixed(add_geometric_noise, dtype=int, check_dtype=True)
 
 
 def test_randomised_response():


### PR DESCRIPTION
## Summary
- Restrict Laplace, Gaussian, exponential, and geometric noise functions to numeric columns
- Preserve non-numeric data and integer dtypes when adding noise
- Add tests verifying noise mechanisms handle mixed-type DataFrames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedc827b488326ad0bdf209e55a43b