### PR TITLE
Run two-config iso-epsilon subgroup LiRA spike

### DIFF
--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -1,4 +1,4 @@
-name: Two-config subgroup LiRA spike
+name: Powered two-config subgroup LiRA spike
 
 on:
   push:
@@ -22,14 +22,22 @@ on:
   workflow_dispatch:
     inputs:
       shadows:
-        description: Number of DP shadow models per recipe
+        description: Number of size-matched DP shadow models per recipe and target seed
         required: false
-        default: "12"
+        default: "32"
+      seeds:
+        description: Space-separated target seeds
+        required: false
+        default: "42 43 44"
+      bootstrap_reps:
+        description: Stratified bootstrap replicates for Delta confidence intervals
+        required: false
+        default: "1000"
 
 jobs:
   spike:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,10 +49,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[experimental]"
-      - name: Run two-config spike
+      - name: Run powered two-config spike
         run: |
           python research/two_config_spike.py \
-            --shadows "${{ github.event.inputs.shadows || '12' }}" \
+            --shadows "${{ github.event.inputs.shadows || '32' }}" \
+            --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
+            --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
+            --auc-gate 0.70 \
             --output-dir reports/spike
       - name: Add result to workflow summary
         if: always()
@@ -56,6 +67,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: two-config-subgroup-lira-spike
+          name: powered-two-config-subgroup-lira-spike
           path: reports/spike
           if-no-files-found: warn

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -6,6 +6,7 @@ on:
       - research/two-config-spike
     paths:
       - research/two_config_spike.py
+      - research/powered_spike_runner.py
       - .github/workflows/two-config-spike.yml
       - src/dp/**
       - data/insurance.csv
@@ -15,6 +16,7 @@ on:
       - main
     paths:
       - research/two_config_spike.py
+      - research/powered_spike_runner.py
       - .github/workflows/two-config-spike.yml
       - src/dp/**
       - data/insurance.csv
@@ -54,7 +56,7 @@ jobs:
         run: |
           mkdir -p reports/spike
           set +e
-          python research/two_config_spike.py \
+          python research/powered_spike_runner.py \
             --shadows "${{ github.event.inputs.shadows || '32' }}" \
             --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
             --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -10,6 +10,15 @@ on:
       - src/dp/**
       - data/insurance.csv
       - pyproject.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - research/two_config_spike.py
+      - .github/workflows/two-config-spike.yml
+      - src/dp/**
+      - data/insurance.csv
+      - pyproject.toml
   workflow_dispatch:
     inputs:
       shadows:

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -1,0 +1,52 @@
+name: Two-config subgroup LiRA spike
+
+on:
+  push:
+    branches:
+      - research/two-config-spike
+    paths:
+      - research/two_config_spike.py
+      - .github/workflows/two-config-spike.yml
+      - src/dp/**
+      - data/insurance.csv
+      - pyproject.toml
+  workflow_dispatch:
+    inputs:
+      shadows:
+        description: Number of DP shadow models per recipe
+        required: false
+        default: "12"
+
+jobs:
+  spike:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Run two-config spike
+        run: |
+          python research/two_config_spike.py \
+            --shadows "${{ github.event.inputs.shadows || '12' }}" \
+            --output-dir reports/spike
+      - name: Add result to workflow summary
+        if: always()
+        run: |
+          if [ -f reports/spike/two_config_spike.md ]; then
+            cat reports/spike/two_config_spike.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload spike results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: two-config-subgroup-lira-spike
+          path: reports/spike
+          if-no-files-found: warn

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -50,18 +50,30 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[experimental]"
       - name: Run powered two-config spike
+        shell: bash
         run: |
+          mkdir -p reports/spike
+          set +e
           python research/two_config_spike.py \
             --shadows "${{ github.event.inputs.shadows || '32' }}" \
             --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
             --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
             --auc-gate 0.70 \
-            --output-dir reports/spike
+            --output-dir reports/spike \
+            2>&1 | tee reports/spike/run.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" >> reports/spike/run.log
+          exit "$status"
       - name: Add result to workflow summary
         if: always()
         run: |
           if [ -f reports/spike/two_config_spike.md ]; then
             cat reports/spike/two_config_spike.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f reports/spike/run.log ]; then
+            echo '```text' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 80 reports/spike/run.log >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload spike results
         if: always()

--- a/reports/spike/CONCLUSION.md
+++ b/reports/spike/CONCLUSION.md
@@ -1,0 +1,3 @@
+# Conclusion
+
+The corrected high-cost spike is a null for subgroup privacy redistribution across the two tested iso-epsilon DP-SGD recipes. All six targets cleared the ROC-AUC gate, all bootstrap intervals for subgroup Delta included zero, and the direction of the gap was not stable across seeds.

--- a/reports/spike/README.md
+++ b/reports/spike/README.md
@@ -1,0 +1,4 @@
+# Spike artifacts
+
+The committed report in `two_config_spike.md` is the durable human-readable result.
+The full JSON output and run log are stored in GitHub Actions artifact `powered-two-config-subgroup-lira-spike` from workflow run `30212921872`.

--- a/reports/spike/two_config_spike.json
+++ b/reports/spike/two_config_spike.json
@@ -1,0 +1,3 @@
+{
+  "note": "The complete machine-readable result is retained in GitHub Actions artifact 8635033599 for workflow run 30212921872. The committed Markdown report contains all headline target AUC, subgroup LiRA, Delta and bootstrap interval results. Shadow-level metadata is intentionally not duplicated in the repository."
+}

--- a/reports/spike/two_config_spike.md
+++ b/reports/spike/two_config_spike.md
@@ -1,0 +1,23 @@
+# Two-configuration iso-epsilon subgroup-LiRA spike
+
+Target privacy: epsilon=8.0, delta=1e-5, RDP accountant, Poisson sampling.
+Attack cohort: equal counts in every `sex x membership` cell (132 per cell; 528 total).
+Attack: offline LiRA with 12 DP shadow models per recipe.
+Headline metric: subgroup TPR at 1% FPR and max-min gap Delta.
+
+| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |
+|---|---:|---:|---:|---|---:|---:|
+| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | female | 0.5250 | 0.0076 |
+| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | male | 0.5562 | 0.0076 |
+| **small_batch_long_tight_clip Delta** |  |  |  | **max-min** |  | **0.0000** |
+| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | female | 0.4815 | 0.0076 |
+| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | male | 0.5526 | 0.0455 |
+| **large_batch_short_loose_clip Delta** |  |  |  | **max-min** |  | **0.0379** |
+
+## Readout
+
+The observed between-recipe Delta separation is 0.0379: the tight-clipping recipe had no subgroup gap at 1% FPR, while the loose-clipping recipe had a male-minus-female gap of 0.0379.
+
+This is not yet evidence for the research claim. Both target models have weak predictive utility, subgroup LiRA AUCs are near chance, and the 12-shadow ensemble left only two OUT losses for the least-covered attack examples. At 132 non-members per subgroup, TPR@1% FPR is quantised in increments of 1/132 = 0.0076; the loose-clipping result is therefore five detected male members versus one detected female member at the permitted FPR.
+
+The result supports exactly one next experiment: repeat these same two recipes across multiple target seeds with a larger shadow ensemble and bootstrap intervals. It does not justify expanding to the full multi-dataset configuration grid yet.

--- a/reports/spike/two_config_spike.md
+++ b/reports/spike/two_config_spike.md
@@ -1,23 +1,50 @@
-# Two-configuration iso-epsilon subgroup-LiRA spike
+# Powered two-configuration iso-epsilon subgroup-LiRA spike
 
-Target privacy: epsilon=8.0, delta=1e-5, RDP accountant, Poisson sampling.
-Attack cohort: equal counts in every `sex x membership` cell (132 per cell; 528 total).
-Attack: offline LiRA with 12 DP shadow models per recipe.
-Headline metric: subgroup TPR at 1% FPR and max-min gap Delta.
+Task: `high_cost`.
 
-| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |
-|---|---:|---:|---:|---|---:|---:|
-| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | female | 0.5250 | 0.0076 |
-| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | male | 0.5562 | 0.0076 |
-| **small_batch_long_tight_clip Delta** |  |  |  | **max-min** |  | **0.0000** |
-| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | female | 0.4815 | 0.0076 |
-| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | male | 0.5526 | 0.0455 |
-| **large_batch_short_loose_clip Delta** |  |  |  | **max-min** |  | **0.0379** |
+- Target privacy: epsilon = 8.0, delta = 1e-5.
+- RDP accountant with Poisson sampling.
+- Hard attack gate: target test ROC-AUC >= 0.70.
+- Three target seeds: 42, 43 and 44.
+- 32 DP shadow models per recipe and target seed.
+- Every shadow trained on exactly 856 rows, matching the target train size and calibrated noise multiplier.
+- Balanced shadow schedule: every attack example had at least 11 OUT-shadow losses.
+- Attack cohort equalised within every `sex x membership` cell.
+- Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-minus-min gap Delta.
 
-## Readout
+| Recipe | Seed | Achieved epsilon | Noise | Test AUC | Group | LiRA AUC | TPR@1% | Delta | Bootstrap 95% CI |
+|---|---:|---:|---:|---:|---|---:|---:|---:|---|
+| small_batch_long_tight_clip | 42 | 7.9937 | 1.2054 | 0.9587 | female | 0.5094 | 0.0156 | 0.0000 | [0.0000, 0.0547] |
+| small_batch_long_tight_clip | 42 | 7.9937 | 1.2054 | 0.9587 | male | 0.5301 | 0.0156 |  |  |
+| small_batch_long_tight_clip | 43 | 7.9937 | 1.2054 | 0.9147 | female | 0.5949 | 0.0000 | 0.0310 | [0.0000, 0.1010] |
+| small_batch_long_tight_clip | 43 | 7.9937 | 1.2054 | 0.9147 | male | 0.5612 | 0.0310 |  |  |
+| small_batch_long_tight_clip | 44 | 7.9937 | 1.2054 | 0.9504 | female | 0.5746 | 0.0076 | 0.0153 | [0.0000, 0.0840] |
+| small_batch_long_tight_clip | 44 | 7.9937 | 1.2054 | 0.9504 | male | 0.5177 | 0.0229 |  |  |
+| large_batch_short_loose_clip | 42 | 7.9999 | 1.0791 | 0.9255 | female | 0.5173 | 0.0000 | 0.0234 | [0.0000, 0.0703] |
+| large_batch_short_loose_clip | 42 | 7.9999 | 1.0791 | 0.9255 | male | 0.5174 | 0.0234 |  |  |
+| large_batch_short_loose_clip | 43 | 7.9999 | 1.0791 | 0.8824 | female | 0.5419 | 0.0310 | 0.0233 | [0.0000, 0.1163] |
+| large_batch_short_loose_clip | 43 | 7.9999 | 1.0791 | 0.8824 | male | 0.5312 | 0.0078 |  |  |
+| large_batch_short_loose_clip | 44 | 7.9999 | 1.0791 | 0.8872 | female | 0.5370 | 0.0000 | 0.0076 | [0.0000, 0.0458] |
+| large_batch_short_loose_clip | 44 | 7.9999 | 1.0791 | 0.8872 | male | 0.5313 | 0.0076 |  |  |
 
-The observed between-recipe Delta separation is 0.0379: the tight-clipping recipe had no subgroup gap at 1% FPR, while the loose-clipping recipe had a male-minus-female gap of 0.0379.
+## Across-seed summary
 
-This is not yet evidence for the research claim. Both target models have weak predictive utility, subgroup LiRA AUCs are near chance, and the 12-shadow ensemble left only two OUT losses for the least-covered attack examples. At 132 non-members per subgroup, TPR@1% FPR is quantised in increments of 1/132 = 0.0076; the loose-clipping result is therefore five detected male members versus one detected female member at the permitted FPR.
+| Recipe | Mean target AUC | Min target AUC | Mean Delta | Delta range |
+|---|---:|---:|---:|---|
+| small_batch_long_tight_clip | 0.9413 | 0.9147 | 0.0154 | [0.0000, 0.0310] |
+| large_batch_short_loose_clip | 0.8984 | 0.8824 | 0.0181 | [0.0076, 0.0234] |
 
-The result supports exactly one next experiment: repeat these same two recipes across multiple target seeds with a larger shadow ensemble and bootstrap intervals. It does not justify expanding to the full multi-dataset configuration grid yet.
+The between-recipe difference in mean Delta is only 0.0027. Seed-wise, the loose-minus-tight Delta differences are +0.0234, -0.0078 and -0.0076, so the direction reverses across seeds.
+
+## Honest readout
+
+This is a null result for the proposed subgroup-redistribution claim on this dataset, task, protected attribute and pair of iso-epsilon recipes.
+
+The target models learned the task well, so the null cannot be blamed on target utility. Shadow and target train sizes, sampling assumptions, privacy target and noise calibration were matched, and every example had 11 OUT observations. Nevertheless:
+
+- every bootstrap interval for Delta includes zero;
+- subgroup LiRA AUC is mostly close to chance;
+- the more exposed group is not stable across seeds; and
+- the two recipes have almost identical mean subgroup gaps despite materially different training recipes.
+
+This result does not justify launching the full multi-dataset hyperparameter grid. The next defensible experiment is an attack-power control: run the same high-cost setup with a non-private/no-noise target and a deliberately higher-capacity model. If LiRA still remains near chance, natural membership leakage is not measurable on this dataset and the research should move to a larger dataset such as MEPS or ACS rather than adding more DP configurations.

--- a/research/powered_spike_runner.py
+++ b/research/powered_spike_runner.py
@@ -1,0 +1,132 @@
+"""Run the corrected spike with balanced fixed-size shadow coverage.
+
+The main spike harness already matches target/shadow training size. This runner
+replaces its independent shadow-set sampling with an evenly spaced cyclic design
+so every attack example receives a usable number of OUT observations without
+changing the training size, privacy target, accountant or model recipe.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import two_config_spike as spike
+
+
+def balanced_shadow_train_sets(
+    y_pool: np.ndarray,
+    train_size: int,
+    num_shadows: int,
+    seed: int,
+) -> tuple[list[np.ndarray], np.ndarray]:
+    """Create exact-size shadow sets with near-uniform OUT coverage."""
+    n = len(y_pool)
+    if train_size >= n:
+        raise ValueError("shadow train_size must be smaller than the shadow pool")
+    if num_shadows < 2:
+        raise ValueError("num_shadows must be at least two")
+
+    exclude_size = n - train_size
+    rng = np.random.default_rng(seed)
+    permutation = rng.permutation(n)
+    excluded_counts = np.zeros(n, dtype=int)
+    train_sets: list[np.ndarray] = []
+
+    for shadow_id in range(num_shadows):
+        start = (shadow_id * n) // num_shadows
+        positions = (start + np.arange(exclude_size)) % n
+        excluded_idx = permutation[positions]
+        excluded_counts[excluded_idx] += 1
+
+        in_mask = np.ones(n, dtype=bool)
+        in_mask[excluded_idx] = False
+        train_idx = np.flatnonzero(in_mask)
+        if len(train_idx) != train_size:
+            raise AssertionError("balanced schedule changed shadow train size")
+        if np.unique(y_pool[train_idx]).size != 2:
+            raise RuntimeError("balanced schedule produced a one-class shadow set")
+        train_sets.append(train_idx)
+
+    return train_sets, excluded_counts
+
+
+def collect_shadow_out_losses_balanced(
+    X_pool: np.ndarray,
+    y_pool: np.ndarray,
+    attack_idx: np.ndarray,
+    target_train_size: int,
+    target_noise_multiplier: float,
+    recipe: spike.Recipe,
+    num_shadows: int,
+    seed: int,
+) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
+    """Train size-matched shadows with balanced OUT observations."""
+    out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
+    metadata: list[dict[str, float | int | str]] = []
+    train_sets, excluded_counts = balanced_shadow_train_sets(
+        y_pool,
+        train_size=target_train_size,
+        num_shadows=num_shadows,
+        seed=seed,
+    )
+
+    for shadow_id, train_idx in enumerate(train_sets):
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
+
+        model, meta = spike.train_private_model(
+            X_pool[train_idx],
+            y_pool[train_idx],
+            recipe,
+            seed=seed + shadow_id + 1,
+        )
+        if int(meta["train_size"]) != target_train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        if not np.isclose(
+            float(meta["noise_multiplier"]),
+            target_noise_multiplier,
+            rtol=0.0,
+            atol=1e-10,
+        ):
+            raise AssertionError(
+                "matched shadow has different noise multiplier: "
+                f"target={target_noise_multiplier}, shadow={meta['noise_multiplier']}"
+            )
+
+        meta["shadow_id"] = shadow_id
+        metadata.append(meta)
+        losses = spike.per_example_bce(
+            y_pool[attack_idx],
+            spike.predict_probability(model, X_pool[attack_idx]),
+        )
+        attack_out = ~in_mask[attack_idx]
+        for local_idx in np.flatnonzero(attack_out):
+            out_losses[local_idx].append(float(losses[local_idx]))
+
+        print(
+            f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
+            f"n={meta['train_size']} achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"noise={meta['noise_multiplier']:.4f}",
+            flush=True,
+        )
+
+    expected_min = int(excluded_counts[attack_idx].min())
+    min_out = min(len(values) for values in out_losses)
+    if min_out != expected_min:
+        raise AssertionError(
+            f"recorded OUT losses ({min_out}) do not match schedule ({expected_min})"
+        )
+    if min_out < 8:
+        raise RuntimeError(
+            f"LiRA requires at least eight OUT observations; minimum was {min_out}"
+        )
+
+    matrix = np.vstack(
+        [np.asarray(values[:min_out], dtype=float) for values in out_losses]
+    )
+    return matrix, metadata, min_out
+
+
+if __name__ == "__main__":
+    spike.collect_shadow_out_losses = collect_shadow_out_losses_balanced
+    spike.main()

--- a/research/two_config_spike.py
+++ b/research/two_config_spike.py
@@ -1,0 +1,393 @@
+"""Two-configuration iso-epsilon subgroup-LiRA spike.
+
+This is deliberately a go/no-go experiment, not a benchmark grid. It trains two
+contrasting DP-SGD recipes at the same target epsilon on the insurance dataset,
+runs offline LiRA, equalises the attack cohort across sex and membership status,
+and reports the subgroup TPR@1% FPR gap Delta.
+
+Run from the repository root:
+
+    python research/two_config_spike.py --shadows 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from opacus import PrivacyEngine
+from sklearn.metrics import roc_auc_score
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from dp.attacks import lira_offline_attack
+from dp.pipeline import build_preprocessor
+from dp.tasks import get_task, prepare_task_data
+
+
+TARGET_EPSILON = 8.0
+DELTA = 1e-5
+ATTACK_FPRS = (0.001, 0.01, 0.1)
+
+
+@dataclass(frozen=True)
+class Recipe:
+    name: str
+    batch_size: int
+    epochs: int
+    max_grad_norm: float
+    hidden_units: int = 32
+    learning_rate: float = 1e-2
+
+
+RECIPES = (
+    Recipe(
+        name="small_batch_long_tight_clip",
+        batch_size=64,
+        epochs=30,
+        max_grad_norm=0.5,
+    ),
+    Recipe(
+        name="large_batch_short_loose_clip",
+        batch_size=256,
+        epochs=5,
+        max_grad_norm=2.0,
+    ),
+)
+
+
+def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
+    y_true = np.asarray(y_true, dtype=float)
+    return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+
+def build_model(n_features: int, hidden_units: int, seed: int) -> nn.Module:
+    torch.manual_seed(seed)
+    return nn.Sequential(
+        nn.Linear(n_features, hidden_units),
+        nn.ReLU(),
+        nn.Linear(hidden_units, 1),
+    )
+
+
+def train_private_model(
+    X: np.ndarray,
+    y: np.ndarray,
+    recipe: Recipe,
+    seed: int,
+) -> tuple[nn.Module, dict[str, float | int | str]]:
+    """Train one RDP-accounted, Poisson-sampled DP-SGD model at epsilon=8."""
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    order = rng.permutation(len(y))
+    X = np.asarray(X[order], dtype=np.float32)
+    y = np.asarray(y[order], dtype=np.float32)
+
+    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=min(recipe.batch_size, len(dataset)),
+        shuffle=True,
+        generator=generator,
+    )
+
+    model = build_model(X.shape[1], recipe.hidden_units, seed)
+    optimizer = torch.optim.Adam(model.parameters(), lr=recipe.learning_rate)
+    engine = PrivacyEngine(accountant="rdp")
+    model, optimizer, loader = engine.make_private_with_epsilon(
+        module=model,
+        optimizer=optimizer,
+        data_loader=loader,
+        epochs=recipe.epochs,
+        target_epsilon=TARGET_EPSILON,
+        target_delta=DELTA,
+        max_grad_norm=recipe.max_grad_norm,
+        poisson_sampling=True,
+    )
+
+    loss_fn = nn.BCEWithLogitsLoss()
+    for _ in range(recipe.epochs):
+        model.train()
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            loss = loss_fn(model(xb).squeeze(-1), yb)
+            loss.backward()
+            optimizer.step()
+
+    metadata: dict[str, float | int | str] = {
+        **asdict(recipe),
+        "target_epsilon": TARGET_EPSILON,
+        "achieved_epsilon": float(engine.get_epsilon(DELTA)),
+        "delta": DELTA,
+        "noise_multiplier": float(optimizer.noise_multiplier),
+        "accountant": "rdp",
+        "sampling": "poisson",
+        "seed": seed,
+        "train_size": int(len(dataset)),
+    }
+    return model, metadata
+
+
+def predict_probability(model: nn.Module, X: np.ndarray) -> np.ndarray:
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
+        return torch.sigmoid(logits).cpu().numpy()
+
+
+def make_equalised_attack_cohort(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    seed: int,
+) -> tuple[np.ndarray, dict[str, int]]:
+    """Equalise every group x membership cell to the smallest cell size."""
+    rng = np.random.default_rng(seed)
+    unique_groups = sorted(str(value) for value in np.unique(groups))
+    string_groups = groups.astype(str)
+    cells: dict[tuple[str, int], np.ndarray] = {}
+    for group in unique_groups:
+        for member in (0, 1):
+            idx = np.flatnonzero((string_groups == group) & (membership == member))
+            if idx.size == 0:
+                raise RuntimeError(f"empty attack cell group={group!r}, membership={member}")
+            cells[(group, member)] = idx
+
+    per_cell = min(len(idx) for idx in cells.values())
+    selected = []
+    counts: dict[str, int] = {}
+    for (group, member), idx in cells.items():
+        chosen = rng.choice(idx, size=per_cell, replace=False)
+        selected.extend(chosen.tolist())
+        counts[f"{group}|member={member}"] = int(per_cell)
+
+    selected_idx = np.asarray(sorted(selected), dtype=int)
+    return selected_idx, counts
+
+
+def collect_shadow_out_losses(
+    X_all: np.ndarray,
+    y_all: np.ndarray,
+    attack_idx: np.ndarray,
+    recipe: Recipe,
+    num_shadows: int,
+    seed: int,
+) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
+    """Train shadows and retain each example's losses only when it was OUT."""
+    rng = np.random.default_rng(seed)
+    out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
+    metadata: list[dict[str, float | int | str]] = []
+
+    for shadow_id in range(num_shadows):
+        mask = rng.random(len(y_all)) < 0.5
+        while np.unique(y_all[mask]).size < 2 or mask.sum() < 2:
+            mask = rng.random(len(y_all)) < 0.5
+
+        model, meta = train_private_model(
+            X_all[mask],
+            y_all[mask],
+            recipe,
+            seed=seed + shadow_id + 1,
+        )
+        meta["shadow_id"] = shadow_id
+        metadata.append(meta)
+
+        losses = per_example_bce(y_all[attack_idx], predict_probability(model, X_all[attack_idx]))
+        attack_out = ~mask[attack_idx]
+        for local_idx in np.flatnonzero(attack_out):
+            out_losses[local_idx].append(float(losses[local_idx]))
+
+        print(
+            f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
+            f"achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"noise={meta['noise_multiplier']:.4f}",
+            flush=True,
+        )
+
+    min_out = min(len(values) for values in out_losses)
+    if min_out < 2:
+        raise RuntimeError(
+            f"LiRA needs at least two OUT shadows per example; minimum was {min_out}. "
+            "Increase --shadows."
+        )
+    matrix = np.vstack([np.asarray(values[:min_out], dtype=float) for values in out_losses])
+    return matrix, metadata, min_out
+
+
+def run_recipe(
+    recipe: Recipe,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    groups_train: np.ndarray,
+    groups_test: np.ndarray,
+    num_shadows: int,
+    seed: int,
+) -> dict[str, object]:
+    X_all = np.vstack([X_train, X_test])
+    y_all = np.concatenate([y_train, y_test])
+    groups_all = np.concatenate([groups_train, groups_test]).astype(str)
+    membership = np.concatenate(
+        [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
+    )
+
+    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_all, membership, seed)
+
+    target, target_meta = train_private_model(X_train, y_train, recipe, seed=seed)
+    target_prob_all = predict_probability(target, X_all)
+    target_losses = per_example_bce(y_all[attack_idx], target_prob_all[attack_idx])
+    target_test_auc = float(roc_auc_score(y_test, target_prob_all[len(y_train) :]))
+
+    shadow_out, shadow_meta, min_out = collect_shadow_out_losses(
+        X_all,
+        y_all,
+        attack_idx,
+        recipe,
+        num_shadows=num_shadows,
+        seed=seed + 10_000,
+    )
+
+    subgroup_results: dict[str, dict[str, float | int]] = {}
+    attack_groups = groups_all[attack_idx]
+    attack_membership = membership[attack_idx]
+    for group in sorted(np.unique(attack_groups)):
+        group_mask = attack_groups == group
+        result = lira_offline_attack(
+            target_losses[group_mask],
+            attack_membership[group_mask],
+            shadow_out[group_mask],
+            fprs=ATTACK_FPRS,
+        )
+        subgroup_results[str(group)] = {
+            "n": int(group_mask.sum()),
+            "members": int(attack_membership[group_mask].sum()),
+            "auc": float(result.auc),
+            "tpr_at_fpr_0.001": float(result.tpr_at_fpr[0.001]),
+            "tpr_at_fpr_0.01": float(result.tpr_at_fpr[0.01]),
+            "tpr_at_fpr_0.1": float(result.tpr_at_fpr[0.1]),
+        }
+
+    tprs = [metrics["tpr_at_fpr_0.01"] for metrics in subgroup_results.values()]
+    delta_tpr_1pct = float(max(tprs) - min(tprs))
+
+    return {
+        "recipe": asdict(recipe),
+        "target": target_meta,
+        "target_test_auc": target_test_auc,
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "num_shadows": int(num_shadows),
+        "min_out_shadow_losses_per_example": int(min_out),
+        "subgroups": subgroup_results,
+        "delta_tpr_at_fpr_0.01": delta_tpr_1pct,
+        "shadow_metadata": shadow_meta,
+    }
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Two-configuration iso-epsilon subgroup-LiRA spike",
+        "",
+        f"Target privacy: epsilon={TARGET_EPSILON}, delta={DELTA}.",
+        "Attack cohort: equal counts in every sex x membership cell.",
+        "Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-min gap Delta.",
+        "",
+        "| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |",
+        "|---|---:|---:|---:|---|---:|---:|",
+    ]
+    for result in payload["results"]:
+        target = result["target"]
+        for group, metrics in result["subgroups"].items():
+            lines.append(
+                f"| {result['recipe']['name']} | {target['achieved_epsilon']:.4f} | "
+                f"{target['noise_multiplier']:.4f} | {result['target_test_auc']:.4f} | "
+                f"{group} | {metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} |"
+            )
+        lines.append(
+            f"| **{result['recipe']['name']} Delta** |  |  |  | **max-min** |  | "
+            f"**{result['delta_tpr_at_fpr_0.01']:.4f}** |"
+        )
+
+    deltas = [result["delta_tpr_at_fpr_0.01"] for result in payload["results"]]
+    lines.extend(
+        [
+            "",
+            "## Go/no-go readout",
+            "",
+            f"Delta values: {', '.join(f'{value:.4f}' for value in deltas)}.",
+            f"Absolute between-recipe Delta separation: {abs(deltas[0] - deltas[1]):.4f}.",
+            "",
+            "This spike is directional only: one target seed and a small shadow ensemble. "
+            "A visible separation justifies a powered repeated-seed experiment; a null result "
+            "means the current dataset/attack/config contrast did not resolve the phenomenon.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shadows", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", default="reports/spike")
+    args = parser.parse_args()
+
+    if args.shadows < 6:
+        raise ValueError("Use at least six shadows; 12 is the intended spike setting.")
+
+    torch.set_num_threads(2)
+    root = Path(__file__).resolve().parents[1]
+    df = pd.read_csv(root / "data" / "insurance.csv")
+    data = prepare_task_data(df, get_task("smoker_without_charges"), random_state=args.seed)
+
+    preprocessor = build_preprocessor(data.X_train)
+    X_train = np.asarray(preprocessor.fit_transform(data.X_train), dtype=np.float32)
+    X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
+
+    payload: dict[str, object] = {
+        "experiment": "two_config_iso_epsilon_subgroup_lira_spike",
+        "target_epsilon": TARGET_EPSILON,
+        "delta": DELTA,
+        "task": data.task.name,
+        "sensitive_attribute": "sex",
+        "seed": args.seed,
+        "results": [],
+    }
+
+    for recipe in RECIPES:
+        print(f"\n=== {recipe.name} ===", flush=True)
+        payload["results"].append(
+            run_recipe(
+                recipe,
+                X_train,
+                data.y_train,
+                X_test,
+                data.y_test,
+                data.sensitive_train,
+                data.sensitive_test,
+                num_shadows=args.shadows,
+                seed=args.seed,
+            )
+        )
+
+    output_dir = root / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "two_config_spike.json"
+    md_path = output_dir / "two_config_spike.md"
+    json_path.write_text(json.dumps(payload, indent=2))
+    md_path.write_text(render_markdown(payload))
+
+    print("\n" + md_path.read_text(), flush=True)
+    print(f"JSON: {json_path}")
+    print(f"Markdown: {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/two_config_spike.py
+++ b/research/two_config_spike.py
@@ -1,13 +1,20 @@
-"""Two-configuration iso-epsilon subgroup-LiRA spike.
+"""Powered two-configuration iso-epsilon subgroup-LiRA spike.
 
-This is deliberately a go/no-go experiment, not a benchmark grid. It trains two
-contrasting DP-SGD recipes at the same target epsilon on the insurance dataset,
-runs offline LiRA, equalises the attack cohort across sex and membership status,
-and reports the subgroup TPR@1% FPR gap Delta.
+This remains a go/no-go experiment rather than a benchmark grid. It corrects the
+first spike by:
+
+* using the learnable ``high_cost`` task;
+* refusing to run an attack when target ROC-AUC is below a hard gate;
+* training every shadow on exactly the target training-set size, so the DP-SGD
+  sampling rate and calibrated noise multiplier match the target;
+* using at least 32 shadows;
+* repeating three target seeds; and
+* reporting stratified-bootstrap confidence intervals for the subgroup
+  TPR@1% FPR gap Delta.
 
 Run from the repository root:
 
-    python research/two_config_spike.py --shadows 12
+    python research/two_config_spike.py --shadows 32 --seeds 42 43 44
 """
 
 from __future__ import annotations
@@ -16,12 +23,13 @@ import argparse
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
 import torch
 from opacus import PrivacyEngine
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import roc_auc_score, roc_curve
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -32,7 +40,13 @@ from dp.tasks import get_task, prepare_task_data
 
 TARGET_EPSILON = 8.0
 DELTA = 1e-5
+TASK_NAME = "high_cost"
 ATTACK_FPRS = (0.001, 0.01, 0.1)
+HARD_AUC_GATE = 0.70
+PREFERRED_AUC = 0.75
+DEFAULT_SEEDS = (42, 43, 44)
+DEFAULT_SHADOWS = 32
+DEFAULT_BOOTSTRAP_REPS = 1000
 
 
 @dataclass(frozen=True)
@@ -62,12 +76,14 @@ RECIPES = (
 
 
 def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    """Numerically stable per-example binary cross-entropy."""
     prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
     y_true = np.asarray(y_true, dtype=float)
     return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
 
 
 def build_model(n_features: int, hidden_units: int, seed: int) -> nn.Module:
+    """Build the target/shadow architecture."""
     torch.manual_seed(seed)
     return nn.Sequential(
         nn.Linear(n_features, hidden_units),
@@ -136,6 +152,7 @@ def train_private_model(
 
 
 def predict_probability(model: nn.Module, X: np.ndarray) -> np.ndarray:
+    """Return positive-class probabilities."""
     model.eval()
     with torch.no_grad():
         logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
@@ -160,103 +177,232 @@ def make_equalised_attack_cohort(
             cells[(group, member)] = idx
 
     per_cell = min(len(idx) for idx in cells.values())
-    selected = []
+    selected: list[int] = []
     counts: dict[str, int] = {}
     for (group, member), idx in cells.items():
         chosen = rng.choice(idx, size=per_cell, replace=False)
         selected.extend(chosen.tolist())
         counts[f"{group}|member={member}"] = int(per_cell)
 
-    selected_idx = np.asarray(sorted(selected), dtype=int)
-    return selected_idx, counts
+    return np.asarray(sorted(selected), dtype=int), counts
+
+
+def _fixed_size_shadow_indices(
+    y_pool: np.ndarray,
+    train_size: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Sample exactly ``train_size`` rows while retaining both target classes."""
+    if train_size >= len(y_pool):
+        raise ValueError("shadow train_size must be smaller than the shadow pool")
+    for _ in range(1000):
+        idx = rng.choice(len(y_pool), size=train_size, replace=False)
+        if np.unique(y_pool[idx]).size == 2:
+            return np.asarray(idx, dtype=int)
+    raise RuntimeError("could not draw a two-class fixed-size shadow training set")
 
 
 def collect_shadow_out_losses(
-    X_all: np.ndarray,
-    y_all: np.ndarray,
+    X_pool: np.ndarray,
+    y_pool: np.ndarray,
     attack_idx: np.ndarray,
+    target_train_size: int,
+    target_noise_multiplier: float,
     recipe: Recipe,
     num_shadows: int,
     seed: int,
 ) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
-    """Train shadows and retain each example's losses only when it was OUT."""
+    """Train size-matched shadows and retain losses when each attack row is OUT."""
     rng = np.random.default_rng(seed)
     out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
     metadata: list[dict[str, float | int | str]] = []
 
     for shadow_id in range(num_shadows):
-        mask = rng.random(len(y_all)) < 0.5
-        while np.unique(y_all[mask]).size < 2 or mask.sum() < 2:
-            mask = rng.random(len(y_all)) < 0.5
+        train_idx = _fixed_size_shadow_indices(y_pool, target_train_size, rng)
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
 
         model, meta = train_private_model(
-            X_all[mask],
-            y_all[mask],
+            X_pool[train_idx],
+            y_pool[train_idx],
             recipe,
             seed=seed + shadow_id + 1,
         )
+        if int(meta["train_size"]) != target_train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        if not np.isclose(
+            float(meta["noise_multiplier"]),
+            target_noise_multiplier,
+            rtol=0.0,
+            atol=1e-10,
+        ):
+            raise AssertionError(
+                "size-matched shadow has a different calibrated noise multiplier: "
+                f"target={target_noise_multiplier}, shadow={meta['noise_multiplier']}"
+            )
+
         meta["shadow_id"] = shadow_id
         metadata.append(meta)
 
-        losses = per_example_bce(y_all[attack_idx], predict_probability(model, X_all[attack_idx]))
-        attack_out = ~mask[attack_idx]
+        losses = per_example_bce(
+            y_pool[attack_idx],
+            predict_probability(model, X_pool[attack_idx]),
+        )
+        attack_out = ~in_mask[attack_idx]
         for local_idx in np.flatnonzero(attack_out):
             out_losses[local_idx].append(float(losses[local_idx]))
 
         print(
             f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
-            f"achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"n={meta['train_size']} achieved_eps={meta['achieved_epsilon']:.4f} "
             f"noise={meta['noise_multiplier']:.4f}",
             flush=True,
         )
 
     min_out = min(len(values) for values in out_losses)
-    if min_out < 2:
+    if min_out < 4:
         raise RuntimeError(
-            f"LiRA needs at least two OUT shadows per example; minimum was {min_out}. "
+            f"LiRA needs a usable OUT distribution; minimum was {min_out}. "
             "Increase --shadows."
         )
     matrix = np.vstack([np.asarray(values[:min_out], dtype=float) for values in out_losses])
     return matrix, metadata, min_out
 
 
-def run_recipe(
+def tpr_at_fpr(membership: np.ndarray, scores: np.ndarray, target_fpr: float) -> float:
+    """Highest TPR attainable without exceeding ``target_fpr``."""
+    fpr, tpr, _ = roc_curve(membership, scores)
+    allowed = fpr <= target_fpr
+    return float(tpr[allowed].max()) if allowed.any() else 0.0
+
+
+def stratified_bootstrap_delta(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    scores: np.ndarray,
+    target_fpr: float,
+    reps: int,
+    seed: int,
+) -> dict[str, float | int]:
+    """Bootstrap Delta while preserving every group x membership cell size."""
+    rng = np.random.default_rng(seed)
+    groups = groups.astype(str)
+    unique_groups = sorted(np.unique(groups))
+    cells = {
+        (group, member): np.flatnonzero((groups == group) & (membership == member))
+        for group in unique_groups
+        for member in (0, 1)
+    }
+    if any(len(idx) == 0 for idx in cells.values()):
+        raise RuntimeError("bootstrap requires non-empty group x membership cells")
+
+    deltas = np.empty(reps, dtype=float)
+    for rep in range(reps):
+        group_tprs = []
+        for group in unique_groups:
+            member_idx = rng.choice(
+                cells[(group, 1)], size=len(cells[(group, 1)]), replace=True
+            )
+            nonmember_idx = rng.choice(
+                cells[(group, 0)], size=len(cells[(group, 0)]), replace=True
+            )
+            idx = np.concatenate([member_idx, nonmember_idx])
+            group_tprs.append(tpr_at_fpr(membership[idx], scores[idx], target_fpr))
+        deltas[rep] = max(group_tprs) - min(group_tprs)
+
+    low, high = np.percentile(deltas, [2.5, 97.5])
+    return {
+        "reps": int(reps),
+        "mean": float(deltas.mean()),
+        "median": float(np.median(deltas)),
+        "ci95_low": float(low),
+        "ci95_high": float(high),
+    }
+
+
+def run_recipe_seed(
     recipe: Recipe,
     X_train: np.ndarray,
     y_train: np.ndarray,
+    X_val: np.ndarray,
+    y_val: np.ndarray,
     X_test: np.ndarray,
     y_test: np.ndarray,
     groups_train: np.ndarray,
     groups_test: np.ndarray,
     num_shadows: int,
+    bootstrap_reps: int,
+    auc_gate: float,
     seed: int,
 ) -> dict[str, object]:
-    X_all = np.vstack([X_train, X_test])
-    y_all = np.concatenate([y_train, y_test])
-    groups_all = np.concatenate([groups_train, groups_test]).astype(str)
+    """Run one recipe/target-seed cell, with an AUC gate before shadow training."""
+    X_attack = np.vstack([X_train, X_test])
+    y_attack = np.concatenate([y_train, y_test])
+    groups_attack = np.concatenate([groups_train, groups_test]).astype(str)
     membership = np.concatenate(
         [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
     )
-
-    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_all, membership, seed)
+    attack_idx, cohort_counts = make_equalised_attack_cohort(
+        groups_attack, membership, seed
+    )
 
     target, target_meta = train_private_model(X_train, y_train, recipe, seed=seed)
-    target_prob_all = predict_probability(target, X_all)
-    target_losses = per_example_bce(y_all[attack_idx], target_prob_all[attack_idx])
-    target_test_auc = float(roc_auc_score(y_test, target_prob_all[len(y_train) :]))
+    target_test_prob = predict_probability(target, X_test)
+    target_test_auc = float(roc_auc_score(y_test, target_test_prob))
+    preferred_auc_met = target_test_auc >= PREFERRED_AUC
 
+    base_result: dict[str, object] = {
+        "seed": int(seed),
+        "recipe": asdict(recipe),
+        "target": target_meta,
+        "target_test_auc": target_test_auc,
+        "auc_gate": float(auc_gate),
+        "preferred_auc": PREFERRED_AUC,
+        "preferred_auc_met": preferred_auc_met,
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "attack_status": "pending",
+    }
+
+    print(
+        f"[{recipe.name} seed={seed}] target AUC={target_test_auc:.4f} "
+        f"(gate={auc_gate:.2f}, preferred={PREFERRED_AUC:.2f})",
+        flush=True,
+    )
+    if target_test_auc < auc_gate:
+        base_result["attack_status"] = "skipped_target_auc_below_gate"
+        base_result["subgroups"] = {}
+        base_result["delta_tpr_at_fpr_0.01"] = None
+        base_result["bootstrap_delta"] = None
+        return base_result
+
+    X_pool = np.vstack([X_train, X_val, X_test])
+    y_pool = np.concatenate([y_train, y_val, y_test])
+
+    attack_pool_idx = attack_idx.copy()
+    train_n = len(y_train)
+    attack_pool_idx[attack_pool_idx >= train_n] += len(y_val)
+
+    target_prob_attack = predict_probability(target, X_attack)
+    target_losses = per_example_bce(
+        y_attack[attack_idx], target_prob_attack[attack_idx]
+    )
     shadow_out, shadow_meta, min_out = collect_shadow_out_losses(
-        X_all,
-        y_all,
-        attack_idx,
-        recipe,
+        X_pool,
+        y_pool,
+        attack_pool_idx,
+        target_train_size=len(y_train),
+        target_noise_multiplier=float(target_meta["noise_multiplier"]),
+        recipe=recipe,
         num_shadows=num_shadows,
         seed=seed + 10_000,
     )
 
-    subgroup_results: dict[str, dict[str, float | int]] = {}
-    attack_groups = groups_all[attack_idx]
+    attack_groups = groups_attack[attack_idx]
     attack_membership = membership[attack_idx]
+    subgroup_results: dict[str, dict[str, float | int]] = {}
+    all_scores = np.empty(len(attack_idx), dtype=float)
+
     for group in sorted(np.unique(attack_groups)):
         group_mask = attack_groups == group
         result = lira_offline_attack(
@@ -265,9 +411,11 @@ def run_recipe(
             shadow_out[group_mask],
             fprs=ATTACK_FPRS,
         )
+        all_scores[group_mask] = result.scores
         subgroup_results[str(group)] = {
             "n": int(group_mask.sum()),
             "members": int(attack_membership[group_mask].sum()),
+            "nonmembers": int((attack_membership[group_mask] == 0).sum()),
             "auc": float(result.auc),
             "tpr_at_fpr_0.001": float(result.tpr_at_fpr[0.001]),
             "tpr_at_fpr_0.01": float(result.tpr_at_fpr[0.01]),
@@ -275,58 +423,148 @@ def run_recipe(
         }
 
     tprs = [metrics["tpr_at_fpr_0.01"] for metrics in subgroup_results.values()]
-    delta_tpr_1pct = float(max(tprs) - min(tprs))
+    observed_delta = float(max(tprs) - min(tprs))
+    bootstrap = stratified_bootstrap_delta(
+        attack_groups,
+        attack_membership,
+        all_scores,
+        target_fpr=0.01,
+        reps=bootstrap_reps,
+        seed=seed + 20_000,
+    )
 
-    return {
+    base_result.update(
+        {
+            "attack_status": "completed",
+            "num_shadows": int(num_shadows),
+            "min_out_shadow_losses_per_example": int(min_out),
+            "subgroups": subgroup_results,
+            "delta_tpr_at_fpr_0.01": observed_delta,
+            "bootstrap_delta": bootstrap,
+            "shadow_train_size": int(len(y_train)),
+            "shadow_metadata": shadow_meta,
+        }
+    )
+    return base_result
+
+
+def summarize_recipe(recipe: Recipe, seed_results: Sequence[dict[str, object]]) -> dict[str, object]:
+    """Aggregate completed target seeds without hiding skipped cells."""
+    completed = [
+        result for result in seed_results if result["attack_status"] == "completed"
+    ]
+    deltas = np.asarray(
+        [result["delta_tpr_at_fpr_0.01"] for result in completed], dtype=float
+    )
+    aucs = np.asarray([result["target_test_auc"] for result in seed_results], dtype=float)
+    summary: dict[str, object] = {
         "recipe": asdict(recipe),
-        "target": target_meta,
-        "target_test_auc": target_test_auc,
-        "cohort_counts": cohort_counts,
-        "num_attack_examples": int(len(attack_idx)),
-        "num_shadows": int(num_shadows),
-        "min_out_shadow_losses_per_example": int(min_out),
-        "subgroups": subgroup_results,
-        "delta_tpr_at_fpr_0.01": delta_tpr_1pct,
-        "shadow_metadata": shadow_meta,
+        "target_seeds": int(len(seed_results)),
+        "completed_attacks": int(len(completed)),
+        "skipped_attacks": int(len(seed_results) - len(completed)),
+        "target_auc_mean": float(aucs.mean()),
+        "target_auc_min": float(aucs.min()),
+        "target_auc_max": float(aucs.max()),
     }
+    if len(deltas):
+        summary.update(
+            {
+                "delta_mean": float(deltas.mean()),
+                "delta_median": float(np.median(deltas)),
+                "delta_min": float(deltas.min()),
+                "delta_max": float(deltas.max()),
+            }
+        )
+    else:
+        summary.update(
+            {
+                "delta_mean": None,
+                "delta_median": None,
+                "delta_min": None,
+                "delta_max": None,
+            }
+        )
+    return summary
 
 
 def render_markdown(payload: dict[str, object]) -> str:
+    """Render an examiner-readable result summary."""
     lines = [
-        "# Two-configuration iso-epsilon subgroup-LiRA spike",
+        "# Powered two-configuration iso-epsilon subgroup-LiRA spike",
         "",
+        f"Task: `{payload['task']}`.",
         f"Target privacy: epsilon={TARGET_EPSILON}, delta={DELTA}.",
+        f"Hard attack gate: target test ROC-AUC >= {payload['auc_gate']:.2f}.",
+        f"Preferred target quality: ROC-AUC >= {PREFERRED_AUC:.2f}.",
+        (
+            "Shadows are trained on exactly the target training-set size, with the "
+            "same recipe, accountant, epsilon and delta."
+        ),
         "Attack cohort: equal counts in every sex x membership cell.",
         "Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-min gap Delta.",
         "",
-        "| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |",
-        "|---|---:|---:|---:|---|---:|---:|",
+        "| Recipe | Seed | Achieved epsilon | Noise | Test AUC | Attack | Group | LiRA AUC | TPR@1% | Delta | Bootstrap 95% CI |",
+        "|---|---:|---:|---:|---:|---|---|---:|---:|---:|---|",
     ]
-    for result in payload["results"]:
-        target = result["target"]
-        for group, metrics in result["subgroups"].items():
-            lines.append(
-                f"| {result['recipe']['name']} | {target['achieved_epsilon']:.4f} | "
-                f"{target['noise_multiplier']:.4f} | {result['target_test_auc']:.4f} | "
-                f"{group} | {metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} |"
-            )
-        lines.append(
-            f"| **{result['recipe']['name']} Delta** |  |  |  | **max-min** |  | "
-            f"**{result['delta_tpr_at_fpr_0.01']:.4f}** |"
-        )
 
-    deltas = [result["delta_tpr_at_fpr_0.01"] for result in payload["results"]]
+    for result in payload["seed_results"]:
+        target = result["target"]
+        if result["attack_status"] != "completed":
+            lines.append(
+                f"| {result['recipe']['name']} | {result['seed']} | "
+                f"{target['achieved_epsilon']:.4f} | {target['noise_multiplier']:.4f} | "
+                f"{result['target_test_auc']:.4f} | **SKIPPED: AUC gate** | - | - | - | - | - |"
+            )
+            continue
+
+        bootstrap = result["bootstrap_delta"]
+        ci = f"[{bootstrap['ci95_low']:.4f}, {bootstrap['ci95_high']:.4f}]"
+        first = True
+        for group, metrics in result["subgroups"].items():
+            delta = f"{result['delta_tpr_at_fpr_0.01']:.4f}" if first else ""
+            ci_cell = ci if first else ""
+            lines.append(
+                f"| {result['recipe']['name']} | {result['seed']} | "
+                f"{target['achieved_epsilon']:.4f} | {target['noise_multiplier']:.4f} | "
+                f"{result['target_test_auc']:.4f} | completed | {group} | "
+                f"{metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} | "
+                f"{delta} | {ci_cell} |"
+            )
+            first = False
+
     lines.extend(
         [
             "",
-            "## Go/no-go readout",
+            "## Across-seed summary",
             "",
-            f"Delta values: {', '.join(f'{value:.4f}' for value in deltas)}.",
-            f"Absolute between-recipe Delta separation: {abs(deltas[0] - deltas[1]):.4f}.",
+            "| Recipe | Seeds | Attacks completed | Mean target AUC | Min target AUC | Mean Delta | Delta range |",
+            "|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for summary in payload["recipe_summaries"]:
+        mean_delta = (
+            "-" if summary["delta_mean"] is None else f"{summary['delta_mean']:.4f}"
+        )
+        delta_range = (
+            "-"
+            if summary["delta_min"] is None
+            else f"[{summary['delta_min']:.4f}, {summary['delta_max']:.4f}]"
+        )
+        lines.append(
+            f"| {summary['recipe']['name']} | {summary['target_seeds']} | "
+            f"{summary['completed_attacks']} | {summary['target_auc_mean']:.4f} | "
+            f"{summary['target_auc_min']:.4f} | {mean_delta} | {delta_range} |"
+        )
+
+    lines.extend(
+        [
             "",
-            "This spike is directional only: one target seed and a small shadow ensemble. "
-            "A visible separation justifies a powered repeated-seed experiment; a null result "
-            "means the current dataset/attack/config contrast did not resolve the phenomenon.",
+            "## Interpretation rule",
+            "",
+            "A non-zero point estimate is not called a signal when its bootstrap interval "
+            "includes zero or when it is driven by a single seed. The experiment only "
+            "supports expansion when target models learn the task and the subgroup gap "
+            "is stable across seeds.",
         ]
     )
     return "\n".join(lines) + "\n"
@@ -334,47 +572,73 @@ def render_markdown(payload: dict[str, object]) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--shadows", type=int, default=12)
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--shadows", type=int, default=DEFAULT_SHADOWS)
+    parser.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
+    parser.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
+    parser.add_argument("--auc-gate", type=float, default=HARD_AUC_GATE)
     parser.add_argument("--output-dir", default="reports/spike")
     args = parser.parse_args()
 
-    if args.shadows < 6:
-        raise ValueError("Use at least six shadows; 12 is the intended spike setting.")
+    if args.shadows < DEFAULT_SHADOWS:
+        raise ValueError(f"Use at least {DEFAULT_SHADOWS} shadows.")
+    if len(args.seeds) < 3:
+        raise ValueError("Use at least three target seeds.")
+    if args.bootstrap_reps < 200:
+        raise ValueError("Use at least 200 bootstrap replicates.")
+    if not (0.5 <= args.auc_gate <= 1.0):
+        raise ValueError("--auc-gate must be in [0.5, 1.0]")
 
     torch.set_num_threads(2)
     root = Path(__file__).resolve().parents[1]
     df = pd.read_csv(root / "data" / "insurance.csv")
-    data = prepare_task_data(df, get_task("smoker_without_charges"), random_state=args.seed)
-
-    preprocessor = build_preprocessor(data.X_train)
-    X_train = np.asarray(preprocessor.fit_transform(data.X_train), dtype=np.float32)
-    X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
 
     payload: dict[str, object] = {
-        "experiment": "two_config_iso_epsilon_subgroup_lira_spike",
+        "experiment": "powered_two_config_iso_epsilon_subgroup_lira_spike",
         "target_epsilon": TARGET_EPSILON,
         "delta": DELTA,
-        "task": data.task.name,
+        "task": TASK_NAME,
         "sensitive_attribute": "sex",
-        "seed": args.seed,
-        "results": [],
+        "auc_gate": float(args.auc_gate),
+        "preferred_auc": PREFERRED_AUC,
+        "seeds": [int(seed) for seed in args.seeds],
+        "num_shadows": int(args.shadows),
+        "bootstrap_reps": int(args.bootstrap_reps),
+        "seed_results": [],
+        "recipe_summaries": [],
     }
 
     for recipe in RECIPES:
-        print(f"\n=== {recipe.name} ===", flush=True)
-        payload["results"].append(
-            run_recipe(
+        recipe_seed_results = []
+        for seed in args.seeds:
+            print(f"\n=== {recipe.name} | target seed {seed} ===", flush=True)
+            data = prepare_task_data(df, get_task(TASK_NAME), random_state=seed)
+            preprocessor = build_preprocessor(data.X_train)
+            X_train = np.asarray(
+                preprocessor.fit_transform(data.X_train), dtype=np.float32
+            )
+            X_val = np.asarray(preprocessor.transform(data.X_val), dtype=np.float32)
+            X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
+
+            result = run_recipe_seed(
                 recipe,
                 X_train,
                 data.y_train,
+                X_val,
+                data.y_val,
                 X_test,
                 data.y_test,
                 data.sensitive_train,
                 data.sensitive_test,
                 num_shadows=args.shadows,
-                seed=args.seed,
+                bootstrap_reps=args.bootstrap_reps,
+                auc_gate=args.auc_gate,
+                seed=seed,
             )
+            recipe_seed_results.append(result)
+            payload["seed_results"].append(result)
+
+        payload["recipe_summaries"].append(
+            summarize_recipe(recipe, recipe_seed_results)
         )
 
     output_dir = root / args.output_dir


### PR DESCRIPTION
This draft PR exists to execute the minimum go/no-go experiment before expanding the research plan.

- one dataset: insurance, `smoker_without_charges`
- fixed target privacy: epsilon=8, delta=1e-5, RDP accountant, Poisson sampling
- two deliberately contrasting DP-SGD recipes
- offline LiRA
- attack cohort equalised across sex and membership status
- headline output: subgroup TPR@1% FPR and max-min gap Delta

The generated results are uploaded as a workflow artifact. Do not merge until the spike is reviewed.