### PR TITLE
Use explicit CLI arguments for output path and random seed

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -41,29 +41,7 @@ def main():
         default=0.7,
         help='Truthful response probability for the randomised-response mechanism',
     )
-    # ``argparse`` raises an error if unexpected arguments are supplied.  The
-    # tests for this repository mutate the command list in-place to change the
-    # output path for a second invocation.  The mutation accidentally drops the
-    # ``--random-state`` flag which would normally precede the random state
-    # value.  In that scenario ``argparse`` would abort with an "unrecognised
-    # arguments" error.  To make the CLI resilient (and the tests happy) we
-    # parse known arguments first and interpret any remaining values as optional
-    # overrides for the output path and random state.
-    args, extra = parser.parse_known_args()
-    if extra:
-        # The first positional argument is treated as an alternative output
-        # path.  This mirrors the behaviour expected by the tests which simply
-        # replace the path in the original command list.
-        if len(extra) >= 1:
-            args.output = Path(extra[0])
-        # A second positional argument, if present, is interpreted as the random
-        # state seed.  Non-integer values are ignored and leave the default in
-        # place.
-        if len(extra) >= 2:
-            try:
-                args.random_state = int(extra[1])
-            except ValueError:
-                pass
+    args = parser.parse_args()
 
     df = pd.read_csv(args.input)
     numeric = df.select_dtypes(include=['number']).columns

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def test_cli_creates_deterministic_output(tmp_path):
     res1 = pd.read_csv(out1)
 
     out2 = tmp_path / 'out2.csv'
-    cmd[-2] = str(out2)  # replace output path
+    cmd[cmd.index(str(out1))] = str(out2)
     subprocess.run(cmd, check=True)
     res2 = pd.read_csv(out2)
 
@@ -49,7 +49,7 @@ def test_cli_randomised_response_deterministic(tmp_path):
     res1 = pd.read_csv(out1)
 
     out2 = tmp_path / 'out2.csv'
-    cmd[-2] = str(out2)
+    cmd[cmd.index(str(out1))] = str(out2)
     subprocess.run(cmd, check=True)
     res2 = pd.read_csv(out2)
 


### PR DESCRIPTION
## Summary
- Simplify CLI argument parsing by relying on `parse_args` and removing positional overrides
- Fix CLI tests to change the output path via the `--output` flag instead of dropping `--random-state`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf03e688f48326adb76f4cc4670b75