### PR TITLE
Fix randomised response sampling and add regression tests

### DIFF
--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -99,3 +99,16 @@ def test_randomised_response_nan_untouched():
     assert out.isna().tolist() == series.isna().tolist()
     # Randomisation should only draw from non-NaN values
     assert out.dropna().isin(["a", "b"]).all()
+
+
+def test_randomised_response_p_zero_changes_all_values():
+    series = pd.Series(["a", "b", "c", "a"])
+    out = randomised_response(series, p=0.0, random_state=42)
+    comparison = out[series.notna()] != series[series.notna()]
+    assert comparison.all()
+
+
+def test_randomised_response_single_category_fallback():
+    series = pd.Series(["only"] * 4)
+    out = randomised_response(series, p=0.0, random_state=0)
+    pdt.assert_series_equal(out, series)


### PR DESCRIPTION
## Summary
- ensure `randomised_response` samples from alternate categories, preserves NaNs, and falls back to the original values when only a single category is present
- add regression coverage for the `p=0.0` multiple-category case and for the single-category fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a95dcd688326a86d8256c5e45501