### PR TITLE
Handle NaNs in randomised_response

### DIFF
--- a/mechanisms.py
+++ b/mechanisms.py
@@ -101,9 +101,19 @@ def add_geometric_noise(
 
 
 def randomised_response(series: pd.Series, p: float = 0.7, random_state: int | None = None) -> pd.Series:
-    """Apply randomised response to a categorical variable."""
-    values = series.unique()
+    """Apply randomised response to a categorical variable.
+
+    NaN values are left untouched and excluded from the random-choice pool.
+    """
     rng = np.random.default_rng(random_state)
-    rand = rng.random(len(series))
-    random_response = rng.choice(values, size=len(series))
-    return pd.Series(np.where(rand < p, series, random_response), index=series.index)
+
+    # Operate only on non-NaN entries so that NaNs remain untouched and
+    # are not part of the random response pool.
+    not_nan = series.notna()
+    values = series[not_nan].unique()
+    rand = rng.random(not_nan.sum())
+    random_response = rng.choice(values, size=not_nan.sum())
+
+    result = series.copy()
+    result[not_nan] = np.where(rand < p, series[not_nan], random_response)
+    return result

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -61,3 +61,12 @@ def test_randomised_response():
     pdt.assert_series_equal(out1, out2)
     out3 = randomised_response(series, random_state=1)
     assert not out1.equals(out3)
+
+
+def test_randomised_response_nan_untouched():
+    series = pd.Series(["a", np.nan, "b", np.nan])
+    out = randomised_response(series, p=0.0, random_state=0)
+    # NaN positions should remain NaN
+    assert out.isna().tolist() == series.isna().tolist()
+    # Randomisation should only draw from non-NaN values
+    assert out.dropna().isin(["a", "b"]).all()


### PR DESCRIPTION
## Summary
- Ensure `randomised_response` leaves `NaN` values untouched and excludes them from the random-choice pool
- Add tests confirming `NaN` entries remain unchanged after randomised response

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedc8849cc8326b00520bcc650464c