### PR TITLE
Add strengthened adversary audit and canary constructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,5 +41,6 @@ For security-relevant issues (e.g. a mechanism that does not satisfy its stated 
 - Erlingsson et al. (2014). *RAPPOR: Randomized Aggregatable Privacy-Preserving Ordinal Response.* — local DP and randomized response at scale.
 - Steinke, Nasr & Jagielski (2023). *Privacy Auditing with One (1) Training Run.* — the one-run auditing bound in `src/dp/audit.py`.
 - Jagielski, Ullman & Oprea (2020). *Auditing Differentially Private Machine Learning.* — Clopper–Pearson multi-run auditing.
-- Carlini et al. (2022). *Membership Inference Attacks From First Principles.* — LiRA and the TPR@low-FPR metric in `src/dp/attacks.py`.
+- Carlini et al. (2022). *Membership Inference Attacks From First Principles.* — offline/online LiRA and the TPR@low-FPR metric in `src/dp/attacks.py`.
+- Nasr et al. (2021). *Adversary Instantiation: Lower Bounds for Differentially Private Machine Learning.* — worst-case canary design behind `src/dp/canaries.py`.
 - Bagdasaryan, Poursaeed & Shmatikov (2019). *Differential Privacy Has Disparate Impact on Model Accuracy.* — the privacy–fairness interaction.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Anyone can call a noise function; the open question in privacy-preserving ML is 
 
 **4. Privacy–fairness frontier.** Measuring demographic-parity and equalized-odds gaps *under* DP (not just on the baseline) exposes the "disparate impact of DP": heavy noise erases signal and apparent disparity together, and the group gap re-emerges only as utility returns.
 
+**5. Stress-testing the ε ≈ 2.13 claim.** We then tried to *break* the DP-SGD headline rather than re-confirm it: a stronger (online) LiRA with more shadow models and an adversary that doesn't know the target's model class, plus worst-case canary constructions (feature-space outliers, duplicated records) fed through a one-run audit of the DP-SGD model itself. The claim **held** — no attack produced an audited ε lower bound above 2.13 — but §5 of the report says plainly what this does and does not show: on a 1,070-row dataset with a small MLP the one-run auditor is too weak to certify ε as low as 2.13 even against a *no-noise* model, so "not broken" is not "verified." The audit's power is demonstrated separately on a learner that genuinely memorises.
+
 ---
 
 ## Why This Project Matters
@@ -80,7 +82,7 @@ This repository demonstrates:
 * Privacy-utility trade-off analysis with honest accounting
 * Fairness auditing (demographic parity, equalized odds)
 * Reproducible ML workflows — the notebook and all reported numbers re-execute in CI
-* Automated testing (48 tests, including statistical calibration checks and DP-SGD integration tests)
+* Automated testing (81 tests, including statistical calibration checks, DP-SGD integration tests, and a strengthened one-run audit that catches a memorising learner)
 
 ### For ML Engineers
 
@@ -123,8 +125,9 @@ Reusable components live in `src/dp/`:
 | `mechanisms.py` | Laplace, Gaussian (analytic calibration), randomized response, exponential mechanism |
 | `pipeline.py` | Dataset loading/splitting, leakage-safe preprocessing, clipping, bounded joint-release noise |
 | `dpsgd.py` | Opacus wrappers: private training loop, ε for a given noise multiplier via RDP accounting |
-| `audit.py` | Empirical ε lower bounds: one-run binomial (Steinke et al.) and Clopper–Pearson multi-run (Jagielski et al.); end-to-end mechanism auditor |
-| `attacks.py` | Membership inference: loss-threshold (Yeom et al.) and offline LiRA (Carlini et al.); TPR@low-FPR metrics |
+| `audit.py` | Empirical ε lower bounds: one-run binomial (Steinke et al.) and Clopper–Pearson multi-run (Jagielski et al.); end-to-end scalar auditor and a one-run auditor for trained models (`one_run_model_audit`) |
+| `attacks.py` | Membership inference: loss-threshold (Yeom et al.), offline **and online** LiRA (Carlini et al.); TPR@low-FPR metrics |
+| `canaries.py` | Canary constructions for auditing: label-flip, feature-space outlier, and duplicated (group) probes |
 | `fairness.py` | Demographic parity and equalized odds differences (max−min across groups) |
 | `evaluation.py` | Privacy–utility sweeps and plotting |
 

--- a/notebooks/strengthened_adversary.py
+++ b/notebooks/strengthened_adversary.py
@@ -1,0 +1,270 @@
+"""Strengthened-adversary stress test of the DP-SGD ε ≈ 2.13 claim.
+
+This standalone, reproducible experiment tries to *break* the project's headline
+privacy claim rather than re-confirm it.  It exercises the library added for the
+stress test (``dp.attacks.lira_online_attack``, ``dp.canaries``,
+``dp.audit.audit_membership_scores`` / ``one_run_model_audit``) and prints every
+number quoted in ``reports/empirical_privacy_report.md`` §5.  Run headless with::
+
+    python notebooks/strengthened_adversary.py
+
+It is deliberately *not* wired into the notebook CI job (each DP-SGD audit is a
+full training run); the library it drives is covered by the pytest suite, which
+does run in CI.  All randomness is seeded, so the printed numbers are stable.
+
+Three parts:
+
+1. **Stronger LiRA.**  More shadow models (32→128), online vs offline
+   likelihood ratios, and *architecture mismatch* (the adversary does not know
+   the target's model class), scored by TPR at low FPR (Carlini et al. 2022).
+2. **New canaries + one-run DP-SGD audit.**  Label-flip, feature-space outlier,
+   and duplicated (group) canaries fed through the Steinke et al. (2023) one-run
+   auditor against a properly-noised DP-SGD model and a no-noise ("broken") one.
+3. **Audit power check.**  The same auditor on an unbounded tree that genuinely
+   memorises, to show the machinery *does* certify leakage where it exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.tree import DecisionTreeClassifier
+
+from dp.attacks import lira_offline_attack, lira_online_attack, loss_threshold_attack
+from dp.audit import one_run_model_audit
+from dp.canaries import (
+    CanarySet,
+    make_duplicated_canaries,
+    make_feature_outlier_canaries,
+    make_label_flip_canaries,
+)
+from dp.constants import RANDOM_STATE
+from dp.pipeline import build_preprocessor, split_dataset
+
+try:
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+    from opacus import PrivacyEngine
+
+    TORCH = True
+except ImportError:  # pragma: no cover - optional dependency
+    TORCH = False
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLAIM_EPS = 2.13
+DELTA = 1e-5
+
+
+def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    """Numerically stable per-example binary cross-entropy loss."""
+    prob = np.clip(prob, 1e-7, 1 - 1e-7)
+    return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+
+def load_features() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Preprocess the insurance dataset exactly as the notebook does."""
+    df = pd.read_csv(REPO_ROOT / "data" / "insurance.csv")
+    split = split_dataset(df, target="smoker")
+    pre = build_preprocessor(split.X_train)
+    x_train = pre.fit_transform(split.X_train)
+    x_test = pre.transform(split.X_test)
+    y_train = (split.y_train == "yes").astype(int).to_numpy()
+    y_test = (split.y_test == "yes").astype(int).to_numpy()
+    return x_train, x_test, y_train, y_test
+
+
+def _banner(title: str) -> None:
+    print("\n" + "=" * 78 + f"\n{title}\n" + "=" * 78)
+
+
+# ---------------------------------------------------------------------------
+# Part 1 — stronger LiRA on the natural task.
+# ---------------------------------------------------------------------------
+def _collect_shadow_losses(builder, x_all, y_all, num_shadows, seed):
+    """Return per-example lists of IN and OUT shadow losses over `num_shadows`."""
+    rng = np.random.default_rng(seed)
+    n = x_all.shape[0]
+    in_losses: list[list[float]] = [[] for _ in range(n)]
+    out_losses: list[list[float]] = [[] for _ in range(n)]
+    for k in range(num_shadows):
+        in_mask = rng.random(n) < 0.5
+        shadow = builder(k).fit(x_all[in_mask], y_all[in_mask])
+        losses = per_example_bce(y_all, shadow.predict_proba(x_all)[:, 1])
+        for i in range(n):
+            (in_losses if in_mask[i] else out_losses)[i].append(float(losses[i]))
+    return in_losses, out_losses
+
+
+def _rectangular(list_of_lists) -> np.ndarray:
+    width = int(min(len(row) for row in list_of_lists))
+    return np.vstack([np.asarray(row)[:width] for row in list_of_lists])
+
+
+def run_lira(x_train, x_test, y_train, y_test) -> None:
+    _banner("PART 1 — stronger LiRA on the natural task (target: unbounded tree)")
+    x_all = np.vstack([x_train, x_test])
+    y_all = np.concatenate([y_train, y_test])
+    membership = np.zeros(x_all.shape[0], dtype=int)
+    membership[: len(y_train)] = 1
+
+    target = DecisionTreeClassifier(random_state=RANDOM_STATE).fit(x_train, y_train)
+    target_losses = per_example_bce(y_all, target.predict_proba(x_all)[:, 1])
+
+    base = loss_threshold_attack(target_losses[membership == 1], target_losses[membership == 0])
+    print(f"loss-threshold baseline        AUC={base.auc:.3f}  "
+          f"TPR@1%={base.tpr_at_fpr[0.01]:.3f}  TPR@0.1%={base.tpr_at_fpr[0.001]:.3f}")
+
+    architectures = {
+        "tree (matched)": lambda k: DecisionTreeClassifier(random_state=k),
+        "shallow tree (mismatch)": lambda k: DecisionTreeClassifier(max_depth=3, random_state=k),
+        "logistic reg (mismatch)": lambda k: LogisticRegression(max_iter=1000, random_state=k),
+    }
+    for arch, builder in architectures.items():
+        for num_shadows in (32, 64, 128):
+            in_losses, out_losses = _collect_shadow_losses(
+                builder, x_all, y_all, num_shadows, RANDOM_STATE
+            )
+            out_mat = _rectangular(out_losses)
+            off = lira_offline_attack(target_losses, membership, out_mat)
+            msg = (f"[{arch:24s} K={num_shadows:3d}] offline AUC={off.auc:.3f} "
+                   f"TPR@1%={off.tpr_at_fpr[0.01]:.3f} TPR@0.1%={off.tpr_at_fpr[0.001]:.3f}")
+            if min(len(row) for row in in_losses) >= 2:
+                on = lira_online_attack(
+                    target_losses, membership, _rectangular(in_losses), out_mat
+                )
+                msg += (f" | online AUC={on.auc:.3f} "
+                        f"TPR@1%={on.tpr_at_fpr[0.01]:.3f} TPR@0.1%={on.tpr_at_fpr[0.001]:.3f}")
+            print(msg)
+
+
+# ---------------------------------------------------------------------------
+# Part 2 — one-run DP-SGD audit against each canary construction.
+# ---------------------------------------------------------------------------
+def _dpsgd_scorer(canary_labels, noise_multiplier, epochs=15, private=True):
+    """Build a `train_and_score` callback for `one_run_model_audit`.
+
+    Trains a small MLP (matching the notebook's DP-SGD network) on the
+    canary-augmented data and scores each canary by −loss (low loss ⇒ member).
+    The accountant ε for the run is stashed in the returned `state` dict.
+    """
+    state: dict = {}
+
+    def train_and_score(x_aug, y_aug, canary_features):
+        torch.manual_seed(RANDOM_STATE)
+        x_t = torch.tensor(x_aug, dtype=torch.float32)
+        y_t = torch.tensor(y_aug, dtype=torch.float32)
+        net = nn.Sequential(nn.Linear(x_aug.shape[1], 32), nn.ReLU(), nn.Linear(32, 1))
+        opt = torch.optim.Adam(net.parameters(), lr=1e-2)
+        loader = DataLoader(TensorDataset(x_t, y_t), batch_size=64, shuffle=True)
+        if private:
+            engine = PrivacyEngine()
+            net, opt, loader = engine.make_private(
+                module=net, optimizer=opt, data_loader=loader,
+                noise_multiplier=noise_multiplier, max_grad_norm=1.0,
+            )
+        net.train()
+        for _ in range(epochs):
+            for xb, yb in loader:
+                opt.zero_grad()
+                nn.BCEWithLogitsLoss()(net(xb).squeeze(1), yb).backward()
+                opt.step()
+        net.eval()
+        if private:
+            try:
+                state["eps"] = float(engine.get_epsilon(delta=DELTA))
+            except Exception:
+                state["eps"] = float("inf")
+        else:
+            state["eps"] = float("inf")
+        with torch.no_grad():
+            canary_t = torch.tensor(canary_features, dtype=torch.float32)
+            prob = torch.sigmoid(net(canary_t).squeeze(1)).numpy()
+        return -per_example_bce(canary_labels, prob)
+
+    return train_and_score, state
+
+
+def _audit_dpsgd(canaries: CanarySet, x_train, y_train, noise_multiplier, private, seed):
+    scorer, state = _dpsgd_scorer(canaries.labels, noise_multiplier, private=private)
+    result = one_run_model_audit(
+        canaries, x_train, y_train, scorer,
+        delta=DELTA, confidence=0.95, random_state=seed,
+    )
+    return result, state["eps"]
+
+
+def run_dpsgd_audit(x_train, x_test, y_train, y_test) -> None:
+    _banner(f"PART 2 — one-run auditor vs DP-SGD (claim ε ≈ {CLAIM_EPS}) by canary type")
+    d = x_train.shape[1]
+    seed = RANDOM_STATE
+    n_flip = min(500, len(y_test))
+    canary_sets = {
+        "label-flip": make_label_flip_canaries(x_test, y_test, n_flip, random_state=1),
+        "feature-outlier": make_feature_outlier_canaries(500, d, random_state=1),
+        "duplicated x8 (group)": make_duplicated_canaries(300, d, duplication=8, random_state=1),
+    }
+
+    print("-- properly-noised DP-SGD (noise_multiplier = 2.0) --")
+    for name, cs in canary_sets.items():
+        result, eps = _audit_dpsgd(cs, x_train, y_train, 2.0, True, seed)
+        group = eps * cs.duplication
+        acc = result.details["accuracy"]
+        lb = result.epsilon_lower_bound
+        print(f"[{name:22s} n={len(cs):3d}] acct_ε={eps:5.2f} group_ε≈{group:6.2f}  "
+              f"attack_acc={acc:.3f}  ε_lb={lb:.3f}  "
+              f"violates_{CLAIM_EPS}={result.violates(CLAIM_EPS)}")
+
+    print("-- broken DP-SGD: noise turned off (noise_multiplier = 0) --")
+    for name, cs in canary_sets.items():
+        result, eps = _audit_dpsgd(cs, x_train, y_train, 0.0, True, seed)
+        acc = result.details["accuracy"]
+        lb = result.epsilon_lower_bound
+        print(f"[{name:22s} n={len(cs):3d}] acct_ε={'inf':>5}             "
+              f"attack_acc={acc:.3f}  ε_lb={lb:.3f}  "
+              f"violates_{CLAIM_EPS}={result.violates(CLAIM_EPS)}")
+
+
+# ---------------------------------------------------------------------------
+# Part 3 — the auditor has power where memorisation is real.
+# ---------------------------------------------------------------------------
+def run_power_check(x_train, x_test, y_train, y_test) -> None:
+    _banner("PART 3 — audit power on a memorising learner (unbounded tree)")
+
+    def make_scorer(labels):
+        def train_and_score(x_aug, y_aug, canary_features):
+            tree = DecisionTreeClassifier(random_state=RANDOM_STATE).fit(x_aug, y_aug)
+            return -per_example_bce(labels, tree.predict_proba(canary_features)[:, 1])
+        return train_and_score
+
+    for seed in (0, 1, 2):
+        cs = make_label_flip_canaries(x_test, y_test, 250, random_state=seed)
+        result = one_run_model_audit(
+            cs, x_train, y_train, make_scorer(cs.labels), delta=DELTA, random_state=seed
+        )
+        acc = result.details["accuracy"]
+        lb = result.epsilon_lower_bound
+        print(f"[tree, label-flip n=250 seed={seed}] attack_acc={acc:.3f}  "
+              f"ε_lb={lb:.3f}  clears_1.0={lb > 1.0}")
+
+
+def main() -> None:
+    x_train, x_test, y_train, y_test = load_features()
+    print(f"preprocessed train={x_train.shape} test={x_test.shape} "
+          f"positive_rate={y_train.mean():.3f}")
+    run_lira(x_train, x_test, y_train, y_test)
+    if TORCH:
+        run_dpsgd_audit(x_train, x_test, y_train, y_test)
+    else:  # pragma: no cover - optional dependency
+        print("\n[torch/opacus unavailable — skipping DP-SGD audit]")
+    run_power_check(x_train, x_test, y_train, y_test)
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/reports/empirical_privacy_report.md
+++ b/reports/empirical_privacy_report.md
@@ -3,8 +3,11 @@
 This report covers the empirical-privacy extension to the project. Where the
 main findings report quantifies the *utility* cost of privacy, this one asks a
 different question: **does the privacy actually hold, and what can an attacker
-recover in practice?** All numbers are produced by executing
-`notebooks/dp_privacy_insurance.ipynb` and are reproduced in CI.
+recover in practice?** The numbers in §1–§4 are produced by executing
+`notebooks/dp_privacy_insurance.ipynb` and are reproduced in CI. The
+strengthened-adversary stress test in §5 is produced by the standalone, seeded
+script `notebooks/strengthened_adversary.py`; the library it drives is covered
+by the pytest suite that runs in CI.
 
 ## Motivation
 
@@ -115,6 +118,122 @@ The apparent "fairness" at low ε is an artifact of a useless model, which is
 why privacy, utility, and fairness must be read jointly: a single fairness
 number without its accompanying utility is meaningless.
 
+## 5. Stress-testing the DP-SGD ε ≈ 2.13 claim with a stronger adversary
+
+Sections 1–4 establish that DP-SGD holds membership inference at chance and that
+the audit is sound. This section does the opposite of confirming that result: it
+gives the adversary more power and actively tries to break the ε ≈ 2.13 claim —
+more shadow models, the stronger online LiRA, an adversary that does not know the
+target's model class, and worst-case canary constructions the earlier sections
+never tested. The headline is stated up front and defended below: **the claim
+held, but the audit is too weak on this model to independently *certify* it — a
+distinction we are careful not to blur.**
+
+### 5.1 A stronger LiRA does not move natural leakage off chance
+
+We strengthened the offline LiRA of §3 three ways: raised the shadow-model count
+from 32 to 128, added the **online** likelihood-ratio attack (Carlini et al.
+2022, §IV — it fits an "in" *and* an "out" Gaussian per example, the field's most
+powerful membership test), and tested **architecture mismatch**, where the
+adversary's shadow models are a different model class than the target
+(`shallow tree`, `logistic regression` vs the target's unbounded tree).
+
+| Shadow arch. | K | offline AUC | offline TPR@1% | online AUC | online TPR@1% |
+| --- | --- | --- | --- | --- | --- |
+| tree (matched) | 32 | 0.547 | 0.021 | 0.549 | 0.025 |
+| tree (matched) | 64 | 0.546 | 0.032 | 0.546 | 0.035 |
+| tree (matched) | 128 | 0.552 | 0.032 | 0.552 | 0.032 |
+| shallow tree (mismatch) | 128 | 0.558 | 0.030 | 0.523 | 0.000 |
+| logistic reg. (mismatch) | 128 | 0.507 | 0.040 | 0.481 | 0.000 |
+
+Three plain observations, none of which helps the attacker:
+
+- **More shadow models barely move the AUC** (matched: 0.547 → 0.552 from K = 32
+  to 128). The signal is not undersampled — it is essentially absent, so paying
+  for more shadow models buys nothing.
+- **Online ≈ offline when the architecture matches.** Modelling the "in"
+  distribution adds no usable low-FPR signal here.
+- **Architecture mismatch degrades the attack, and it collapses *online* LiRA
+  to chance or below** (AUC 0.46–0.52, TPR@1% ≈ 0). This is expected: online
+  LiRA's power comes from calibrating against loss distributions that match the
+  target's; when the adversary guesses the wrong model class, the "in" Gaussian
+  is mis-specified and the extra modelling hurts rather than helps. The offline
+  attack, which only models the "out" distribution, is more robust to mismatch
+  but stays near chance (AUC ≤ 0.56).
+
+The §3 finding survives a much stronger adversary: natural membership leakage on
+this task is near chance (AUC ≤ 0.56, TPR@1% ≤ 0.04) under every strengthening we
+tried. `smoker` is too separable to memorise exploitably, and no amount of
+attack machinery manufactures signal that is not there.
+
+### 5.2 Worst-case canaries and a one-run audit of DP-SGD itself
+
+Section 1 audited only the scalar Laplace mechanism. Here the one-run auditor of
+Steinke et al. (2023) is run against the **DP-SGD model itself**
+(`dp.audit.one_run_model_audit`): insert canaries (each included by a fair coin),
+train one private model, score each canary by its loss, guess membership, and
+invert the correct-guess count into an ε lower bound. We test three canary
+constructions — the §3 **label-flip** (outlier in label space) plus two the
+project had not tried: a **feature-space outlier** (a point far outside the data
+cloud) and a **duplicated** record repeated eight times (the worst-case
+memorisation probe). Each is run against the properly-noised model
+(noise_multiplier = 2.0) and a deliberately **broken** one (noise turned off).
+
+| Canary | model | acct ε (run) | attacker acc | ε lower bound | violates 2.13? |
+| --- | --- | --- | --- | --- | --- |
+| label-flip | DP-SGD (noise on) | 2.00 | 0.478 | 0.000 | no |
+| feature-outlier | DP-SGD (noise on) | 1.89 | 0.468 | 0.000 | no |
+| duplicated ×8 | DP-SGD (noise on) | 1.41 (group ≈ 11.3) | 0.583 | 0.138 | no |
+| label-flip | broken (no noise) | ∞ | 0.545 | 0.000 | no |
+| feature-outlier | broken (no noise) | ∞ | 0.516 | 0.000 | no |
+| duplicated ×8 | broken (no noise) | ∞ | 0.710 | 0.680 | no |
+
+**No canary construction produced an audited lower bound above the claim.** On
+the noised model, feature-outlier and label-flip canaries pin the bound at
+exactly 0.0 — the noised gradients erase the per-example signal. The **duplicated
+probe is the most sensitive** and is the only construction that separates the
+no-noise model (ε_lb 0.68) from the noised one (ε_lb 0.14). But a duplicated
+record audits *group* privacy for a group of eight, whose budget degrades to
+≈ 8·ε ≈ 11 (the group-privacy property), so even 0.68 sits far below the relevant
+budget and says nothing about the single-record ε ≈ 2.13 claim. The
+`duplicated ×8` run's accountant ε is lower (1.41) only because inserting many
+duplicated rows enlarges the dataset and dilutes the sampling rate.
+
+### 5.3 The honest caveat: this audit is under-powered on this model
+
+The result above is easy to over-read, so we state the limitation plainly.
+**Even the broken, no-noise model audits at ε_lb ≤ 0.68 — far below 2.13.** To
+certify ε > 2.13 through the binomial one-run bound, the attacker must be ~89%
+accurate with 95% confidence; a 32-unit MLP trained for 15 epochs does not
+memorise individual input-space canaries anywhere near that hard, and its
+out-of-training loss on a canary is noisy. So the audit **fails to break** the
+claim, which is a much weaker statement than **verifying** it: on a 1,070-row
+dataset with this model and a loss-based score, the one-run auditor cannot
+distinguish ε ≈ 2 from ε = ∞. A "not detected" is not a certificate.
+
+The weakness is in this particular attack, not in the audit machinery. Pointed at
+a target that genuinely memorises — an unbounded decision tree with the same
+mislabelled canaries — the identical auditor certifies ε_lb ≈ 1.1–1.7 (attacker
+accuracy 0.80–0.88), and the scalar no-noise mechanism of §2 still audits at
+ε ≥ 6.5. The power exists; it is the DP-SGD MLP scored by loss that resists this
+input-space attack. Closing the gap would require the gradient-space "Dirac"
+canaries used by the state-of-the-art one-run DP-SGD audits, which this
+loss-based attack does not implement — a concrete direction for future work, not
+a claim we can currently support.
+
+### 5.4 Verdict
+
+The ε ≈ 2.13 headline **held** against the strengthened adversary, and the number
+does not need revising: no larger shadow pool, stronger (online) attack,
+architecture assumption, or worst-case canary construction produced an audited
+lower bound above 2.13, and natural membership leakage stayed near chance. But
+the finding is a negative result about the *adversary*, not a positive
+certificate about the *mechanism*: on this small model the loss-based one-run
+auditor cannot certify a bound as low as 2.13 even against a completely
+non-private model, so it can only fail to refute the claim. We report the claim
+as surviving, and we report — with equal prominence — that this particular audit
+is not powerful enough to independently confirm it.
+
 ## Conclusion
 
 The extension turns the project from one that *claims* privacy into one that
@@ -122,8 +241,12 @@ The extension turns the project from one that *claims* privacy into one that
 guarantee-voiding implementation bug that passes conventional tests; membership
 inference shows that practical leakage tracks memorisation rather than ε alone;
 and the fairness frontier shows privacy noise interacting with group disparity.
-Together these support a reporting discipline — ε, empirical audit, attack
-success at low FPR, and fairness, all together — rather than any single metric
+The strengthened-adversary stress test (§5) adds a note of caution to its own
+tooling: a stronger attacker did not break the DP-SGD claim, but the one-run
+auditor is too weak on this small model to independently certify it, so "not
+broken" must not be mistaken for "verified." Together these support a reporting
+discipline — ε, empirical audit, attack success at low FPR, and fairness, all
+together, each with its power and limits stated — rather than any single metric
 in isolation.
 
 ## References
@@ -134,6 +257,9 @@ in isolation.
   Private Machine Learning: How Private is Private SGD?* NeurIPS 2020.
 - Carlini, N., Chien, S., Nasr, M., Song, S., Terzis, A., & Tramèr, F. (2022).
   *Membership Inference Attacks From First Principles.* IEEE S&P 2022.
+- Nasr, M., Song, S., Thakurta, A., Papernot, N., & Carlini, N. (2021).
+  *Adversary Instantiation: Lower Bounds for Differentially Private Machine
+  Learning.* IEEE S&P 2021.
 - Yeom, S., Giacomelli, I., Fredrikson, M., & Jha, S. (2018). *Privacy Risk in
   Machine Learning: Analyzing the Connection to Overfitting.* IEEE CSF 2018.
 - Bagdasaryan, E., Poursaeed, O., & Shmatikov, V. (2019). *Differential Privacy

--- a/src/dp/__init__.py
+++ b/src/dp/__init__.py
@@ -1,11 +1,24 @@
 """Differential privacy tooling for the insurance dataset."""
 
-from .attacks import AttackResult, lira_offline_attack, loss_threshold_attack
+from .attacks import (
+    AttackResult,
+    lira_offline_attack,
+    lira_online_attack,
+    loss_threshold_attack,
+)
 from .audit import (
     AuditResult,
+    audit_membership_scores,
     audit_scalar_mechanism,
     epsilon_lower_bound_binomial,
     epsilon_lower_bound_clopper_pearson,
+    one_run_model_audit,
+)
+from .canaries import (
+    CanarySet,
+    make_duplicated_canaries,
+    make_feature_outlier_canaries,
+    make_label_flip_canaries,
 )
 from .constants import RANDOM_STATE
 from .evaluation import plot_privacy_utility, plot_roc_curves, privacy_utility_sweep
@@ -32,10 +45,12 @@ __all__ = [
     "RANDOM_STATE",
     "AttackResult",
     "AuditResult",
+    "CanarySet",
     "add_gaussian_noise",
     "add_laplace_noise",
     "apply_bounded_feature_noise",
     "apply_randomized_response",
+    "audit_membership_scores",
     "audit_scalar_mechanism",
     "calibrate_analytic_gaussian_sigma",
     "clip_numeric",
@@ -46,7 +61,12 @@ __all__ = [
     "equalized_odds_difference",
     "exponential_mechanism",
     "lira_offline_attack",
+    "lira_online_attack",
     "loss_threshold_attack",
+    "make_duplicated_canaries",
+    "make_feature_outlier_canaries",
+    "make_label_flip_canaries",
+    "one_run_model_audit",
     "build_decision_tree_model",
     "build_model_registry",
     "build_svm_model",

--- a/src/dp/attacks.py
+++ b/src/dp/attacks.py
@@ -23,6 +23,16 @@ implements two attacks and reports both AUC and TPR at fixed FPRs.
     models trained without that example, yielding a per-example likelihood
     ratio.  The offline variant uses only "out" shadow models, which is the
     practical setting when the target's training set is unknown.
+
+``lira_online_attack``
+    Online Likelihood-Ratio Attack (Carlini et al. 2022, §IV).  The stronger
+    adversary: it fits *two* Gaussians per example — one to the losses of
+    shadow models trained *with* the example ("in") and one to those trained
+    *without* it ("out") — and scores membership by the log-likelihood ratio
+    between them.  Using the "in" distribution as well as the "out" distribution
+    is what makes the online attack the field's most powerful membership test;
+    the price is that the adversary must be able to train shadow models that
+    contain the target example.
 """
 
 from __future__ import annotations
@@ -161,4 +171,91 @@ def lira_offline_attack(
         scores=scores,
         membership=membership,
         method="lira-offline",
+    )
+
+
+def lira_online_attack(
+    target_losses: np.ndarray,
+    membership: np.ndarray,
+    shadow_in_losses: np.ndarray,
+    shadow_out_losses: np.ndarray,
+    fprs=(0.001, 0.01, 0.1),
+    eps: float = 1e-12,
+) -> AttackResult:
+    """Online Likelihood-Ratio Attack (Carlini et al. 2022, §IV).
+
+    The online attack fits, per example, a Gaussian to the losses of shadow
+    models trained *with* the example (``shadow_in_losses[i]``) and another to
+    the losses of shadow models trained *without* it (``shadow_out_losses[i]``).
+    The membership score is the log-likelihood ratio of the observed target
+    loss under the two fits,
+
+        score_i = log N(loss_i; μ_in, σ_in²) − log N(loss_i; μ_out, σ_out²),
+
+    which is the most powerful test between the two simple hypotheses (Neyman–
+    Pearson).  Unlike :func:`lira_offline_attack`, which only models the "out"
+    distribution, the online variant calibrates against the "in" distribution
+    too, so it recovers more signal at low FPR — at the cost of requiring shadow
+    models that contain the target example.
+
+    Args:
+        target_losses: Shape ``(n,)``. Loss of each example under the target
+            model.
+        membership: Shape ``(n,)``. 1 if the example was in the target's
+            training set, else 0. Used only to score the attack.
+        shadow_in_losses: Shape ``(n, k_in)``. For each example, ``k_in`` losses
+            from shadow models trained *with* it.
+        shadow_out_losses: Shape ``(n, k_out)``. For each example, ``k_out``
+            losses from shadow models trained *without* it.
+        fprs: False-positive rates at which to report TPR.
+        eps: Floor on the fitted standard deviations for numerical stability.
+
+    Returns:
+        An :class:`AttackResult`.
+
+    Raises:
+        ValueError: On shape mismatches or fewer than 2 shadow samples on
+            either side.
+
+    Reference:
+        Carlini, Chien, Nasr, Song, Terzis, Tramèr (2022). "Membership
+        Inference Attacks From First Principles." IEEE S&P, §IV ("online" LiRA).
+    """
+    target_losses = np.asarray(target_losses, dtype=float)
+    membership = np.asarray(membership)
+    shadow_in_losses = np.asarray(shadow_in_losses, dtype=float)
+    shadow_out_losses = np.asarray(shadow_out_losses, dtype=float)
+
+    n = target_losses.shape[0]
+    aligned = (
+        membership.shape[0] == n
+        and shadow_in_losses.shape[0] == n
+        and shadow_out_losses.shape[0] == n
+    )
+    if not aligned:
+        raise ValueError(
+            "target_losses, membership, shadow_in_losses, shadow_out_losses must align on axis 0"
+        )
+    if shadow_in_losses.ndim != 2 or shadow_in_losses.shape[1] < 2:
+        raise ValueError("shadow_in_losses must be (n, k) with k >= 2 shadow models")
+    if shadow_out_losses.ndim != 2 or shadow_out_losses.shape[1] < 2:
+        raise ValueError("shadow_out_losses must be (n, k) with k >= 2 shadow models")
+
+    mu_in = shadow_in_losses.mean(axis=1)
+    sigma_in = np.maximum(shadow_in_losses.std(axis=1, ddof=1), eps)
+    mu_out = shadow_out_losses.mean(axis=1)
+    sigma_out = np.maximum(shadow_out_losses.std(axis=1, ddof=1), eps)
+
+    # log N(x; mu, sigma) up to the shared constant, which cancels in the ratio.
+    def log_gaussian(mu, sigma):
+        return -np.log(sigma) - 0.5 * ((target_losses - mu) / sigma) ** 2
+
+    scores = log_gaussian(mu_in, sigma_in) - log_gaussian(mu_out, sigma_out)
+
+    return AttackResult(
+        auc=float(roc_auc_score(membership, scores)),
+        tpr_at_fpr=_tpr_at_fpr(membership, scores, fprs),
+        scores=scores,
+        membership=membership,
+        method="lira-online",
     )

--- a/src/dp/audit.py
+++ b/src/dp/audit.py
@@ -37,6 +37,8 @@ from typing import Callable
 import numpy as np
 from scipy import optimize, stats
 
+from .canaries import CanarySet
+
 
 @dataclass(frozen=True)
 class AuditResult:
@@ -225,6 +227,79 @@ def epsilon_lower_bound_clopper_pearson(
     )
 
 
+def audit_membership_scores(
+    scores: np.ndarray,
+    included: np.ndarray,
+    delta: float = 0.0,
+    confidence: float = 0.95,
+    guess_fraction: float = 1.0,
+) -> AuditResult:
+    """One-run ε lower bound from real-valued membership scores.
+
+    This generalises :func:`audit_scalar_mechanism` from a scalar sampler to any
+    attack that emits a per-canary membership *score* (higher = more member-like)
+    against known inclusion labels — for instance the loss of each canary under
+    a single trained model, or a LiRA statistic.  It is the auditing side of the
+    membership-inference attacks in :mod:`dp.attacks`: strengthen the attack, run
+    it against canaries whose inclusion you control, and this turns the result
+    into a lower bound on ε.
+
+    Following Steinke et al. (2023), the auditor commits a hard guess only where
+    it is most confident: it sorts by score, guesses "in" for the top ``k`` and
+    "out" for the bottom ``k`` (``k = ⌊guess_fraction · m / 2⌋``, abstaining on
+    the middle), counts correct guesses, and feeds ``(correct, 2k)`` to
+    :func:`epsilon_lower_bound_binomial`.  The guessing rule depends only on the
+    scores, never on the inclusion labels, so the binomial bound applies.
+
+    Args:
+        scores: Shape ``(m,)``. Membership score per canary (higher = more
+            member-like).
+        included: Shape ``(m,)``. 1 if the canary was in training, else 0.
+        delta: δ of the (ε, δ)-DP claim being audited.
+        confidence: Confidence level 1 − β for the lower bound.
+        guess_fraction: Fraction of canaries to commit guesses on, split evenly
+            between the most and least member-like.  1.0 guesses on all of them;
+            a smaller value trades coverage for a more confident subset.
+
+    Returns:
+        An :class:`AuditResult` from the binomial one-run estimator, with the
+        realised guessing budget and attacker accuracy in ``details``.
+
+    Raises:
+        ValueError: On shape mismatch, non-binary ``included``, a
+            ``guess_fraction`` outside ``(0, 1]``, or too few canaries to commit
+            even a single in/out guess pair.
+    """
+    scores = np.asarray(scores, dtype=float)
+    included = np.asarray(included)
+    if scores.shape != included.shape or scores.ndim != 1:
+        raise ValueError("scores and included must be 1-D arrays of the same length")
+    if not set(np.unique(included)).issubset({0, 1}):
+        raise ValueError("included must be binary (0/1)")
+    if not (0.0 < guess_fraction <= 1.0):
+        raise ValueError("guess_fraction must be in (0, 1]")
+
+    m = scores.shape[0]
+    k = int(np.floor(guess_fraction * m / 2.0))
+    if k < 1:
+        raise ValueError("too few canaries to commit an in/out guess pair")
+
+    order = np.argsort(scores)  # ascending: low score = out-like, high = in-like
+    out_idx = order[:k]
+    in_idx = order[m - k:]
+    correct = int((included[in_idx] == 1).sum() + (included[out_idx] == 0).sum())
+
+    result = epsilon_lower_bound_binomial(
+        num_correct=correct,
+        num_guesses=2 * k,
+        delta=delta,
+        confidence=confidence,
+    )
+    result.details["guess_fraction"] = guess_fraction
+    result.details["num_canaries"] = m
+    return result
+
+
 def audit_scalar_mechanism(
     mechanism: Callable[[float, int | None], float],
     value_in: float = 1.0,
@@ -287,3 +362,77 @@ def audit_scalar_mechanism(
         delta=delta,
         confidence=confidence,
     )
+
+
+def one_run_model_audit(
+    canaries: CanarySet,
+    base_features: np.ndarray,
+    base_labels: np.ndarray,
+    train_and_score: Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray],
+    delta: float = 0.0,
+    confidence: float = 0.95,
+    guess_fraction: float = 1.0,
+    random_state: int | None = None,
+) -> AuditResult:
+    """Audit a trained model in a single run using membership canaries.
+
+    This is the model-level counterpart of :func:`audit_scalar_mechanism`: it
+    realises the one-run auditor of Steinke, Nasr & Jagielski (2023) against a
+    real learner and a real membership attack.  Each canary is independently
+    included (fair coin); included canaries are appended to the base training
+    set (repeated ``canaries.duplication`` times), the caller's
+    ``train_and_score`` trains one model on the augmented data and returns a
+    membership score for every canary, and :func:`audit_membership_scores`
+    inverts the score/label agreement into an ε lower bound.
+
+    Keeping training and scoring in the ``train_and_score`` callback makes the
+    audit agnostic to the mechanism: pass a DP-SGD trainer to audit DP-SGD, or a
+    plain learner to check that the audit has power where memorisation is real.
+    Because the auditor only sees scores, it cannot over-state privacy — a loose
+    bound means "not detected at this power", not "proven private".
+
+    Args:
+        canaries: The pool of canaries to include/exclude and score.
+        base_features: Real training features the canaries are added to.
+        base_labels: Labels aligned with ``base_features``.
+        train_and_score: Callable ``(X_aug, y_aug, canary_features) -> scores``
+            that trains one model on the augmented data and returns a membership
+            score per canary (higher = more member-like).
+        delta: δ of the (ε, δ)-DP claim being audited.
+        confidence: Confidence level 1 − β for the lower bound.
+        guess_fraction: Passed through to :func:`audit_membership_scores`.
+        random_state: Seed for the inclusion coins.
+
+    Returns:
+        An :class:`AuditResult`; ``details`` also carries the realised
+        ``included`` mask and the canary ``kind``/``duplication`` for reporting.
+    """
+    base_features = np.asarray(base_features, dtype=float)
+    base_labels = np.asarray(base_labels)
+    rng = np.random.default_rng(random_state)
+    included = rng.integers(0, 2, size=len(canaries))
+
+    in_features = canaries.features[included == 1]
+    in_labels = canaries.labels[included == 1]
+    if canaries.duplication > 1 and in_features.shape[0] > 0:
+        in_features = np.repeat(in_features, canaries.duplication, axis=0)
+        in_labels = np.repeat(in_labels, canaries.duplication)
+
+    aug_features = np.vstack([base_features, in_features])
+    aug_labels = np.concatenate([base_labels, in_labels])
+
+    scores = np.asarray(train_and_score(aug_features, aug_labels, canaries.features), dtype=float)
+    if scores.shape[0] != len(canaries):
+        raise ValueError("train_and_score must return one score per canary")
+
+    result = audit_membership_scores(
+        scores,
+        included,
+        delta=delta,
+        confidence=confidence,
+        guess_fraction=guess_fraction,
+    )
+    result.details["canary_kind"] = canaries.kind
+    result.details["duplication"] = canaries.duplication
+    result.details["included_fraction"] = float(included.mean())
+    return result

--- a/src/dp/canaries.py
+++ b/src/dp/canaries.py
@@ -1,0 +1,201 @@
+"""Canary constructions for empirical privacy auditing.
+
+A *canary* is a crafted record inserted into (or withheld from) a training set
+so that a membership-inference attack can be scored against ground truth.  The
+strength of an audit depends heavily on how memorable the canary is: a bound is
+only ever as tight as the worst case the attack actually probes (Nasr et al.,
+"Adversary Instantiation", IEEE S&P 2021).  This module provides three
+constructions that probe different failure modes, so an audit can test more
+than the single label-flip canary the notebook originally used:
+
+``make_label_flip_canaries``
+    Real feature rows with their labels flipped.  An *outlier in label space*:
+    the point is in-distribution but its label contradicts the pattern, so a
+    model can only fit it by memorising.  This is the classic auditing device
+    (Carlini et al. 2019; Jagielski et al. 2020).
+
+``make_feature_outlier_canaries``
+    Synthetic rows placed far from the data cloud in random, mutually
+    near-orthogonal directions — an *outlier in feature space*.  Each point is
+    unique and isolated, so a high-capacity model that memorises it is exposed,
+    while independence keeps one canary's inclusion from leaking through a
+    near-duplicate neighbour.
+
+``make_duplicated_canaries``
+    A distinctive record repeated ``k`` times, the worst-case memorisation
+    probe: duplication amplifies the record's influence on the model ``k``-fold.
+    Under DP this audits *group* privacy for a group of size ``k``, whose budget
+    degrades to ≈ ``k·ε`` (group-privacy property), so its audit must be read
+    against that larger budget, not the single-record ε.
+
+Each constructor returns a :class:`CanarySet` of feature rows and labels; the
+audit driver (see :func:`dp.audit.audit_membership_scores`) draws the inclusion
+coins, trains once, scores every canary, and inverts the count into an ε lower
+bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CanarySet:
+    """A pool of canaries to audit.
+
+    Attributes:
+        features: Shape ``(n, d)``. One feature row per canary.
+        labels: Shape ``(n,)``. The (audited) label of each canary.
+        duplication: How many times each *included* canary is repeated in the
+            training set.  ``1`` for single-record canaries; ``k`` marks a
+            group-privacy probe whose audit is read against ≈ ``k·ε``.
+        kind: Name of the construction, for reporting.
+    """
+
+    features: np.ndarray
+    labels: np.ndarray
+    duplication: int
+    kind: str
+
+    def __post_init__(self) -> None:
+        if self.features.ndim != 2:
+            raise ValueError("features must be a 2-D (n, d) array")
+        if self.labels.shape[0] != self.features.shape[0]:
+            raise ValueError("features and labels must align on axis 0")
+        if self.duplication < 1:
+            raise ValueError("duplication must be >= 1")
+
+    def __len__(self) -> int:
+        return self.features.shape[0]
+
+
+def make_label_flip_canaries(
+    features: np.ndarray,
+    labels: np.ndarray,
+    num_canaries: int,
+    random_state: int | None = None,
+) -> CanarySet:
+    """Draw ``num_canaries`` distinct rows and flip their (binary) labels.
+
+    An outlier in *label* space: the feature row is in-distribution but its
+    label contradicts the model's learned pattern, so fitting it requires
+    memorisation.  Rows are sampled *without replacement* so no two canaries
+    coincide — near-duplicate canaries would let an excluded canary inherit an
+    included neighbour's memorisation and corrupt the audit.
+
+    Args:
+        features: Pool of feature rows to draw from, shape ``(N, d)``.
+        labels: Binary labels (0/1) aligned with ``features``.
+        num_canaries: Number of canaries to draw (``<= N``).
+        random_state: Seed for the row selection.
+
+    Returns:
+        A :class:`CanarySet` with flipped labels and ``duplication == 1``.
+
+    Raises:
+        ValueError: If ``num_canaries`` exceeds the pool size or labels are not
+            binary.
+    """
+    features = np.asarray(features, dtype=float)
+    labels = np.asarray(labels)
+    if num_canaries > features.shape[0]:
+        raise ValueError("num_canaries cannot exceed the pool size")
+    if not set(np.unique(labels)).issubset({0, 1}):
+        raise ValueError("labels must be binary (0/1) to flip")
+
+    rng = np.random.default_rng(random_state)
+    idx = rng.choice(features.shape[0], size=num_canaries, replace=False)
+    return CanarySet(
+        features=features[idx].copy(),
+        labels=(1 - labels[idx]).astype(int),
+        duplication=1,
+        kind="label-flip",
+    )
+
+
+def make_feature_outlier_canaries(
+    num_canaries: int,
+    num_features: int,
+    random_state: int | None = None,
+    radius: float = 6.0,
+) -> CanarySet:
+    """Create synthetic canaries that are outliers in *feature* space.
+
+    Each canary is a random unit vector scaled to ``radius``, so on
+    standardised features (unit variance) it sits ~``radius`` standard
+    deviations from the origin — far outside the data cloud.  In high dimension
+    the directions are near-orthogonal, so the points are mutually isolated:
+    an excluded canary lands nowhere near an included one, which keeps the
+    membership signal clean.  Labels are assigned by a fair coin.
+
+    Args:
+        num_canaries: Number of canaries to create.
+        num_features: Feature dimension ``d`` (match the preprocessed matrix).
+        random_state: Seed for the directions and labels.
+        radius: Distance from the origin in standardised units.
+
+    Returns:
+        A :class:`CanarySet` with ``duplication == 1``.
+
+    Raises:
+        ValueError: If ``num_features`` or ``radius`` is not positive.
+    """
+    if num_features <= 0:
+        raise ValueError("num_features must be positive")
+    if radius <= 0:
+        raise ValueError("radius must be positive")
+
+    rng = np.random.default_rng(random_state)
+    directions = rng.standard_normal(size=(num_canaries, num_features))
+    directions /= np.linalg.norm(directions, axis=1, keepdims=True)
+    return CanarySet(
+        features=directions * radius,
+        labels=rng.integers(0, 2, size=num_canaries).astype(int),
+        duplication=1,  # single-record; see make_duplicated_canaries for groups
+        kind="feature-outlier",
+    )
+
+
+def make_duplicated_canaries(
+    num_canaries: int,
+    num_features: int,
+    duplication: int = 8,
+    random_state: int | None = None,
+    radius: float = 6.0,
+) -> CanarySet:
+    """Create feature-outlier canaries to be repeated ``duplication`` times.
+
+    The worst-case memorisation probe: repeating an included canary
+    ``duplication`` times multiplies its gradient contribution, so its
+    influence on the trained model is amplified ``duplication``-fold.  Because
+    DP protects a *group* of ``duplication`` identical records only at a budget
+    that grows to ≈ ``duplication · ε`` (the group-privacy property), an audit
+    that finds more leakage here does not by itself violate the single-record
+    ε; it must be compared against the inflated group budget.
+
+    Args:
+        num_canaries: Number of distinct canaries.
+        num_features: Feature dimension ``d``.
+        duplication: Repetition count ``k`` for each included canary (``>= 1``).
+        random_state: Seed for the directions and labels.
+        radius: Distance from the origin in standardised units.
+
+    Returns:
+        A :class:`CanarySet` whose ``duplication`` field records ``k``.
+
+    Raises:
+        ValueError: If ``duplication`` < 1 or geometry parameters are invalid.
+    """
+    if duplication < 1:
+        raise ValueError("duplication must be >= 1")
+    base = make_feature_outlier_canaries(
+        num_canaries, num_features, random_state=random_state, radius=radius
+    )
+    return CanarySet(
+        features=base.features,
+        labels=base.labels,
+        duplication=duplication,
+        kind="duplicated",
+    )

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from dp.attacks import lira_offline_attack, loss_threshold_attack
+from dp.attacks import lira_offline_attack, lira_online_attack, loss_threshold_attack
 
 
 def test_loss_threshold_detects_separation():
@@ -61,3 +61,38 @@ def test_lira_offline_shape_validation():
         )
     with pytest.raises(ValueError, match="k >= 2"):
         lira_offline_attack(np.zeros(5), np.zeros(5), np.zeros((5, 1)))
+
+
+def test_lira_online_beats_offline_when_in_distribution_is_informative():
+    # Construct a case where the "in" distribution carries signal the offline
+    # attack (out-only) cannot use: members' losses are drawn from a tight "in"
+    # Gaussian well below a wide "out" Gaussian, and per-example difficulty
+    # shifts both, so modelling the in-distribution sharpens the test.
+    rng = np.random.default_rng(3)
+    n, k = 500, 32
+    difficulty = rng.normal(1.5, 0.6, size=n).clip(min=0.2)
+    membership = rng.integers(0, 2, size=n)
+    shadow_in = rng.normal((difficulty - 0.8)[:, None], 0.1, size=(n, k)).clip(min=0)
+    shadow_out = rng.normal(difficulty[:, None], 0.4, size=(n, k)).clip(min=0)
+    # Target losses come from the matching distribution for each example.
+    target = np.where(
+        membership == 1,
+        rng.normal(difficulty - 0.8, 0.1),
+        rng.normal(difficulty, 0.4),
+    ).clip(min=0)
+
+    online = lira_online_attack(target, membership, shadow_in, shadow_out)
+    offline = lira_offline_attack(target, membership, shadow_out)
+    assert online.method == "lira-online"
+    assert online.auc > 0.5
+    # Using the in-distribution should not hurt, and here it helps.
+    assert online.auc >= offline.auc - 0.02
+
+
+def test_lira_online_shape_validation():
+    with pytest.raises(ValueError, match="align"):
+        lira_online_attack(np.zeros(5), np.zeros(4), np.zeros((5, 8)), np.zeros((5, 8)))
+    with pytest.raises(ValueError, match="shadow_in_losses"):
+        lira_online_attack(np.zeros(5), np.zeros(5), np.zeros((5, 1)), np.zeros((5, 8)))
+    with pytest.raises(ValueError, match="shadow_out_losses"):
+        lira_online_attack(np.zeros(5), np.zeros(5), np.zeros((5, 8)), np.zeros((5, 1)))

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.tree import DecisionTreeClassifier
 
 from dp.audit import (
+    audit_membership_scores,
     audit_scalar_mechanism,
     epsilon_lower_bound_binomial,
     epsilon_lower_bound_clopper_pearson,
+    one_run_model_audit,
 )
+from dp.canaries import make_label_flip_canaries
 from dp.mechanisms import add_laplace_noise
 
 
@@ -158,3 +162,117 @@ def test_audit_detects_undernoised_mechanism():
         random_state=1,
     )
     assert actual.violates(epsilon_claim=claimed)
+
+
+# --- one-run auditor from membership scores -------------------------------
+
+def test_audit_membership_scores_perfect_separation_is_large():
+    # A score that ranks every member above every non-member => all guesses
+    # correct => a large lower bound, just like the scalar no-noise audit.
+    rng = np.random.default_rng(0)
+    included = rng.integers(0, 2, size=1000)
+    scores = included + rng.normal(0, 1e-3, size=1000)  # perfectly ordered
+    result = audit_membership_scores(scores, included)
+    assert result.epsilon_lower_bound > 2.5
+
+
+def test_audit_membership_scores_chance_is_zero():
+    # Scores independent of membership => attacker at chance => bound is 0.
+    rng = np.random.default_rng(1)
+    included = rng.integers(0, 2, size=2000)
+    scores = rng.normal(0, 1, size=2000)
+    result = audit_membership_scores(scores, included)
+    assert result.epsilon_lower_bound == 0.0
+
+
+def test_audit_membership_scores_abstention_reports_budget():
+    # guess_fraction commits guesses on the most confident subset only.
+    rng = np.random.default_rng(2)
+    included = rng.integers(0, 2, size=1000)
+    scores = included + rng.normal(0, 1e-3, size=1000)
+    result = audit_membership_scores(scores, included, guess_fraction=0.4)
+    assert result.details["guess_fraction"] == 0.4
+    assert result.num_guesses == 2 * int(0.4 * 1000 / 2)
+
+
+def test_audit_membership_scores_validation():
+    with pytest.raises(ValueError, match="same length"):
+        audit_membership_scores(np.zeros(5), np.zeros(4))
+    with pytest.raises(ValueError, match="binary"):
+        audit_membership_scores(np.zeros(5), np.full(5, 2))
+    with pytest.raises(ValueError, match="guess_fraction"):
+        audit_membership_scores(np.zeros(6), np.zeros(6), guess_fraction=0.0)
+    with pytest.raises(ValueError, match="too few"):
+        audit_membership_scores(np.array([0.0]), np.array([1]))
+
+
+# --- one-run model audit: the strengthened privacy regression test --------
+
+def _blobs(n, d, sep, seed):
+    """Two well-separated Gaussian blobs; a learner predicts the true label."""
+    rng = np.random.default_rng(seed)
+    half = n // 2
+    features = np.vstack([
+        rng.normal(-sep, 1.0, size=(half, d)),
+        rng.normal(sep, 1.0, size=(half, d)),
+    ])
+    labels = np.concatenate([np.zeros(half), np.ones(half)]).astype(int)
+    return features, labels
+
+
+def _bce(y_true, prob):
+    prob = np.clip(prob, 1e-7, 1 - 1e-7)
+    return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+
+def test_one_run_audit_catches_memorising_learner():
+    # The strengthened auditor, run against a NON-private learner that
+    # memorises mislabelled canaries, must certify a large ε lower bound — the
+    # model-level analogue of the scalar no-noise regression test. A private
+    # model that stopped memorising would drive this bound to ~0, so the
+    # assertion is a live privacy contract, not a tautology.
+    base_x, base_y = _blobs(600, 8, sep=3.0, seed=1)
+    pool_x, pool_y = _blobs(400, 8, sep=3.0, seed=101)
+    canaries = make_label_flip_canaries(pool_x, pool_y, 300, random_state=1)
+
+    def train_and_score(x_aug, y_aug, canary_features):
+        tree = DecisionTreeClassifier(random_state=0).fit(x_aug, y_aug)
+        return -_bce(canaries.labels, tree.predict_proba(canary_features)[:, 1])
+
+    result = one_run_model_audit(
+        canaries, base_x, base_y, train_and_score,
+        delta=0.0, guess_fraction=0.5, random_state=1,
+    )
+    assert result.epsilon_lower_bound > 1.5
+    assert result.violates(epsilon_claim=1.0)
+    assert result.details["canary_kind"] == "label-flip"
+
+
+def test_one_run_audit_chance_attack_is_zero():
+    # The SAME canaries and base data, but a scorer that ignores membership,
+    # must not manufacture leakage: a sound audit reports ~0.
+    base_x, base_y = _blobs(600, 8, sep=3.0, seed=1)
+    pool_x, pool_y = _blobs(400, 8, sep=3.0, seed=101)
+    canaries = make_label_flip_canaries(pool_x, pool_y, 300, random_state=1)
+    noise = np.random.default_rng(7)
+
+    def train_and_score(x_aug, y_aug, canary_features):
+        return noise.standard_normal(canary_features.shape[0])
+
+    result = one_run_model_audit(
+        canaries, base_x, base_y, train_and_score,
+        delta=0.0, guess_fraction=0.5, random_state=1,
+    )
+    assert result.epsilon_lower_bound == 0.0
+
+
+def test_one_run_model_audit_validates_score_length():
+    base_x, base_y = _blobs(200, 4, sep=2.0, seed=0)
+    pool_x, pool_y = _blobs(100, 4, sep=2.0, seed=9)
+    canaries = make_label_flip_canaries(pool_x, pool_y, 40, random_state=0)
+    with pytest.raises(ValueError, match="one score per canary"):
+        one_run_model_audit(
+            canaries, base_x, base_y,
+            lambda x_aug, y_aug, cf: np.zeros(cf.shape[0] - 1),
+            random_state=0,
+        )

--- a/tests/test_canaries.py
+++ b/tests/test_canaries.py
@@ -1,0 +1,96 @@
+"""Tests for the canary constructions used by the empirical audit.
+
+Each construction probes a different memorisation failure mode; these tests pin
+down the structural properties an audit relies on — distinctness (so an excluded
+canary does not inherit an included neighbour's memorisation), correct label
+flipping, feature-space isolation, and duplication bookkeeping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from dp.canaries import (
+    CanarySet,
+    make_duplicated_canaries,
+    make_feature_outlier_canaries,
+    make_label_flip_canaries,
+)
+
+
+def _pool(n=200, d=6, seed=0):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(size=(n, d))
+    y = rng.integers(0, 2, size=n)
+    return x, y
+
+
+def test_label_flip_flips_labels_and_keeps_features():
+    x, y = _pool()
+    cs = make_label_flip_canaries(x, y, num_canaries=50, random_state=0)
+    assert cs.kind == "label-flip"
+    assert cs.duplication == 1
+    assert cs.features.shape == (50, x.shape[1])
+    # Each canary's label is the flip of some real row it copied.
+    for row, lab in zip(cs.features, cs.labels):
+        matches = np.all(np.isclose(x, row), axis=1)
+        assert matches.any()
+        assert lab == 1 - y[matches.argmax()]
+
+
+def test_label_flip_rows_are_distinct():
+    x, y = _pool()
+    cs = make_label_flip_canaries(x, y, num_canaries=120, random_state=1)
+    # No two canaries share a feature row (sampled without replacement).
+    unique = np.unique(cs.features, axis=0)
+    assert unique.shape[0] == len(cs)
+
+
+def test_label_flip_rejects_oversized_or_nonbinary():
+    x, y = _pool(n=30)
+    with pytest.raises(ValueError, match="pool size"):
+        make_label_flip_canaries(x, y, num_canaries=31)
+    with pytest.raises(ValueError, match="binary"):
+        make_label_flip_canaries(x, np.full(30, 2), num_canaries=5)
+
+
+def test_feature_outlier_radius_and_separation():
+    cs = make_feature_outlier_canaries(80, num_features=12, random_state=0, radius=6.0)
+    assert cs.kind == "feature-outlier"
+    assert cs.duplication == 1
+    norms = np.linalg.norm(cs.features, axis=1)
+    assert np.allclose(norms, 6.0)
+    # Outliers are mutually far apart: nearest-neighbour distance is large
+    # relative to a single feature's scale (near-orthogonal in high dimension).
+    gram = cs.features @ cs.features.T
+    np.fill_diagonal(gram, -np.inf)
+    max_cos = gram.max() / 36.0  # divide by radius^2
+    assert max_cos < 0.9
+    assert set(np.unique(cs.labels)).issubset({0, 1})
+
+
+def test_feature_outlier_validates_geometry():
+    with pytest.raises(ValueError, match="num_features"):
+        make_feature_outlier_canaries(10, num_features=0)
+    with pytest.raises(ValueError, match="radius"):
+        make_feature_outlier_canaries(10, num_features=4, radius=0.0)
+
+
+def test_duplicated_records_duplication_factor():
+    cs = make_duplicated_canaries(40, num_features=8, duplication=8, random_state=2)
+    assert cs.kind == "duplicated"
+    assert cs.duplication == 8
+    assert cs.features.shape == (40, 8)
+    with pytest.raises(ValueError, match="duplication"):
+        make_duplicated_canaries(10, num_features=4, duplication=0)
+
+
+def test_canaryset_validates_shapes():
+    with pytest.raises(ValueError, match="2-D"):
+        CanarySet(np.zeros(5), np.zeros(5), 1, "bad")
+    with pytest.raises(ValueError, match="align"):
+        CanarySet(np.zeros((5, 3)), np.zeros(4), 1, "bad")
+    with pytest.raises(ValueError, match="duplication"):
+        CanarySet(np.zeros((5, 3)), np.zeros(5), 0, "bad")
+    assert len(CanarySet(np.zeros((7, 3)), np.zeros(7), 1, "ok")) == 7


### PR DESCRIPTION
## Summary

This PR adds a comprehensive empirical privacy auditing framework to stress-test the DP-SGD privacy claims with stronger adversaries and multiple canary constructions. It introduces three new modules (`dp.canaries`, enhanced `dp.attacks`, and enhanced `dp.audit`) plus a standalone reproducible stress-test script.

## Key Changes

### New Modules

- **`dp/canaries.py`**: Three canary constructions for membership inference auditing:
  - `make_label_flip_canaries`: Real features with flipped labels (outlier in label space)
  - `make_feature_outlier_canaries`: Synthetic points far from the data cloud (outlier in feature space)
  - `make_duplicated_canaries`: Records repeated k times to probe group privacy and worst-case memorization
  - `CanarySet` dataclass to encapsulate canary pools with metadata

- **`notebooks/strengthened_adversary.py`**: Standalone, seeded stress-test script that:
  - Runs stronger LiRA attacks (32→128 shadow models, online vs offline, architecture mismatch)
  - Executes one-run DP-SGD audits against each canary type on properly-noised and deliberately broken models
  - Validates audit power on a memorizing learner (unbounded decision tree)
  - Produces all numbers quoted in the empirical privacy report §5

### Enhanced Modules

- **`dp/attacks.py`**: Added `lira_online_attack()` implementing Carlini et al. 2022's online likelihood-ratio attack, which fits separate Gaussians to "in" and "out" shadow model losses for more powerful membership inference at low FPR

- **`dp/audit.py`**: 
  - Added `audit_membership_scores()`: Generalizes scalar mechanism auditing to real-valued membership scores from any attack, using Steinke et al. 2023's one-run auditor with binomial inversion
  - Added `one_run_model_audit()`: Model-level auditor that inserts canaries with fair-coin inclusion, trains one model, scores canaries, and inverts agreement into ε lower bounds

### Testing & Documentation

- **`tests/test_canaries.py`**: Comprehensive tests for canary constructions (distinctness, label flipping, feature isolation, duplication bookkeeping)
- **`tests/test_attacks.py`**: Tests for online LiRA showing it outperforms offline when "in" distribution is informative
- **`tests/test_audit.py`**: Tests for membership score auditing and one-run model audit (perfect separation, chance baseline, abstention, validation)
- **`reports/empirical_privacy_report.md`**: New §5 documenting the strengthened adversary stress test with detailed tables and findings
- Updated `src/dp/__init__.py` and `README.md` to expose new public APIs

## Notable Implementation Details

- All randomness is seeded for reproducibility; the stress-test script is deliberately not wired into CI (full DP-SGD audits are expensive) but the library it drives is covered by pytest
- The one-run auditor commits guesses only where confident (top/bottom k by score), abstaining on the middle, following Steinke et al. 2023
- Duplicated canaries audit *group* privacy whose budget degrades to ≈ k·ε, requiring careful interpretation against the inflated group budget
- Architecture mismatch testing shows online LiRA collapses to chance when the adversary guesses the wrong model class, while offline LiRA is more robust but still near-chance

https://claude.ai/code/session_017wBgGwCby2PamrYXqhiaeN