### PR TITLE
Attack-power control experiment with stratified permutation null testing

### DIFF
--- a/.github/workflows/attack-power-control.yml
+++ b/.github/workflows/attack-power-control.yml
@@ -1,0 +1,81 @@
+name: Attack-power control
+
+# Manual dispatch only, plus the research PR. This trains dozens of shadow
+# models and must never run on every push to main.
+on:
+  workflow_dispatch:
+    inputs:
+      shadows:
+        description: Shadow models per control and target seed
+        required: false
+        default: "32"
+      seeds:
+        description: Space-separated target seeds
+        required: false
+        default: "42 43 44"
+      bootstrap_reps:
+        description: Stratified bootstrap replicates
+        required: false
+        default: "1000"
+      controls:
+        description: Space-separated control names to run
+        required: false
+        default: "matched_capacity_mlp memorising_mlp unbounded_decision_tree"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - research/attack_power_control.py
+      - .github/workflows/attack-power-control.yml
+      - tests/test_attack_power_control.py
+
+jobs:
+  attack-power-control:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Run attack-power control experiment
+        shell: bash
+        run: |
+          mkdir -p reports/attack_power_control
+          set +e
+          python research/attack_power_control.py \
+            --shadows "${{ github.event.inputs.shadows || '32' }}" \
+            --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
+            --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
+            --controls ${{ github.event.inputs.controls || 'matched_capacity_mlp memorising_mlp unbounded_decision_tree' }} \
+            --output-dir reports/attack_power_control \
+            2>&1 | tee reports/attack_power_control/console.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" >> reports/attack_power_control/console.log
+          exit "$status"
+      - name: Add report to workflow summary
+        if: always()
+        run: |
+          if [ -f reports/attack_power_control/attack_power_control.md ]; then
+            cat reports/attack_power_control/attack_power_control.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f reports/attack_power_control/console.log ]; then
+            echo '```text' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 80 reports/attack_power_control/console.log >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # Results are uploaded as artifacts only; they are never committed back to
+      # the repository and no pull request is merged by this workflow.
+      - name: Upload attack-power control results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: attack-power-control
+          path: reports/attack_power_control
+          if-no-files-found: warn

--- a/.github/workflows/attack-power-control.yml
+++ b/.github/workflows/attack-power-control.yml
@@ -17,6 +17,10 @@ on:
         description: Stratified bootstrap replicates
         required: false
         default: "1000"
+      permutation_reps:
+        description: Stratified membership permutation replicates
+        required: false
+        default: "1000"
       controls:
         description: Space-separated control names to run
         required: false
@@ -53,6 +57,7 @@ jobs:
             --shadows "${{ github.event.inputs.shadows || '32' }}" \
             --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
             --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
+            --permutation-reps "${{ github.event.inputs.permutation_reps || '1000' }}" \
             --controls ${{ github.event.inputs.controls || 'matched_capacity_mlp memorising_mlp unbounded_decision_tree' }} \
             --output-dir reports/attack_power_control \
             2>&1 | tee reports/attack_power_control/console.log

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -1,4 +1,4 @@
-name: Two-config subgroup LiRA spike
+name: Powered two-config subgroup LiRA spike
 
 on:
   push:
@@ -22,14 +22,22 @@ on:
   workflow_dispatch:
     inputs:
       shadows:
-        description: Number of DP shadow models per recipe
+        description: Number of size-matched DP shadow models per recipe and target seed
         required: false
-        default: "12"
+        default: "32"
+      seeds:
+        description: Space-separated target seeds
+        required: false
+        default: "42 43 44"
+      bootstrap_reps:
+        description: Stratified bootstrap replicates for Delta confidence intervals
+        required: false
+        default: "1000"
 
 jobs:
   spike:
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,10 +49,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[experimental]"
-      - name: Run two-config spike
+      - name: Run powered two-config spike
         run: |
           python research/two_config_spike.py \
-            --shadows "${{ github.event.inputs.shadows || '12' }}" \
+            --shadows "${{ github.event.inputs.shadows || '32' }}" \
+            --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
+            --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
+            --auc-gate 0.70 \
             --output-dir reports/spike
       - name: Add result to workflow summary
         if: always()
@@ -56,6 +67,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: two-config-subgroup-lira-spike
+          name: powered-two-config-subgroup-lira-spike
           path: reports/spike
           if-no-files-found: warn

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -6,6 +6,7 @@ on:
       - research/two-config-spike
     paths:
       - research/two_config_spike.py
+      - research/powered_spike_runner.py
       - .github/workflows/two-config-spike.yml
       - src/dp/**
       - data/insurance.csv
@@ -15,6 +16,7 @@ on:
       - main
     paths:
       - research/two_config_spike.py
+      - research/powered_spike_runner.py
       - .github/workflows/two-config-spike.yml
       - src/dp/**
       - data/insurance.csv
@@ -54,7 +56,7 @@ jobs:
         run: |
           mkdir -p reports/spike
           set +e
-          python research/two_config_spike.py \
+          python research/powered_spike_runner.py \
             --shadows "${{ github.event.inputs.shadows || '32' }}" \
             --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
             --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -10,6 +10,15 @@ on:
       - src/dp/**
       - data/insurance.csv
       - pyproject.toml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - research/two_config_spike.py
+      - .github/workflows/two-config-spike.yml
+      - src/dp/**
+      - data/insurance.csv
+      - pyproject.toml
   workflow_dispatch:
     inputs:
       shadows:

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -1,0 +1,52 @@
+name: Two-config subgroup LiRA spike
+
+on:
+  push:
+    branches:
+      - research/two-config-spike
+    paths:
+      - research/two_config_spike.py
+      - .github/workflows/two-config-spike.yml
+      - src/dp/**
+      - data/insurance.csv
+      - pyproject.toml
+  workflow_dispatch:
+    inputs:
+      shadows:
+        description: Number of DP shadow models per recipe
+        required: false
+        default: "12"
+
+jobs:
+  spike:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Run two-config spike
+        run: |
+          python research/two_config_spike.py \
+            --shadows "${{ github.event.inputs.shadows || '12' }}" \
+            --output-dir reports/spike
+      - name: Add result to workflow summary
+        if: always()
+        run: |
+          if [ -f reports/spike/two_config_spike.md ]; then
+            cat reports/spike/two_config_spike.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload spike results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: two-config-subgroup-lira-spike
+          path: reports/spike
+          if-no-files-found: warn

--- a/.github/workflows/two-config-spike.yml
+++ b/.github/workflows/two-config-spike.yml
@@ -50,18 +50,30 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ".[experimental]"
       - name: Run powered two-config spike
+        shell: bash
         run: |
+          mkdir -p reports/spike
+          set +e
           python research/two_config_spike.py \
             --shadows "${{ github.event.inputs.shadows || '32' }}" \
             --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
             --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
             --auc-gate 0.70 \
-            --output-dir reports/spike
+            --output-dir reports/spike \
+            2>&1 | tee reports/spike/run.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" >> reports/spike/run.log
+          exit "$status"
       - name: Add result to workflow summary
         if: always()
         run: |
           if [ -f reports/spike/two_config_spike.md ]; then
             cat reports/spike/two_config_spike.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f reports/spike/run.log ]; then
+            echo '```text' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 80 reports/spike/run.log >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload spike results
         if: always()

--- a/reports/spike/CONCLUSION.md
+++ b/reports/spike/CONCLUSION.md
@@ -1,0 +1,3 @@
+# Conclusion
+
+The corrected high-cost spike is a null for subgroup privacy redistribution across the two tested iso-epsilon DP-SGD recipes. All six targets cleared the ROC-AUC gate, all bootstrap intervals for subgroup Delta included zero, and the direction of the gap was not stable across seeds.

--- a/reports/spike/README.md
+++ b/reports/spike/README.md
@@ -1,0 +1,4 @@
+# Spike artifacts
+
+The committed report in `two_config_spike.md` is the durable human-readable result.
+The full JSON output and run log are stored in GitHub Actions artifact `powered-two-config-subgroup-lira-spike` from workflow run `30212921872`.

--- a/reports/spike/two_config_spike.json
+++ b/reports/spike/two_config_spike.json
@@ -1,0 +1,3 @@
+{
+  "note": "The complete machine-readable result is retained in GitHub Actions artifact 8635033599 for workflow run 30212921872. The committed Markdown report contains all headline target AUC, subgroup LiRA, Delta and bootstrap interval results. Shadow-level metadata is intentionally not duplicated in the repository."
+}

--- a/reports/spike/two_config_spike.md
+++ b/reports/spike/two_config_spike.md
@@ -1,0 +1,23 @@
+# Two-configuration iso-epsilon subgroup-LiRA spike
+
+Target privacy: epsilon=8.0, delta=1e-5, RDP accountant, Poisson sampling.
+Attack cohort: equal counts in every `sex x membership` cell (132 per cell; 528 total).
+Attack: offline LiRA with 12 DP shadow models per recipe.
+Headline metric: subgroup TPR at 1% FPR and max-min gap Delta.
+
+| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |
+|---|---:|---:|---:|---|---:|---:|
+| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | female | 0.5250 | 0.0076 |
+| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | male | 0.5562 | 0.0076 |
+| **small_batch_long_tight_clip Delta** |  |  |  | **max-min** |  | **0.0000** |
+| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | female | 0.4815 | 0.0076 |
+| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | male | 0.5526 | 0.0455 |
+| **large_batch_short_loose_clip Delta** |  |  |  | **max-min** |  | **0.0379** |
+
+## Readout
+
+The observed between-recipe Delta separation is 0.0379: the tight-clipping recipe had no subgroup gap at 1% FPR, while the loose-clipping recipe had a male-minus-female gap of 0.0379.
+
+This is not yet evidence for the research claim. Both target models have weak predictive utility, subgroup LiRA AUCs are near chance, and the 12-shadow ensemble left only two OUT losses for the least-covered attack examples. At 132 non-members per subgroup, TPR@1% FPR is quantised in increments of 1/132 = 0.0076; the loose-clipping result is therefore five detected male members versus one detected female member at the permitted FPR.
+
+The result supports exactly one next experiment: repeat these same two recipes across multiple target seeds with a larger shadow ensemble and bootstrap intervals. It does not justify expanding to the full multi-dataset configuration grid yet.

--- a/reports/spike/two_config_spike.md
+++ b/reports/spike/two_config_spike.md
@@ -1,23 +1,50 @@
-# Two-configuration iso-epsilon subgroup-LiRA spike
+# Powered two-configuration iso-epsilon subgroup-LiRA spike
 
-Target privacy: epsilon=8.0, delta=1e-5, RDP accountant, Poisson sampling.
-Attack cohort: equal counts in every `sex x membership` cell (132 per cell; 528 total).
-Attack: offline LiRA with 12 DP shadow models per recipe.
-Headline metric: subgroup TPR at 1% FPR and max-min gap Delta.
+Task: `high_cost`.
 
-| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |
-|---|---:|---:|---:|---|---:|---:|
-| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | female | 0.5250 | 0.0076 |
-| small_batch_long_tight_clip | 7.9937 | 1.2054 | 0.5536 | male | 0.5562 | 0.0076 |
-| **small_batch_long_tight_clip Delta** |  |  |  | **max-min** |  | **0.0000** |
-| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | female | 0.4815 | 0.0076 |
-| large_batch_short_loose_clip | 7.9999 | 1.0791 | 0.5143 | male | 0.5526 | 0.0455 |
-| **large_batch_short_loose_clip Delta** |  |  |  | **max-min** |  | **0.0379** |
+- Target privacy: epsilon = 8.0, delta = 1e-5.
+- RDP accountant with Poisson sampling.
+- Hard attack gate: target test ROC-AUC >= 0.70.
+- Three target seeds: 42, 43 and 44.
+- 32 DP shadow models per recipe and target seed.
+- Every shadow trained on exactly 856 rows, matching the target train size and calibrated noise multiplier.
+- Balanced shadow schedule: every attack example had at least 11 OUT-shadow losses.
+- Attack cohort equalised within every `sex x membership` cell.
+- Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-minus-min gap Delta.
 
-## Readout
+| Recipe | Seed | Achieved epsilon | Noise | Test AUC | Group | LiRA AUC | TPR@1% | Delta | Bootstrap 95% CI |
+|---|---:|---:|---:|---:|---|---:|---:|---:|---|
+| small_batch_long_tight_clip | 42 | 7.9937 | 1.2054 | 0.9587 | female | 0.5094 | 0.0156 | 0.0000 | [0.0000, 0.0547] |
+| small_batch_long_tight_clip | 42 | 7.9937 | 1.2054 | 0.9587 | male | 0.5301 | 0.0156 |  |  |
+| small_batch_long_tight_clip | 43 | 7.9937 | 1.2054 | 0.9147 | female | 0.5949 | 0.0000 | 0.0310 | [0.0000, 0.1010] |
+| small_batch_long_tight_clip | 43 | 7.9937 | 1.2054 | 0.9147 | male | 0.5612 | 0.0310 |  |  |
+| small_batch_long_tight_clip | 44 | 7.9937 | 1.2054 | 0.9504 | female | 0.5746 | 0.0076 | 0.0153 | [0.0000, 0.0840] |
+| small_batch_long_tight_clip | 44 | 7.9937 | 1.2054 | 0.9504 | male | 0.5177 | 0.0229 |  |  |
+| large_batch_short_loose_clip | 42 | 7.9999 | 1.0791 | 0.9255 | female | 0.5173 | 0.0000 | 0.0234 | [0.0000, 0.0703] |
+| large_batch_short_loose_clip | 42 | 7.9999 | 1.0791 | 0.9255 | male | 0.5174 | 0.0234 |  |  |
+| large_batch_short_loose_clip | 43 | 7.9999 | 1.0791 | 0.8824 | female | 0.5419 | 0.0310 | 0.0233 | [0.0000, 0.1163] |
+| large_batch_short_loose_clip | 43 | 7.9999 | 1.0791 | 0.8824 | male | 0.5312 | 0.0078 |  |  |
+| large_batch_short_loose_clip | 44 | 7.9999 | 1.0791 | 0.8872 | female | 0.5370 | 0.0000 | 0.0076 | [0.0000, 0.0458] |
+| large_batch_short_loose_clip | 44 | 7.9999 | 1.0791 | 0.8872 | male | 0.5313 | 0.0076 |  |  |
 
-The observed between-recipe Delta separation is 0.0379: the tight-clipping recipe had no subgroup gap at 1% FPR, while the loose-clipping recipe had a male-minus-female gap of 0.0379.
+## Across-seed summary
 
-This is not yet evidence for the research claim. Both target models have weak predictive utility, subgroup LiRA AUCs are near chance, and the 12-shadow ensemble left only two OUT losses for the least-covered attack examples. At 132 non-members per subgroup, TPR@1% FPR is quantised in increments of 1/132 = 0.0076; the loose-clipping result is therefore five detected male members versus one detected female member at the permitted FPR.
+| Recipe | Mean target AUC | Min target AUC | Mean Delta | Delta range |
+|---|---:|---:|---:|---|
+| small_batch_long_tight_clip | 0.9413 | 0.9147 | 0.0154 | [0.0000, 0.0310] |
+| large_batch_short_loose_clip | 0.8984 | 0.8824 | 0.0181 | [0.0076, 0.0234] |
 
-The result supports exactly one next experiment: repeat these same two recipes across multiple target seeds with a larger shadow ensemble and bootstrap intervals. It does not justify expanding to the full multi-dataset configuration grid yet.
+The between-recipe difference in mean Delta is only 0.0027. Seed-wise, the loose-minus-tight Delta differences are +0.0234, -0.0078 and -0.0076, so the direction reverses across seeds.
+
+## Honest readout
+
+This is a null result for the proposed subgroup-redistribution claim on this dataset, task, protected attribute and pair of iso-epsilon recipes.
+
+The target models learned the task well, so the null cannot be blamed on target utility. Shadow and target train sizes, sampling assumptions, privacy target and noise calibration were matched, and every example had 11 OUT observations. Nevertheless:
+
+- every bootstrap interval for Delta includes zero;
+- subgroup LiRA AUC is mostly close to chance;
+- the more exposed group is not stable across seeds; and
+- the two recipes have almost identical mean subgroup gaps despite materially different training recipes.
+
+This result does not justify launching the full multi-dataset hyperparameter grid. The next defensible experiment is an attack-power control: run the same high-cost setup with a non-private/no-noise target and a deliberately higher-capacity model. If LiRA still remains near chance, natural membership leakage is not measurable on this dataset and the research should move to a larger dataset such as MEPS or ACS rather than adding more DP configurations.

--- a/research/attack_power_control.py
+++ b/research/attack_power_control.py
@@ -16,6 +16,12 @@ and online LiRA stay near chance against a model with a clear train--test gap,
 the attack -- not DP -- is the limiting factor, and the iso-epsilon subgroup
 research needs a larger dataset.
 
+Attack statistics are tested against a stratified membership permutation null
+(labels reshuffled within each sensitive group, scores fixed) as well as being
+bracketed by stratified bootstrap intervals. The bootstrap says how precise an
+estimate is; the permutation test says whether an estimate that large happens by
+chance.
+
 Run from the repository root::
 
     python research/attack_power_control.py --shadows 32 --seeds 42 43 44
@@ -42,6 +48,7 @@ HEADLINE_FPR = 0.01
 DEFAULT_SEEDS = (42, 43, 44)
 DEFAULT_SHADOWS = 32
 DEFAULT_BOOTSTRAP_REPS = 1000
+DEFAULT_PERMUTATION_REPS = 1000
 
 #: A control must show at least this much train--test separation on one of the
 #: three memorisation probes before the attack is worth running.
@@ -52,6 +59,14 @@ MIN_GAUSSIAN_OBSERVATIONS = 10
 #: Decision-table thresholds.
 DETECT_MEAN_AUC = 0.55
 CHANCE_AUC_BAND = 0.53
+#: Significance level for the permutation tests.
+ALPHA = 0.05
+#: A verdict needs this many seeds to reject the permutation null.
+MIN_SIGNIFICANT_SEEDS = 2
+
+SUBGROUP_SUPPORTED = "SUBGROUP DISPARITY SUPPORTED"
+SUBGROUP_UNSUPPORTED = "SUBGROUP DISPARITY UNSUPPORTED"
+SUBGROUP_INCONCLUSIVE = "SUBGROUP DISPARITY INCONCLUSIVE"
 
 DETECTS = "ATTACK DETECTS LEAKAGE"
 INCONCLUSIVE = "ATTACK INCONCLUSIVE"
@@ -383,12 +398,113 @@ def stratified_bootstrap(
     return summary
 
 
+def _permutation_pvalue(observed: float, null_draws: np.ndarray, alternative: str) -> float:
+    """Empirical p-value with the finite-sample ``(1 + k) / (reps + 1)`` correction.
+
+    ``alternative`` is ``"greater"`` for one-sided tests (AUC, TPR, absolute
+    gap) and ``"two-sided"`` for the signed subgroup difference, where the null
+    draws and the observation are compared on absolute value.
+    """
+    finite = null_draws[np.isfinite(null_draws)]
+    reps = int(len(null_draws))
+    if not np.isfinite(observed) or finite.size == 0:
+        return float("nan")
+    if alternative == "two-sided":
+        extreme = int(np.sum(np.abs(finite) >= abs(observed)))
+    else:
+        extreme = int(np.sum(finite >= observed))
+    return float((1 + extreme) / (reps + 1))
+
+
+def stratified_membership_permutation_test(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    scores: np.ndarray,
+    target_fpr: float = HEADLINE_FPR,
+    reps: int = DEFAULT_PERMUTATION_REPS,
+    seed: int = 0,
+) -> dict[str, dict[str, float | str]]:
+    """Permutation null for the attack statistics, stratified by sensitive group.
+
+    Each replicate reshuffles the membership labels *within* each sensitive
+    group, so every group keeps its exact member/non-member counts while the
+    scores stay fixed. That destroys any association between score and
+    membership but preserves the cohort geometry, the class balance and the
+    discreteness of the operating point -- which is what a bootstrap interval
+    alone cannot tell you. The bootstrap says how precise the estimate is; this
+    says whether an estimate that size happens by chance.
+
+    Returns:
+        One entry per statistic (``aggregate_auc``, ``aggregate_tpr``, each
+        group's TPR, ``signed_difference`` and ``absolute_gap``) holding the
+        observed value, the permutation-null mean and 95% interval, and the
+        empirical p-value.
+    """
+    groups = np.asarray(groups).astype(str)
+    membership = np.asarray(membership)
+    scores = np.asarray(scores, dtype=float)
+    unique_groups = sorted(np.unique(groups))
+    group_idx = {group: np.flatnonzero(groups == group) for group in unique_groups}
+    for group, idx in group_idx.items():
+        if np.unique(membership[idx]).size < 2:
+            raise RuntimeError(f"permutation test needs both classes in group {group!r}")
+
+    def statistics(labels: np.ndarray) -> dict[str, float]:
+        group_tprs = {
+            group: tpr_at_fpr(labels[idx], scores[idx], target_fpr)
+            for group, idx in group_idx.items()
+        }
+        values = {
+            "aggregate_auc": float(roc_auc_score(labels, scores)),
+            "aggregate_tpr": tpr_at_fpr(labels, scores, target_fpr),
+            "signed_difference": signed_subgroup_difference(group_tprs),
+            "absolute_gap": absolute_subgroup_gap(group_tprs),
+        }
+        values.update(group_tprs)
+        return values
+
+    observed = statistics(membership)
+    rng = np.random.default_rng(seed)
+    null_draws: dict[str, list[float]] = {key: [] for key in observed}
+
+    for _ in range(reps):
+        permuted = membership.copy()
+        for idx in group_idx.values():
+            # Shuffling within the group's own labels preserves its exact
+            # member and non-member counts.
+            permuted[idx] = rng.permutation(membership[idx])
+        for key, value in statistics(permuted).items():
+            null_draws[key].append(value)
+
+    alternatives = {"signed_difference": "two-sided"}
+    summary: dict[str, dict[str, float | str]] = {}
+    for key, value in observed.items():
+        draws = np.asarray(null_draws[key], dtype=float)
+        finite = draws[np.isfinite(draws)]
+        low, high = (
+            np.percentile(finite, [2.5, 97.5]) if finite.size else (float("nan"),) * 2
+        )
+        summary[key] = {
+            "reps": int(reps),
+            "observed": float(value),
+            "null_mean": float(finite.mean()) if finite.size else float("nan"),
+            "null_ci95_low": float(low),
+            "null_ci95_high": float(high),
+            "alternative": alternatives.get(key, "greater"),
+            "p_value": _permutation_pvalue(
+                value, draws, alternatives.get(key, "greater")
+            ),
+        }
+    return summary
+
+
 def attack_metrics(
     membership: np.ndarray,
     groups: np.ndarray,
     scores: np.ndarray,
     bootstrap_reps: int,
     seed: int,
+    permutation_reps: int = DEFAULT_PERMUTATION_REPS,
 ) -> dict[str, object]:
     """Aggregate and subgroup metrics for one score vector."""
     membership = np.asarray(membership)
@@ -430,6 +546,9 @@ def attack_metrics(
         "bootstrap": stratified_bootstrap(
             groups, membership, scores, HEADLINE_FPR, bootstrap_reps, seed
         ),
+        "permutation": stratified_membership_permutation_test(
+            groups, membership, scores, HEADLINE_FPR, permutation_reps, seed + 1
+        ),
     }
 
 
@@ -456,30 +575,119 @@ def classify_control(
         [float(r["offline"]["bootstrap"]["aggregate"]["ci95_low"]) for r in completed],
         dtype=float,
     )
-    # Random-guessing baseline at a 1% FPR operating point is a 1% TPR.
-    above_baseline = ci_lows > HEADLINE_FPR
+    auc_p = np.asarray(
+        [float(r["offline"]["permutation"]["aggregate_auc"]["p_value"]) for r in completed],
+        dtype=float,
+    )
+    tpr_p = np.asarray(
+        [float(r["offline"]["permutation"]["aggregate_tpr"]["p_value"]) for r in completed],
+        dtype=float,
+    )
     mean_auc = float(np.nanmean(aucs))
+    # Random-guessing baseline at a 1% FPR operating point is a 1% TPR.
+    above_baseline = int(np.sum(ci_lows > HEADLINE_FPR))
+    significant = int(np.sum((auc_p < ALPHA) | (tpr_p < ALPHA)))
+    consistent_direction = bool(np.all(aucs > 0.5))
 
-    if mean_auc >= DETECT_MEAN_AUC and bool(np.all(aucs > 0.5)) and bool(above_baseline.any()):
+    if (
+        all(gate_passed)
+        and mean_auc >= DETECT_MEAN_AUC
+        and significant >= MIN_SIGNIFICANT_SEEDS
+        and consistent_direction
+    ):
         return (
             DETECTS,
-            f"Mean aggregate offline-LiRA AUC {mean_auc:.4f} above chance on every seed, "
-            f"with {int(above_baseline.sum())}/{len(completed)} seeds whose bootstrap "
-            "TPR@1% FPR interval sits above the 1% random baseline.",
+            f"Mean aggregate offline-LiRA AUC {mean_auc:.4f}, above chance on every seed; "
+            f"the stratified membership permutation null is rejected at p<{ALPHA} on "
+            f"{significant}/{len(completed)} seeds "
+            f"({above_baseline}/{len(completed)} bootstrap TPR@1% intervals also clear the "
+            "1% random baseline).",
         )
 
-    if control.positive_control and all(gate_passed) and mean_auc < CHANCE_AUC_BAND:
+    if (
+        control.positive_control
+        and all(gate_passed)
+        and mean_auc < CHANCE_AUC_BAND
+        and significant < MIN_SIGNIFICANT_SEEDS
+    ):
         return (
             FAILS_POSITIVE_CONTROL,
             f"Every seed shows a clear train-test gap, yet mean aggregate LiRA AUC is "
-            f"{mean_auc:.4f} -- statistically indistinguishable from chance.",
+            f"{mean_auc:.4f} and the permutation null survives on "
+            f"{len(completed) - significant}/{len(completed)} seeds.",
         )
 
     return (
         INCONCLUSIVE,
-        f"Mean aggregate LiRA AUC {mean_auc:.4f} with unstable or baseline-overlapping "
-        "bootstrap intervals across seeds.",
+        f"Mean aggregate LiRA AUC {mean_auc:.4f} with the permutation null rejected on "
+        f"only {significant}/{len(completed)} seeds.",
     )
+
+
+def assess_subgroup_disparity(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
+    """Judge subgroup TPR disparity separately from aggregate attack power.
+
+    Aggregate leakage says nothing about whether one sex leaks more than the
+    other, so this never inherits the aggregate verdict. Disparity is called
+    supported only when the signed direction is stable across seeds, the
+    permutation null is rejected on enough seeds, and the bootstrap interval is
+    not simply the discrete operating-point resolution.
+    """
+    completed = [r for r in seed_results if r["attack_status"] == "completed"]
+    if not completed:
+        return SUBGROUP_INCONCLUSIVE, "No attack completed, so no subgroup comparison exists."
+
+    signed = np.asarray(
+        [float(r["offline"]["signed_subgroup_difference"]) for r in completed], dtype=float
+    )
+    signed_p = np.asarray(
+        [
+            float(r["offline"]["permutation"]["signed_difference"]["p_value"])
+            for r in completed
+        ],
+        dtype=float,
+    )
+    gap_p = np.asarray(
+        [float(r["offline"]["permutation"]["absolute_gap"]["p_value"]) for r in completed],
+        dtype=float,
+    )
+    significant = int(np.sum((signed_p < ALPHA) | (gap_p < ALPHA)))
+    nonzero = signed[signed != 0.0]
+    stable_direction = bool(nonzero.size and np.all(np.sign(nonzero) == np.sign(nonzero[0])))
+
+    # One extra member at the 1% FPR operating point moves a subgroup TPR by
+    # 1/n_members. A "gap" smaller than that is resolution, not disparity.
+    resolutions = [
+        1.0 / max(int(r["offline"]["subgroups"][group]["members"]), 1)
+        for r in completed
+        for group in r["offline"]["subgroups"]
+    ]
+    resolution = float(max(resolutions)) if resolutions else float("inf")
+    resolvable = bool(np.all(np.abs(signed) >= resolution) and signed.size)
+
+    if significant >= MIN_SIGNIFICANT_SEEDS and stable_direction and resolvable:
+        direction = "male" if np.mean(signed) > 0 else "female"
+        return (
+            SUBGROUP_SUPPORTED,
+            f"Signed male-female TPR@1% difference keeps the same sign on every seed "
+            f"({direction} more exposed), permutation p<{ALPHA} on "
+            f"{significant}/{len(completed)} seeds, and the effect exceeds the "
+            f"{resolution:.4f} operating-point resolution.",
+        )
+
+    reasons = []
+    if not stable_direction:
+        reasons.append("the signed direction is not stable across seeds")
+    if significant < MIN_SIGNIFICANT_SEEDS:
+        reasons.append(
+            f"the permutation null is rejected on only {significant}/{len(completed)} seeds"
+        )
+    if not resolvable:
+        reasons.append(
+            f"at least one gap is within the {resolution:.4f} discrete operating-point "
+            "resolution"
+        )
+    return SUBGROUP_UNSUPPORTED, "; ".join(reasons).capitalize() + "."
 
 
 # --------------------------------------------------------------------------- #
@@ -629,6 +837,7 @@ def run_control_seed(
     data_arrays: dict[str, np.ndarray],
     num_shadows: int,
     bootstrap_reps: int,
+    permutation_reps: int,
     seed: int,
     log,
 ) -> dict[str, object]:
@@ -730,6 +939,7 @@ def run_control_seed(
                 offline.scores,
                 bootstrap_reps,
                 seed + 20_000,
+                permutation_reps,
             ),
         }
     )
@@ -749,6 +959,7 @@ def run_control_seed(
             online.scores,
             bootstrap_reps,
             seed + 30_000,
+            permutation_reps,
         )
     else:
         result["online_unavailable_reason"] = (
@@ -793,6 +1004,7 @@ def build_rows(payload: dict[str, object]) -> list[dict[str, object]]:
                 continue
             aggregate = metrics["aggregate"]
             bootstrap = metrics["bootstrap"]
+            permutation = metrics["permutation"]
             row: dict[str, object] = {
                 "control": result["control"],
                 "seed": result["seed"],
@@ -821,6 +1033,24 @@ def build_rows(payload: dict[str, object]) -> list[dict[str, object]]:
                 ],
                 "aggregate_tpr_ci_low": bootstrap["aggregate"]["ci95_low"],
                 "aggregate_tpr_ci_high": bootstrap["aggregate"]["ci95_high"],
+                "permutation_p_aggregate_auc": permutation["aggregate_auc"]["p_value"],
+                "permutation_p_aggregate_tpr": permutation["aggregate_tpr"]["p_value"],
+                "permutation_null_auc_mean": permutation["aggregate_auc"]["null_mean"],
+                "permutation_null_auc_ci_low": permutation["aggregate_auc"]["null_ci95_low"],
+                "permutation_null_auc_ci_high": permutation["aggregate_auc"]["null_ci95_high"],
+                "permutation_null_tpr_mean": permutation["aggregate_tpr"]["null_mean"],
+                "permutation_null_tpr_ci_low": permutation["aggregate_tpr"]["null_ci95_low"],
+                "permutation_null_tpr_ci_high": permutation["aggregate_tpr"]["null_ci95_high"],
+                "permutation_p_signed_difference": permutation["signed_difference"]["p_value"],
+                "permutation_p_absolute_gap": permutation["absolute_gap"]["p_value"],
+                "permutation_null_signed_ci_low": permutation["signed_difference"][
+                    "null_ci95_low"
+                ],
+                "permutation_null_signed_ci_high": permutation["signed_difference"][
+                    "null_ci95_high"
+                ],
+                "permutation_null_gap_ci_low": permutation["absolute_gap"]["null_ci95_low"],
+                "permutation_null_gap_ci_high": permutation["absolute_gap"]["null_ci95_high"],
                 "signed_subgroup_difference": metrics["signed_subgroup_difference"],
                 "absolute_subgroup_gap": metrics["absolute_subgroup_gap"],
                 "signed_difference_ci_low": bootstrap["signed_difference"]["ci95_low"],
@@ -833,6 +1063,7 @@ def build_rows(payload: dict[str, object]) -> list[dict[str, object]]:
                 row[f"{group}_tpr_at_fpr_0.01"] = group_metrics["tpr_at_fpr_0.01"]
                 row[f"{group}_tpr_ci_low"] = bootstrap[group]["ci95_low"]
                 row[f"{group}_tpr_ci_high"] = bootstrap[group]["ci95_high"]
+                row[f"{group}_permutation_p"] = permutation[group]["p_value"]
             rows.append(row)
 
         if not result.get("offline"):
@@ -876,6 +1107,11 @@ def render_markdown(payload: dict[str, object]) -> str:
         "(balanced fixed-size schedule, training size pinned to the target's).",
         f"Bootstrap replicates: {payload['bootstrap_reps']}, resampled within each "
         "`sex x membership` cell.",
+        f"Permutation replicates: "
+        f"{payload.get('permutation_reps', DEFAULT_PERMUTATION_REPS)}, with membership "
+        "labels reshuffled within each sensitive group. Bootstrap intervals are kept, "
+        "but they are not used as the hypothesis test against chance; the permutation "
+        "null is.",
         (
             f"Memorisation gate: the attack runs only when train-test ROC-AUC, "
             f"test-train loss or train-test accuracy differs by at least "
@@ -1040,23 +1276,163 @@ def render_markdown(payload: dict[str, object]) -> str:
 
     lines += [
         "",
-        "## 8. Decision table",
+        "## 8. Stratified permutation tests against the membership null",
+        "",
+        (
+            f"Membership labels are reshuffled within each sensitive group "
+            f"({payload.get('permutation_reps', DEFAULT_PERMUTATION_REPS)} replicates), "
+            "preserving each group's exact member and non-member counts while the "
+            "attack scores stay fixed. Bootstrap intervals above describe the "
+            "precision of an estimate; these p-values ask whether an estimate that "
+            "large arises from finite-sample ROC variation alone. AUC, TPR and the "
+            "absolute gap use one-sided tests; the signed difference is two-sided on "
+            f"absolute value. All p-values use the (1+k)/(reps+1) correction, so the "
+            "smallest attainable value is "
+            f"{1.0 / (int(payload.get('permutation_reps', DEFAULT_PERMUTATION_REPS)) + 1):.4f}."
+        ),
+        "",
+        "| Control | Seed | Attack | AUC (p) | Null AUC 95% | TPR@1% (p) | Null TPR 95% | "
+        "Signed diff (p, two-sided) | Null signed 95% | Absolute gap (p) | Null gap 95% |",
+        "|---|---:|---|---|---|---|---|---|---|---|---|",
+    ]
+    for result in seed_results:
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                continue
+            perm = metrics["permutation"]
+
+            def cell(key: str) -> str:
+                entry = perm[key]
+                return f"{_fmt(entry['observed'])} (p={_fmt(entry['p_value'], 4)})"
+
+            def null_ci(key: str) -> str:
+                entry = perm[key]
+                return f"[{_fmt(entry['null_ci95_low'])}, {_fmt(entry['null_ci95_high'])}]"
+
+            lines.append(
+                f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                f"{cell('aggregate_auc')} | {null_ci('aggregate_auc')} | "
+                f"{cell('aggregate_tpr')} | {null_ci('aggregate_tpr')} | "
+                f"{cell('signed_difference')} | {null_ci('signed_difference')} | "
+                f"{cell('absolute_gap')} | {null_ci('absolute_gap')} |"
+            )
+    if not any(result.get("offline") for result in seed_results):
+        lines.append("| - | - | - | - | - | - | - | - | - | - | - |")
+
+    lines += [
+        "",
+        "Per-subgroup TPR@1% permutation p-values:",
+        "",
+        "| Control | Seed | Attack | Female TPR@1% (p) | Male TPR@1% (p) |",
+        "|---|---:|---|---|---|",
+    ]
+    for result in seed_results:
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                continue
+            perm = metrics["permutation"]
+
+            def group_cell(name: str) -> str:
+                for candidate, entry in perm.items():
+                    if candidate.lower() == name:
+                        return f"{_fmt(entry['observed'])} (p={_fmt(entry['p_value'], 4)})"
+                return "-"
+
+            lines.append(
+                f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                f"{group_cell('female')} | {group_cell('male')} |"
+            )
+    if not any(result.get("offline") for result in seed_results):
+        lines.append("| - | - | - | - | - |")
+
+    lines += [
+        "",
+        "## 9. Decision table",
         "",
         "| Control | Positive control | Seeds attacked | Mean memorisation gap (AUC) | "
-        "Mean offline LiRA AUC | Verdict | Basis |",
-        "|---|---|---:|---:|---:|---|---|",
+        "Mean offline LiRA AUC | Mean permutation p (AUC) | Verdict | Basis |",
+        "|---|---|---:|---:|---:|---:|---|---|",
     ]
     for decision in payload["decisions"]:
         lines.append(
             f"| {decision['control']} | {'yes' if decision['positive_control'] else 'no'} | "
             f"{decision['seeds_attacked']} | {_fmt(decision['mean_auc_gap'])} | "
-            f"{_fmt(decision['mean_lira_auc'])} | **{decision['verdict']}** | "
-            f"{decision['basis']} |"
+            f"{_fmt(decision['mean_lira_auc'])} | "
+            f"{_fmt(decision.get('mean_permutation_p_auc'))} | "
+            f"**{decision['verdict']}** | {decision['basis']} |"
         )
 
-    lines += ["", "## Conclusion", ""]
+    lines += [
+        "",
+        "Subgroup disparity is judged separately; an aggregate detection is never "
+        "carried over into a disparity claim.",
+        "",
+        "| Control | Subgroup verdict | Basis |",
+        "|---|---|---|",
+    ]
+    for decision in payload["decisions"]:
+        lines.append(
+            f"| {decision['control']} | **{decision.get('subgroup_verdict', SUBGROUP_INCONCLUSIVE)}** "
+            f"| {decision.get('subgroup_basis', '-')} |"
+        )
+
     failed = [d for d in payload["decisions"] if d["verdict"] == FAILS_POSITIVE_CONTROL]
     detected = [d for d in payload["decisions"] if d["verdict"] == DETECTS]
+    supported = [
+        d for d in payload["decisions"] if d.get("subgroup_verdict") == SUBGROUP_SUPPORTED
+    ]
+
+    lines += [
+        "",
+        "## Conclusions",
+        "",
+        "These three questions are answered separately. Aggregate attack success is "
+        "not evidence of subgroup disparity, and neither is evidence about the DP "
+        "results on its own.",
+        "",
+        "### 1. Is aggregate membership leakage detectable?",
+        "",
+    ]
+    if detected:
+        names = ", ".join(d["control"] for d in detected)
+        lines.append(
+            f"Yes, on: {names}. Mean aggregate LiRA AUC clears {DETECT_MEAN_AUC} with the "
+            f"stratified membership permutation null rejected at p<{ALPHA} on at least "
+            f"{MIN_SIGNIFICANT_SEEDS} of the target seeds, in a consistent direction."
+        )
+    elif failed:
+        lines.append(
+            "No. Every positive control memorised -- a clear train-test gap on all "
+            "seeds -- yet aggregate LiRA stayed near chance and the permutation null "
+            "was not rejected consistently."
+        )
+    else:
+        lines.append(
+            "Not established. No control produced both an above-chance mean AUC and "
+            "consistent rejection of the permutation null."
+        )
+
+    lines += ["", "### 2. Does subgroup leakage differ by sex?", ""]
+    if supported:
+        names = ", ".join(d["control"] for d in supported)
+        lines.append(
+            f"Supported on: {names} -- stable signed direction across seeds, "
+            f"permutation p<{ALPHA} on at least {MIN_SIGNIFICANT_SEEDS} seeds, and an "
+            "effect larger than the discrete operating-point resolution."
+        )
+    else:
+        lines.append(
+            "Not supported. No control satisfies all three requirements (stable signed "
+            "direction across seeds, permutation rejection on at least "
+            f"{MIN_SIGNIFICANT_SEEDS} seeds, and a gap exceeding the operating-point "
+            "resolution). Where an aggregate attack does succeed, that success is "
+            "reported as aggregate leakage only."
+        )
+
+    lines += ["", "### 3. Is the insurance dataset still suitable for the iso-epsilon "
+              "subgroup research question?", ""]
     if failed and not detected:
         lines += [
             "**Natural membership leakage is not reliably measurable with the current "
@@ -1069,22 +1445,32 @@ def render_markdown(payload: dict[str, object]) -> str:
             "attributed to differential privacy, because the same pipeline fails "
             "against an unprotected, demonstrably memorising target.",
         ]
-    elif detected:
-        names = ", ".join(d["control"] for d in detected)
+    elif detected and not supported:
         lines += [
-            f"The pipeline detects membership leakage on: {names}. The attack "
-            "implementation therefore has measurable power on this dataset, and the "
-            "null DP result is evidence about the DP-SGD configurations rather than "
-            "about the attack.",
+            "Partially. The pipeline has measurable aggregate attack power at "
+            "non-private capacity, so the powered spike's null is informative about "
+            "the DP-SGD configurations rather than about a dead attack. But the "
+            "subgroup contrast -- the actual research question -- is not resolvable "
+            "here: subgroup TPR@1% FPR moves in units of one member, so the cohort is "
+            "too small to separate a real disparity from operating-point resolution.",
             "",
-            "Go/no-go: **GO** -- the insurance dataset supports membership auditing "
-            "at non-private capacity, so subgroup DP work here remains interpretable.",
+            "Go/no-go: **CONDITIONAL GO** -- aggregate auditing on the insurance "
+            "dataset is sound, but the iso-epsilon *subgroup* comparison needs a "
+            "larger dataset to reach usable resolution.",
+        ]
+    elif detected and supported:
+        lines += [
+            "Yes. The pipeline detects aggregate leakage and a stable subgroup "
+            "disparity at non-private capacity, so the dataset can in principle "
+            "support the iso-epsilon subgroup comparison.",
+            "",
+            "Go/no-go: **GO** -- subgroup DP work on this dataset remains "
+            "interpretable.",
         ]
     else:
         lines += [
-            "No control produced a stable above-chance attack, and no positive "
-            "control both memorised and stayed at chance, so the experiment is "
-            "inconclusive.",
+            "Undetermined. No positive control both memorised and stayed at chance, "
+            "and no control produced a stable above-chance attack.",
             "",
             "Go/no-go: **HOLD** -- re-run with more shadows or a stronger memorising "
             "target before drawing conclusions about the insurance dataset.",
@@ -1093,7 +1479,8 @@ def render_markdown(payload: dict[str, object]) -> str:
     lines += [
         "",
         "Attack AUC near 0.5 is reported here as a failure of attack power, not as "
-        "evidence of privacy, and no claim of subgroup privacy variance is made.",
+        "evidence of privacy. No claim of subgroup privacy variance is made unless "
+        "section 2 above explicitly supports it.",
     ]
     return "\n".join(lines) + "\n"
 
@@ -1108,6 +1495,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--shadows", type=int, default=DEFAULT_SHADOWS)
     parser.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
     parser.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
+    parser.add_argument("--permutation-reps", type=int, default=DEFAULT_PERMUTATION_REPS)
     parser.add_argument("--output-dir", default="reports/attack_power_control")
     parser.add_argument(
         "--controls",
@@ -1123,6 +1511,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         raise ValueError("Use at least three target seeds.")
     if args.bootstrap_reps < 200:
         raise ValueError("Use at least 200 bootstrap replicates.")
+    if args.permutation_reps < 200:
+        raise ValueError("Use at least 200 permutation replicates.")
 
     from dp.pipeline import build_preprocessor
     from dp.tasks import get_task, prepare_task_data
@@ -1155,6 +1545,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         "seeds": [int(seed) for seed in args.seeds],
         "num_shadows": int(args.shadows),
         "bootstrap_reps": int(args.bootstrap_reps),
+        "permutation_reps": int(args.permutation_reps),
+        "alpha": ALPHA,
         "memorisation_gate": MEMORISATION_GATE,
         "controls": [
             {**asdict(control), "architecture": control.architecture()}
@@ -1187,6 +1579,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 arrays,
                 num_shadows=args.shadows,
                 bootstrap_reps=args.bootstrap_reps,
+                permutation_reps=args.permutation_reps,
                 seed=seed,
                 log=log,
             )
@@ -1194,6 +1587,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             payload["seed_results"].append(result)
 
         verdict, basis = classify_control(control, control_results)
+        subgroup_verdict, subgroup_basis = assess_subgroup_disparity(control_results)
         completed = [r for r in control_results if r["attack_status"] == "completed"]
         payload["decisions"].append(
             {
@@ -1208,11 +1602,26 @@ def main(argv: Sequence[str] | None = None) -> None:
                     if completed
                     else None
                 ),
+                "mean_permutation_p_auc": (
+                    float(
+                        np.mean(
+                            [
+                                r["offline"]["permutation"]["aggregate_auc"]["p_value"]
+                                for r in completed
+                            ]
+                        )
+                    )
+                    if completed
+                    else None
+                ),
                 "verdict": verdict,
                 "basis": basis,
+                "subgroup_verdict": subgroup_verdict,
+                "subgroup_basis": subgroup_basis,
             }
         )
         log(f"[{control.name}] verdict: {verdict} -- {basis}")
+        log(f"[{control.name}] subgroup: {subgroup_verdict} -- {subgroup_basis}")
 
     json_path = output_dir / "attack_power_control.json"
     csv_path = output_dir / "attack_power_control.csv"

--- a/research/attack_power_control.py
+++ b/research/attack_power_control.py
@@ -1,0 +1,1232 @@
+"""Attack-power control experiment for the insurance ``high_cost`` task.
+
+The powered two-configuration DP spike (``research/two_config_spike.py``)
+returned a null result: subgroup LiRA was near chance under every DP-SGD
+recipe. That is only informative if the attack pipeline can detect membership
+leakage *at all* on this dataset. This script is the control experiment:
+
+* **Control A** -- a non-private MLP matching the DP target architecture.
+* **Control B** -- a deliberately over-parameterised, long-trained MLP with no
+  regularisation, meant to memorise.
+* **Control C** -- an unconstrained decision tree, the classic positive control.
+
+Nothing here is differentially private. There is no Opacus, no clipping and no
+noise: the point is to give the attack the easiest possible target. If offline
+and online LiRA stay near chance against a model with a clear train--test gap,
+the attack -- not DP -- is the limiting factor, and the iso-epsilon subgroup
+research needs a larger dataset.
+
+Run from the repository root::
+
+    python research/attack_power_control.py --shadows 32 --seeds 42 43 44
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import accuracy_score, roc_auc_score, roc_curve
+from sklearn.tree import DecisionTreeClassifier
+
+TASK_NAME = "high_cost"
+SENSITIVE_ATTRIBUTE = "sex"
+ATTACK_FPRS = (0.001, 0.01, 0.1)
+HEADLINE_FPR = 0.01
+DEFAULT_SEEDS = (42, 43, 44)
+DEFAULT_SHADOWS = 32
+DEFAULT_BOOTSTRAP_REPS = 1000
+
+#: A control must show at least this much train--test separation on one of the
+#: three memorisation probes before the attack is worth running.
+MEMORISATION_GATE = 0.03
+#: LiRA needs a usable Gaussian fit; never fit one from fewer observations.
+MIN_GAUSSIAN_OBSERVATIONS = 10
+
+#: Decision-table thresholds.
+DETECT_MEAN_AUC = 0.55
+CHANCE_AUC_BAND = 0.53
+
+DETECTS = "ATTACK DETECTS LEAKAGE"
+INCONCLUSIVE = "ATTACK INCONCLUSIVE"
+FAILS_POSITIVE_CONTROL = "ATTACK FAILS POSITIVE CONTROL"
+
+
+@dataclass(frozen=True)
+class Control:
+    """One non-private control model definition.
+
+    ``positive_control`` marks the models that are *supposed* to memorise; only
+    those can produce an ``ATTACK FAILS POSITIVE CONTROL`` verdict.
+    """
+
+    name: str
+    kind: str  # "mlp" or "tree"
+    description: str
+    positive_control: bool = False
+    hidden_units: tuple[int, ...] = ()
+    epochs: int = 0
+    batch_size: int = 0
+    learning_rate: float = 1e-2
+    tree_kwargs: dict[str, object] = field(default_factory=dict)
+
+    def architecture(self) -> str:
+        if self.kind == "tree":
+            params = ", ".join(f"{k}={v}" for k, v in sorted(self.tree_kwargs.items()))
+            return f"DecisionTreeClassifier({params or 'unconstrained'})"
+        layers = " -> ".join(str(units) for units in self.hidden_units)
+        return f"Linear(input_dim, {layers} -> 1) with ReLU between layers"
+
+
+CONTROLS = (
+    Control(
+        name="matched_capacity_mlp",
+        kind="mlp",
+        description=(
+            "Non-private MLP with the same architecture, optimiser family, "
+            "learning rate and epoch count as the DP-SGD target recipe."
+        ),
+        hidden_units=(32,),
+        epochs=30,
+        batch_size=64,
+        learning_rate=1e-2,
+    ),
+    Control(
+        name="memorising_mlp",
+        kind="mlp",
+        description=(
+            "Deliberately over-parameterised MLP trained far longer than needed, "
+            "with no dropout, weight decay or early stopping."
+        ),
+        positive_control=True,
+        hidden_units=(128, 128, 64),
+        epochs=400,
+        batch_size=64,
+        learning_rate=1e-3,
+    ),
+    Control(
+        name="unbounded_decision_tree",
+        kind="tree",
+        description=(
+            "Unconstrained decision tree grown to purity; the strongest "
+            "memorising positive control available in this repository."
+        ),
+        positive_control=True,
+        tree_kwargs={"max_depth": None, "min_samples_leaf": 1, "min_samples_split": 2},
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch import needed, so the tests stay cheap)
+# --------------------------------------------------------------------------- #
+
+
+def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    """Numerically stable per-example binary cross-entropy."""
+    prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
+    y_true = np.asarray(y_true, dtype=float)
+    return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+
+def make_equalised_attack_cohort(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    seed: int,
+) -> tuple[np.ndarray, dict[str, int]]:
+    """Equalise every ``group x membership`` cell to the smallest cell size.
+
+    Same construction as the powered DP spike, so cohort sizes stay comparable
+    between the two experiments.
+    """
+    rng = np.random.default_rng(seed)
+    string_groups = groups.astype(str)
+    unique_groups = sorted(str(value) for value in np.unique(string_groups))
+    cells: dict[tuple[str, int], np.ndarray] = {}
+    for group in unique_groups:
+        for member in (0, 1):
+            idx = np.flatnonzero((string_groups == group) & (membership == member))
+            if idx.size == 0:
+                raise RuntimeError(f"empty attack cell group={group!r}, membership={member}")
+            cells[(group, member)] = idx
+
+    per_cell = min(len(idx) for idx in cells.values())
+    selected: list[int] = []
+    counts: dict[str, int] = {}
+    for (group, member), idx in cells.items():
+        chosen = rng.choice(idx, size=per_cell, replace=False)
+        selected.extend(chosen.tolist())
+        counts[f"{group}|member={member}"] = int(per_cell)
+
+    return np.asarray(sorted(selected), dtype=int), counts
+
+
+def balanced_shadow_train_sets(
+    y_pool: np.ndarray,
+    train_size: int,
+    num_shadows: int,
+    seed: int,
+) -> tuple[list[np.ndarray], np.ndarray]:
+    """Exact-size shadow training sets with near-uniform IN/OUT coverage.
+
+    Ported from ``research/powered_spike_runner.py``: a cyclic sliding window
+    over a random permutation excludes each pool row a near-equal number of
+    times, so every audited example collects a similar number of IN and OUT
+    shadow observations while the training size stays pinned to the target's.
+
+    Returns:
+        The per-shadow training indices and, per pool row, how often it was
+        excluded (its OUT count).
+    """
+    n = len(y_pool)
+    if train_size >= n:
+        raise ValueError("shadow train_size must be smaller than the shadow pool")
+    if num_shadows < 2:
+        raise ValueError("num_shadows must be at least two")
+
+    exclude_size = n - train_size
+    rng = np.random.default_rng(seed)
+    permutation = rng.permutation(n)
+    excluded_counts = np.zeros(n, dtype=int)
+    train_sets: list[np.ndarray] = []
+
+    for shadow_id in range(num_shadows):
+        start = (shadow_id * n) // num_shadows
+        positions = (start + np.arange(exclude_size)) % n
+        excluded_idx = permutation[positions]
+        excluded_counts[excluded_idx] += 1
+
+        in_mask = np.ones(n, dtype=bool)
+        in_mask[excluded_idx] = False
+        train_idx = np.flatnonzero(in_mask)
+        if len(train_idx) != train_size:
+            raise AssertionError("balanced schedule changed shadow train size")
+        if np.unique(y_pool[train_idx]).size != 2:
+            raise RuntimeError("balanced schedule produced a one-class shadow set")
+        train_sets.append(train_idx)
+
+    return train_sets, excluded_counts
+
+
+def memorisation_metrics(
+    y_train: np.ndarray,
+    train_prob: np.ndarray,
+    y_test: np.ndarray,
+    test_prob: np.ndarray,
+) -> dict[str, float]:
+    """Utility and memorisation probes for one target model."""
+    train_loss = float(per_example_bce(y_train, train_prob).mean())
+    test_loss = float(per_example_bce(y_test, test_prob).mean())
+    train_auc = float(roc_auc_score(y_train, train_prob))
+    test_auc = float(roc_auc_score(y_test, test_prob))
+    train_acc = float(accuracy_score(y_train, (np.asarray(train_prob) >= 0.5).astype(int)))
+    test_acc = float(accuracy_score(y_test, (np.asarray(test_prob) >= 0.5).astype(int)))
+    return {
+        "train_auc": train_auc,
+        "test_auc": test_auc,
+        "train_loss": train_loss,
+        "test_loss": test_loss,
+        "train_accuracy": train_acc,
+        "test_accuracy": test_acc,
+        "auc_gap": train_auc - test_auc,
+        "loss_gap": test_loss - train_loss,
+        "accuracy_gap": train_acc - test_acc,
+    }
+
+
+def memorisation_gate_passed(metrics: dict[str, float], gate: float = MEMORISATION_GATE) -> bool:
+    """True when any of the three memorisation probes clears ``gate``.
+
+    Deliberately *not* the old ROC-AUC >= 0.70 utility gate: a model can
+    generalise well and still be a useless membership-inference target.
+    """
+    return (
+        metrics["auc_gap"] >= gate
+        or metrics["loss_gap"] >= gate
+        or metrics["accuracy_gap"] >= gate
+    )
+
+
+def tpr_at_fpr(membership: np.ndarray, scores: np.ndarray, target_fpr: float) -> float:
+    """Highest TPR attainable without exceeding ``target_fpr``."""
+    membership = np.asarray(membership)
+    if np.unique(membership).size < 2:
+        return float("nan")
+    fpr, tpr, _ = roc_curve(membership, scores)
+    allowed = fpr <= target_fpr
+    return float(tpr[allowed].max()) if allowed.any() else 0.0
+
+
+def operating_point_counts(
+    membership: np.ndarray,
+    scores: np.ndarray,
+    target_fpr: float,
+) -> dict[str, int | float]:
+    """Detected members and false positives at the selected FPR threshold."""
+    membership = np.asarray(membership)
+    fpr, tpr, thresholds = roc_curve(membership, scores)
+    allowed = np.flatnonzero(fpr <= target_fpr)
+    n_members = int((membership == 1).sum())
+    n_nonmembers = int((membership == 0).sum())
+    if allowed.size == 0:
+        return {
+            "threshold": float("nan"),
+            "detected_members": 0,
+            "false_positives": 0,
+            "n_members": n_members,
+            "n_nonmembers": n_nonmembers,
+        }
+    best = allowed[int(np.argmax(tpr[allowed]))]
+    return {
+        "threshold": float(thresholds[best]),
+        "detected_members": int(round(tpr[best] * n_members)),
+        "false_positives": int(round(fpr[best] * n_nonmembers)),
+        "n_members": n_members,
+        "n_nonmembers": n_nonmembers,
+    }
+
+
+def signed_subgroup_difference(group_tprs: dict[str, float]) -> float:
+    """``male_tpr - female_tpr`` at the headline operating point."""
+    keys = {key.lower(): key for key in group_tprs}
+    if "male" in keys and "female" in keys:
+        return float(group_tprs[keys["male"]] - group_tprs[keys["female"]])
+    ordered = sorted(group_tprs)
+    if len(ordered) != 2:
+        return float("nan")
+    return float(group_tprs[ordered[1]] - group_tprs[ordered[0]])
+
+
+def absolute_subgroup_gap(group_tprs: dict[str, float]) -> float:
+    """``max_group_tpr - min_group_tpr``."""
+    values = list(group_tprs.values())
+    if not values:
+        return float("nan")
+    return float(max(values) - min(values))
+
+
+def stratified_bootstrap(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    scores: np.ndarray,
+    target_fpr: float = HEADLINE_FPR,
+    reps: int = DEFAULT_BOOTSTRAP_REPS,
+    seed: int = 0,
+) -> dict[str, dict[str, float]]:
+    """Bootstrap the headline attack statistics within each cell.
+
+    Resampling happens separately inside every ``group x membership`` cell, so
+    each replicate keeps the equalised cohort design of the point estimate.
+    """
+    groups = np.asarray(groups).astype(str)
+    membership = np.asarray(membership)
+    scores = np.asarray(scores, dtype=float)
+    unique_groups = sorted(np.unique(groups))
+    cells = {
+        (group, member): np.flatnonzero((groups == group) & (membership == member))
+        for group in unique_groups
+        for member in (0, 1)
+    }
+    if any(len(idx) == 0 for idx in cells.values()):
+        raise RuntimeError("bootstrap requires non-empty group x membership cells")
+
+    rng = np.random.default_rng(seed)
+    draws: dict[str, list[float]] = {"aggregate": []}
+    for group in unique_groups:
+        draws[group] = []
+    draws["signed_difference"] = []
+    draws["absolute_gap"] = []
+
+    for _ in range(reps):
+        group_tprs: dict[str, float] = {}
+        all_idx: list[np.ndarray] = []
+        for group in unique_groups:
+            member_idx = rng.choice(cells[(group, 1)], size=len(cells[(group, 1)]), replace=True)
+            nonmember_idx = rng.choice(
+                cells[(group, 0)], size=len(cells[(group, 0)]), replace=True
+            )
+            idx = np.concatenate([member_idx, nonmember_idx])
+            all_idx.append(idx)
+            group_tprs[group] = tpr_at_fpr(membership[idx], scores[idx], target_fpr)
+        pooled = np.concatenate(all_idx)
+        draws["aggregate"].append(tpr_at_fpr(membership[pooled], scores[pooled], target_fpr))
+        for group, value in group_tprs.items():
+            draws[group].append(value)
+        draws["signed_difference"].append(signed_subgroup_difference(group_tprs))
+        draws["absolute_gap"].append(absolute_subgroup_gap(group_tprs))
+
+    summary: dict[str, dict[str, float]] = {}
+    for key, values in draws.items():
+        array = np.asarray(values, dtype=float)
+        finite = array[np.isfinite(array)]
+        if finite.size == 0:
+            summary[key] = {
+                "reps": int(reps),
+                "mean": float("nan"),
+                "ci95_low": float("nan"),
+                "ci95_high": float("nan"),
+            }
+            continue
+        low, high = np.percentile(finite, [2.5, 97.5])
+        summary[key] = {
+            "reps": int(reps),
+            "mean": float(finite.mean()),
+            "ci95_low": float(low),
+            "ci95_high": float(high),
+        }
+    return summary
+
+
+def attack_metrics(
+    membership: np.ndarray,
+    groups: np.ndarray,
+    scores: np.ndarray,
+    bootstrap_reps: int,
+    seed: int,
+) -> dict[str, object]:
+    """Aggregate and subgroup metrics for one score vector."""
+    membership = np.asarray(membership)
+    groups = np.asarray(groups).astype(str)
+    scores = np.asarray(scores, dtype=float)
+
+    aggregate = {
+        "auc": float(roc_auc_score(membership, scores)),
+        **{
+            f"tpr_at_fpr_{fpr}": tpr_at_fpr(membership, scores, fpr) for fpr in ATTACK_FPRS
+        },
+        "operating_point": operating_point_counts(membership, scores, HEADLINE_FPR),
+    }
+
+    subgroups: dict[str, dict[str, object]] = {}
+    group_tprs: dict[str, float] = {}
+    for group in sorted(np.unique(groups)):
+        mask = groups == group
+        subgroups[group] = {
+            "n": int(mask.sum()),
+            "members": int((membership[mask] == 1).sum()),
+            "nonmembers": int((membership[mask] == 0).sum()),
+            "auc": float(roc_auc_score(membership[mask], scores[mask])),
+            **{
+                f"tpr_at_fpr_{fpr}": tpr_at_fpr(membership[mask], scores[mask], fpr)
+                for fpr in ATTACK_FPRS
+            },
+            "operating_point": operating_point_counts(
+                membership[mask], scores[mask], HEADLINE_FPR
+            ),
+        }
+        group_tprs[group] = float(subgroups[group][f"tpr_at_fpr_{HEADLINE_FPR}"])
+
+    return {
+        "aggregate": aggregate,
+        "subgroups": subgroups,
+        "signed_subgroup_difference": signed_subgroup_difference(group_tprs),
+        "absolute_subgroup_gap": absolute_subgroup_gap(group_tprs),
+        "bootstrap": stratified_bootstrap(
+            groups, membership, scores, HEADLINE_FPR, bootstrap_reps, seed
+        ),
+    }
+
+
+def classify_control(
+    control: Control,
+    seed_results: Sequence[dict[str, object]],
+) -> tuple[str, str]:
+    """Return the decision-table verdict and its one-line justification."""
+    completed = [r for r in seed_results if r["attack_status"] == "completed"]
+    gate_passed = [bool(r["memorisation_gate_passed"]) for r in seed_results]
+
+    if not completed:
+        if not any(gate_passed):
+            return (
+                INCONCLUSIVE,
+                "No seed cleared the memorisation gate, so the attack never ran.",
+            )
+        return INCONCLUSIVE, "No attack completed for this control."
+
+    aucs = np.asarray(
+        [float(r["offline"]["aggregate"]["auc"]) for r in completed], dtype=float
+    )
+    ci_lows = np.asarray(
+        [float(r["offline"]["bootstrap"]["aggregate"]["ci95_low"]) for r in completed],
+        dtype=float,
+    )
+    # Random-guessing baseline at a 1% FPR operating point is a 1% TPR.
+    above_baseline = ci_lows > HEADLINE_FPR
+    mean_auc = float(np.nanmean(aucs))
+
+    if mean_auc >= DETECT_MEAN_AUC and bool(np.all(aucs > 0.5)) and bool(above_baseline.any()):
+        return (
+            DETECTS,
+            f"Mean aggregate offline-LiRA AUC {mean_auc:.4f} above chance on every seed, "
+            f"with {int(above_baseline.sum())}/{len(completed)} seeds whose bootstrap "
+            "TPR@1% FPR interval sits above the 1% random baseline.",
+        )
+
+    if control.positive_control and all(gate_passed) and mean_auc < CHANCE_AUC_BAND:
+        return (
+            FAILS_POSITIVE_CONTROL,
+            f"Every seed shows a clear train-test gap, yet mean aggregate LiRA AUC is "
+            f"{mean_auc:.4f} -- statistically indistinguishable from chance.",
+        )
+
+    return (
+        INCONCLUSIVE,
+        f"Mean aggregate LiRA AUC {mean_auc:.4f} with unstable or baseline-overlapping "
+        "bootstrap intervals across seeds.",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Model training (torch is imported lazily so the tests do not need it)
+# --------------------------------------------------------------------------- #
+
+
+def build_mlp(n_features: int, hidden_units: Sequence[int], seed: int):
+    """Build a plain feed-forward classifier with ReLU activations."""
+    import torch
+    from torch import nn
+
+    torch.manual_seed(seed)
+    layers: list[nn.Module] = []
+    in_dim = n_features
+    for units in hidden_units:
+        layers.append(nn.Linear(in_dim, units))
+        layers.append(nn.ReLU())
+        in_dim = units
+    layers.append(nn.Linear(in_dim, 1))
+    return nn.Sequential(*layers)
+
+
+def train_control_model(X: np.ndarray, y: np.ndarray, control: Control, seed: int):
+    """Train one non-private control model. No Opacus, clipping or noise."""
+    if control.kind == "tree":
+        model = DecisionTreeClassifier(random_state=seed, **control.tree_kwargs)
+        model.fit(np.asarray(X), np.asarray(y))
+        return model
+
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    torch.manual_seed(seed)
+    X = np.asarray(X, dtype=np.float32)
+    y = np.asarray(y, dtype=np.float32)
+    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=min(control.batch_size, len(dataset)),
+        shuffle=True,
+        generator=generator,
+    )
+
+    model = build_mlp(X.shape[1], control.hidden_units, seed)
+    optimizer = torch.optim.Adam(model.parameters(), lr=control.learning_rate)
+    loss_fn = nn.BCEWithLogitsLoss()
+    model.train()
+    for _ in range(control.epochs):
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            loss = loss_fn(model(xb).squeeze(-1), yb)
+            loss.backward()
+            optimizer.step()
+    return model
+
+
+def predict_probability(model, X: np.ndarray) -> np.ndarray:
+    """Positive-class probabilities for either control family."""
+    if isinstance(model, DecisionTreeClassifier):
+        proba = model.predict_proba(np.asarray(X))
+        if proba.shape[1] == 1:
+            only = float(model.classes_[0])
+            return np.full(len(X), only, dtype=float)
+        return np.asarray(proba[:, 1], dtype=float)
+
+    import torch
+
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
+        return torch.sigmoid(logits).cpu().numpy()
+
+
+def collect_shadow_losses(
+    X_pool: np.ndarray,
+    y_pool: np.ndarray,
+    attack_idx: np.ndarray,
+    target_train_size: int,
+    control: Control,
+    num_shadows: int,
+    seed: int,
+    log,
+) -> dict[str, object]:
+    """Train balanced, size-matched shadows and keep both IN and OUT losses."""
+    train_sets, excluded_counts = balanced_shadow_train_sets(
+        y_pool, train_size=target_train_size, num_shadows=num_shadows, seed=seed
+    )
+    out_losses: list[list[float]] = [[] for _ in attack_idx]
+    in_losses: list[list[float]] = [[] for _ in attack_idx]
+
+    for shadow_id, train_idx in enumerate(train_sets):
+        if len(train_idx) != target_train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
+
+        model = train_control_model(
+            X_pool[train_idx], y_pool[train_idx], control, seed=seed + shadow_id + 1
+        )
+        losses = per_example_bce(
+            y_pool[attack_idx], predict_probability(model, X_pool[attack_idx])
+        )
+        attack_in = in_mask[attack_idx]
+        for local_idx, is_in in enumerate(attack_in):
+            if is_in:
+                in_losses[local_idx].append(float(losses[local_idx]))
+            else:
+                out_losses[local_idx].append(float(losses[local_idx]))
+
+        log(
+            f"[{control.name}] shadow {shadow_id + 1}/{num_shadows} "
+            f"n={len(train_idx)} in_cover={int(attack_in.sum())}/{len(attack_idx)}"
+        )
+
+    min_out = min(len(values) for values in out_losses)
+    min_in = min(len(values) for values in in_losses)
+    expected_min_out = int(excluded_counts[attack_idx].min())
+    if min_out != expected_min_out:
+        raise AssertionError(
+            f"recorded OUT losses ({min_out}) do not match schedule ({expected_min_out})"
+        )
+    if min_out < MIN_GAUSSIAN_OBSERVATIONS:
+        raise RuntimeError(
+            f"offline LiRA needs at least {MIN_GAUSSIAN_OBSERVATIONS} OUT observations "
+            f"per example; minimum was {min_out}. Increase --shadows."
+        )
+
+    out_matrix = np.vstack([np.asarray(v[:min_out], dtype=float) for v in out_losses])
+    in_matrix = (
+        np.vstack([np.asarray(v[:min_in], dtype=float) for v in in_losses])
+        if min_in >= MIN_GAUSSIAN_OBSERVATIONS
+        else None
+    )
+    return {
+        "out_matrix": out_matrix,
+        "in_matrix": in_matrix,
+        "min_out": int(min_out),
+        "min_in": int(min_in),
+    }
+
+
+def run_control_seed(
+    control: Control,
+    data_arrays: dict[str, np.ndarray],
+    num_shadows: int,
+    bootstrap_reps: int,
+    seed: int,
+    log,
+) -> dict[str, object]:
+    """Train one control target, gate it, then attack it if it memorised."""
+    from dp.attacks import lira_offline_attack, lira_online_attack
+
+    X_train = data_arrays["X_train"]
+    y_train = data_arrays["y_train"]
+    X_val = data_arrays["X_val"]
+    y_val = data_arrays["y_val"]
+    X_test = data_arrays["X_test"]
+    y_test = data_arrays["y_test"]
+    groups_train = data_arrays["groups_train"]
+    groups_test = data_arrays["groups_test"]
+
+    X_attack = np.vstack([X_train, X_test])
+    y_attack = np.concatenate([y_train, y_test])
+    groups_attack = np.concatenate([groups_train, groups_test]).astype(str)
+    membership = np.concatenate(
+        [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
+    )
+    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_attack, membership, seed)
+
+    target = train_control_model(X_train, y_train, control, seed=seed)
+    metrics = memorisation_metrics(
+        y_train,
+        predict_probability(target, X_train),
+        y_test,
+        predict_probability(target, X_test),
+    )
+    gate_passed = memorisation_gate_passed(metrics)
+
+    result: dict[str, object] = {
+        "control": control.name,
+        "kind": control.kind,
+        "architecture": control.architecture(),
+        "positive_control": control.positive_control,
+        "seed": int(seed),
+        "train_size": int(len(y_train)),
+        "val_size": int(len(y_val)),
+        "test_size": int(len(y_test)),
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "memorisation": metrics,
+        "memorisation_gate": MEMORISATION_GATE,
+        "memorisation_gate_passed": bool(gate_passed),
+        "attack_status": "pending",
+        "offline": None,
+        "online": None,
+        "online_available": False,
+    }
+
+    log(
+        f"[{control.name} seed={seed}] train_auc={metrics['train_auc']:.4f} "
+        f"test_auc={metrics['test_auc']:.4f} auc_gap={metrics['auc_gap']:.4f} "
+        f"loss_gap={metrics['loss_gap']:.4f} acc_gap={metrics['accuracy_gap']:.4f} "
+        f"gate={'PASS' if gate_passed else 'FAIL'}"
+    )
+    if not gate_passed:
+        result["attack_status"] = "skipped_memorisation_gate"
+        return result
+
+    # Shadow pool spans all partitions; remap attack indices into pool space.
+    X_pool = np.vstack([X_train, X_val, X_test])
+    y_pool = np.concatenate([y_train, y_val, y_test])
+    attack_pool_idx = attack_idx.copy()
+    attack_pool_idx[attack_pool_idx >= len(y_train)] += len(y_val)
+
+    target_losses = per_example_bce(
+        y_attack[attack_idx], predict_probability(target, X_attack)[attack_idx]
+    )
+    shadows = collect_shadow_losses(
+        X_pool,
+        y_pool,
+        attack_pool_idx,
+        target_train_size=len(y_train),
+        control=control,
+        num_shadows=num_shadows,
+        seed=seed + 10_000,
+        log=log,
+    )
+
+    attack_groups = groups_attack[attack_idx]
+    attack_membership = membership[attack_idx]
+
+    offline = lira_offline_attack(
+        target_losses, attack_membership, shadows["out_matrix"], fprs=ATTACK_FPRS
+    )
+    result.update(
+        {
+            "attack_status": "completed",
+            "num_shadows": int(num_shadows),
+            "shadow_train_size": int(len(y_train)),
+            "min_out_observations": shadows["min_out"],
+            "min_in_observations": shadows["min_in"],
+            "offline": attack_metrics(
+                attack_membership,
+                attack_groups,
+                offline.scores,
+                bootstrap_reps,
+                seed + 20_000,
+            ),
+        }
+    )
+
+    if shadows["in_matrix"] is not None:
+        online = lira_online_attack(
+            target_losses,
+            attack_membership,
+            shadows["in_matrix"],
+            shadows["out_matrix"],
+            fprs=ATTACK_FPRS,
+        )
+        result["online_available"] = True
+        result["online"] = attack_metrics(
+            attack_membership,
+            attack_groups,
+            online.scores,
+            bootstrap_reps,
+            seed + 30_000,
+        )
+    else:
+        result["online_unavailable_reason"] = (
+            f"only {shadows['min_in']} IN observations per example; "
+            f"{MIN_GAUSSIAN_OBSERVATIONS} required"
+        )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def _fmt(value: object, digits: int = 4) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, (int, np.integer)) and not isinstance(value, bool):
+        return str(int(value))
+    try:
+        number = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return str(value)
+    if not np.isfinite(number):
+        return "-"
+    return f"{number:.{digits}f}"
+
+
+def _ci(entry: dict[str, float] | None) -> str:
+    if not entry:
+        return "-"
+    return f"[{_fmt(entry['ci95_low'])}, {_fmt(entry['ci95_high'])}]"
+
+
+def build_rows(payload: dict[str, object]) -> list[dict[str, object]]:
+    """Flatten the payload into one CSV row per control/seed/attack variant."""
+    rows: list[dict[str, object]] = []
+    for result in payload["seed_results"]:
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                continue
+            aggregate = metrics["aggregate"]
+            bootstrap = metrics["bootstrap"]
+            row: dict[str, object] = {
+                "control": result["control"],
+                "seed": result["seed"],
+                "attack": f"lira-{variant}",
+                "attack_status": result["attack_status"],
+                "memorisation_gate_passed": result["memorisation_gate_passed"],
+                "train_size": result["train_size"],
+                "num_attack_examples": result["num_attack_examples"],
+                "num_shadows": result.get("num_shadows"),
+                "min_out_observations": result.get("min_out_observations"),
+                "min_in_observations": result.get("min_in_observations"),
+                "train_auc": result["memorisation"]["train_auc"],
+                "test_auc": result["memorisation"]["test_auc"],
+                "auc_gap": result["memorisation"]["auc_gap"],
+                "loss_gap": result["memorisation"]["loss_gap"],
+                "accuracy_gap": result["memorisation"]["accuracy_gap"],
+                "lira_auc": aggregate["auc"],
+                "tpr_at_fpr_0.001": aggregate["tpr_at_fpr_0.001"],
+                "tpr_at_fpr_0.01": aggregate["tpr_at_fpr_0.01"],
+                "tpr_at_fpr_0.1": aggregate["tpr_at_fpr_0.1"],
+                "detected_members_at_1pct_fpr": aggregate["operating_point"][
+                    "detected_members"
+                ],
+                "false_positives_at_1pct_fpr": aggregate["operating_point"][
+                    "false_positives"
+                ],
+                "aggregate_tpr_ci_low": bootstrap["aggregate"]["ci95_low"],
+                "aggregate_tpr_ci_high": bootstrap["aggregate"]["ci95_high"],
+                "signed_subgroup_difference": metrics["signed_subgroup_difference"],
+                "absolute_subgroup_gap": metrics["absolute_subgroup_gap"],
+                "signed_difference_ci_low": bootstrap["signed_difference"]["ci95_low"],
+                "signed_difference_ci_high": bootstrap["signed_difference"]["ci95_high"],
+                "absolute_gap_ci_low": bootstrap["absolute_gap"]["ci95_low"],
+                "absolute_gap_ci_high": bootstrap["absolute_gap"]["ci95_high"],
+            }
+            for group, group_metrics in metrics["subgroups"].items():
+                row[f"{group}_lira_auc"] = group_metrics["auc"]
+                row[f"{group}_tpr_at_fpr_0.01"] = group_metrics["tpr_at_fpr_0.01"]
+                row[f"{group}_tpr_ci_low"] = bootstrap[group]["ci95_low"]
+                row[f"{group}_tpr_ci_high"] = bootstrap[group]["ci95_high"]
+            rows.append(row)
+
+        if not result.get("offline"):
+            rows.append(
+                {
+                    "control": result["control"],
+                    "seed": result["seed"],
+                    "attack": "lira-offline",
+                    "attack_status": result["attack_status"],
+                    "memorisation_gate_passed": result["memorisation_gate_passed"],
+                    "train_size": result["train_size"],
+                    "num_attack_examples": result["num_attack_examples"],
+                    "train_auc": result["memorisation"]["train_auc"],
+                    "test_auc": result["memorisation"]["test_auc"],
+                    "auc_gap": result["memorisation"]["auc_gap"],
+                    "loss_gap": result["memorisation"]["loss_gap"],
+                    "accuracy_gap": result["memorisation"]["accuracy_gap"],
+                }
+            )
+    return rows
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    """Render the examiner-facing report, including the go/no-go decision."""
+    seed_results: list[dict[str, object]] = list(payload["seed_results"])
+    lines = [
+        "# Attack-power control experiment",
+        "",
+        "## 1. Experimental design",
+        "",
+        f"Task: `{payload['task']}`. Sensitive attribute: `{payload['sensitive_attribute']}`.",
+        (
+            "This is a control for the powered two-configuration DP spike, which "
+            "returned a null subgroup result. Every model here is **non-private**: "
+            "no Opacus, no gradient clipping, no noise. If the pipeline cannot "
+            "detect membership in an unprotected, deliberately memorising model, "
+            "the null DP result says nothing about DP."
+        ),
+        f"Seeds: {', '.join(str(seed) for seed in payload['seeds'])}.",
+        f"Shadow models per control and seed: {payload['num_shadows']} "
+        "(balanced fixed-size schedule, training size pinned to the target's).",
+        f"Bootstrap replicates: {payload['bootstrap_reps']}, resampled within each "
+        "`sex x membership` cell.",
+        (
+            f"Memorisation gate: the attack runs only when train-test ROC-AUC, "
+            f"test-train loss or train-test accuracy differs by at least "
+            f"{MEMORISATION_GATE}. The old ROC-AUC >= 0.70 utility gate is not used "
+            "on its own -- a model can generalise well and still be an unattackable "
+            "membership target."
+        ),
+        "",
+        "## 2. Training sizes and cohort counts",
+        "",
+        "| Control | Seed | Train | Val | Test | Attack cohort | Cells (sex\\|membership) |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for result in seed_results:
+        cells = ", ".join(f"{k}={v}" for k, v in sorted(result["cohort_counts"].items()))
+        lines.append(
+            f"| {result['control']} | {result['seed']} | {result['train_size']} | "
+            f"{result['val_size']} | {result['test_size']} | "
+            f"{result['num_attack_examples']} | {cells} |"
+        )
+
+    lines += [
+        "",
+        "Target and shadow training sizes are exactly matched; every cohort cell "
+        "holds the same number of rows by construction.",
+        "",
+        "## 3. Target and shadow architectures",
+        "",
+        "| Control | Kind | Architecture | Training | Positive control |",
+        "|---|---|---|---|---|",
+    ]
+    for control in payload["controls"]:
+        if control["kind"] == "tree":
+            training = "fitted to purity"
+        else:
+            training = (
+                f"Adam, lr={control['learning_rate']}, "
+                f"batch={control['batch_size']}, epochs={control['epochs']}"
+            )
+        lines.append(
+            f"| {control['name']} | {control['kind']} | `{control['architecture']}` | "
+            f"{training} | {'yes' if control['positive_control'] else 'no'} |"
+        )
+    lines.append("")
+    lines.append("Shadow models use the identical architecture and recipe as their target.")
+
+    lines += [
+        "",
+        "## 4. Memorisation metrics",
+        "",
+        "| Control | Seed | Train AUC | Test AUC | AUC gap | Train BCE | Test BCE | "
+        "Loss gap | Train acc | Test acc | Acc gap | Gate |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for result in seed_results:
+        m = result["memorisation"]
+        lines.append(
+            f"| {result['control']} | {result['seed']} | {_fmt(m['train_auc'])} | "
+            f"{_fmt(m['test_auc'])} | {_fmt(m['auc_gap'])} | {_fmt(m['train_loss'])} | "
+            f"{_fmt(m['test_loss'])} | {_fmt(m['loss_gap'])} | {_fmt(m['train_accuracy'])} | "
+            f"{_fmt(m['test_accuracy'])} | {_fmt(m['accuracy_gap'])} | "
+            f"{'PASS' if result['memorisation_gate_passed'] else 'FAIL (attack skipped)'} |"
+        )
+
+    lines += [
+        "",
+        "## 5. Aggregate LiRA results",
+        "",
+        "| Control | Seed | Attack | LiRA AUC | TPR@0.1% | TPR@1% | TPR@10% | "
+        "Detected members @1% | False positives @1% | OUT obs | IN obs |",
+        "|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in seed_results:
+        if result["attack_status"] != "completed":
+            lines.append(
+                f"| {result['control']} | {result['seed']} | - | "
+                f"**SKIPPED: {result['attack_status']}** | - | - | - | - | - | - | - |"
+            )
+            continue
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                lines.append(
+                    f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                    f"**unavailable: {result.get('online_unavailable_reason', 'n/a')}** "
+                    "| - | - | - | - | - | - | - |"
+                )
+                continue
+            agg = metrics["aggregate"]
+            op = agg["operating_point"]
+            lines.append(
+                f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                f"{_fmt(agg['auc'])} | {_fmt(agg['tpr_at_fpr_0.001'])} | "
+                f"{_fmt(agg['tpr_at_fpr_0.01'])} | {_fmt(agg['tpr_at_fpr_0.1'])} | "
+                f"{op['detected_members']}/{op['n_members']} | "
+                f"{op['false_positives']}/{op['n_nonmembers']} | "
+                f"{result['min_out_observations']} | {result['min_in_observations']} |"
+            )
+
+    lines += [
+        "",
+        "## 6. Subgroup LiRA results",
+        "",
+        "| Control | Seed | Attack | Female AUC | Male AUC | Female TPR@1% | "
+        "Male TPR@1% | Signed diff (male-female) | Absolute gap |",
+        "|---|---:|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for result in seed_results:
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                continue
+            groups = metrics["subgroups"]
+
+            def group_value(name: str, key: str) -> object:
+                for candidate, values in groups.items():
+                    if candidate.lower() == name:
+                        return values[key]
+                return None
+
+            lines.append(
+                f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                f"{_fmt(group_value('female', 'auc'))} | {_fmt(group_value('male', 'auc'))} | "
+                f"{_fmt(group_value('female', 'tpr_at_fpr_0.01'))} | "
+                f"{_fmt(group_value('male', 'tpr_at_fpr_0.01'))} | "
+                f"{_fmt(metrics['signed_subgroup_difference'])} | "
+                f"{_fmt(metrics['absolute_subgroup_gap'])} |"
+            )
+    if not any(result.get("offline") for result in seed_results):
+        lines.append("| - | - | - | - | - | - | - | - | - |")
+
+    lines += [
+        "",
+        "## 7. Bootstrap 95% confidence intervals",
+        "",
+        "Stratified within each `sex x membership` cell.",
+        "",
+        "| Control | Seed | Attack | Aggregate TPR@1% | Female TPR@1% | Male TPR@1% | "
+        "Signed diff | Absolute gap |",
+        "|---|---:|---|---|---|---|---|---|",
+    ]
+    for result in seed_results:
+        for variant in ("offline", "online"):
+            metrics = result.get(variant)
+            if not metrics:
+                continue
+            bootstrap = metrics["bootstrap"]
+
+            def ci_for(name: str) -> str:
+                for candidate, values in bootstrap.items():
+                    if candidate.lower() == name:
+                        return _ci(values)
+                return "-"
+
+            lines.append(
+                f"| {result['control']} | {result['seed']} | lira-{variant} | "
+                f"{_ci(bootstrap['aggregate'])} | {ci_for('female')} | {ci_for('male')} | "
+                f"{_ci(bootstrap['signed_difference'])} | {_ci(bootstrap['absolute_gap'])} |"
+            )
+    if not any(result.get("offline") for result in seed_results):
+        lines.append("| - | - | - | - | - | - | - | - |")
+
+    lines += [
+        "",
+        "## 8. Decision table",
+        "",
+        "| Control | Positive control | Seeds attacked | Mean memorisation gap (AUC) | "
+        "Mean offline LiRA AUC | Verdict | Basis |",
+        "|---|---|---:|---:|---:|---|---|",
+    ]
+    for decision in payload["decisions"]:
+        lines.append(
+            f"| {decision['control']} | {'yes' if decision['positive_control'] else 'no'} | "
+            f"{decision['seeds_attacked']} | {_fmt(decision['mean_auc_gap'])} | "
+            f"{_fmt(decision['mean_lira_auc'])} | **{decision['verdict']}** | "
+            f"{decision['basis']} |"
+        )
+
+    lines += ["", "## Conclusion", ""]
+    failed = [d for d in payload["decisions"] if d["verdict"] == FAILS_POSITIVE_CONTROL]
+    detected = [d for d in payload["decisions"] if d["verdict"] == DETECTS]
+    if failed and not detected:
+        lines += [
+            "**Natural membership leakage is not reliably measurable with the current "
+            "insurance dataset and attack implementation. The iso-epsilon "
+            "subgroup-privacy research should move to a larger dataset rather than "
+            "adding further DP configurations.**",
+            "",
+            "Go/no-go: **NO-GO** for further DP-SGD configurations on the insurance "
+            "dataset. The null subgroup result from the powered spike cannot be "
+            "attributed to differential privacy, because the same pipeline fails "
+            "against an unprotected, demonstrably memorising target.",
+        ]
+    elif detected:
+        names = ", ".join(d["control"] for d in detected)
+        lines += [
+            f"The pipeline detects membership leakage on: {names}. The attack "
+            "implementation therefore has measurable power on this dataset, and the "
+            "null DP result is evidence about the DP-SGD configurations rather than "
+            "about the attack.",
+            "",
+            "Go/no-go: **GO** -- the insurance dataset supports membership auditing "
+            "at non-private capacity, so subgroup DP work here remains interpretable.",
+        ]
+    else:
+        lines += [
+            "No control produced a stable above-chance attack, and no positive "
+            "control both memorised and stayed at chance, so the experiment is "
+            "inconclusive.",
+            "",
+            "Go/no-go: **HOLD** -- re-run with more shadows or a stronger memorising "
+            "target before drawing conclusions about the insurance dataset.",
+        ]
+
+    lines += [
+        "",
+        "Attack AUC near 0.5 is reported here as a failure of attack power, not as "
+        "evidence of privacy, and no claim of subgroup privacy variance is made.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shadows", type=int, default=DEFAULT_SHADOWS)
+    parser.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
+    parser.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
+    parser.add_argument("--output-dir", default="reports/attack_power_control")
+    parser.add_argument(
+        "--controls",
+        nargs="+",
+        default=[control.name for control in CONTROLS],
+        help="Subset of control names to run.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.shadows < DEFAULT_SHADOWS:
+        raise ValueError(f"Use at least {DEFAULT_SHADOWS} shadows.")
+    if len(args.seeds) < 3:
+        raise ValueError("Use at least three target seeds.")
+    if args.bootstrap_reps < 200:
+        raise ValueError("Use at least 200 bootstrap replicates.")
+
+    from dp.pipeline import build_preprocessor
+    from dp.tasks import get_task, prepare_task_data
+
+    selected = [control for control in CONTROLS if control.name in set(args.controls)]
+    if not selected:
+        raise ValueError(f"No known controls selected from {args.controls}")
+    if any(control.kind == "mlp" for control in selected):
+        import torch
+
+        torch.set_num_threads(2)
+
+    root = Path(__file__).resolve().parents[1]
+    output_dir = root / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "attack_power_control.log"
+    log_handle = log_path.open("w", encoding="utf-8")
+
+    def log(message: str) -> None:
+        print(message, flush=True)
+        log_handle.write(message + "\n")
+        log_handle.flush()
+
+    df = pd.read_csv(root / "data" / "insurance.csv")
+    payload: dict[str, object] = {
+        "experiment": "attack_power_control",
+        "task": TASK_NAME,
+        "sensitive_attribute": SENSITIVE_ATTRIBUTE,
+        "private": False,
+        "seeds": [int(seed) for seed in args.seeds],
+        "num_shadows": int(args.shadows),
+        "bootstrap_reps": int(args.bootstrap_reps),
+        "memorisation_gate": MEMORISATION_GATE,
+        "controls": [
+            {**asdict(control), "architecture": control.architecture()}
+            for control in selected
+        ],
+        "seed_results": [],
+        "decisions": [],
+    }
+
+    for control in selected:
+        control_results: list[dict[str, object]] = []
+        for seed in args.seeds:
+            log(f"\n=== {control.name} | target seed {seed} ===")
+            data = prepare_task_data(df, get_task(TASK_NAME), random_state=seed)
+            preprocessor = build_preprocessor(data.X_train)
+            arrays = {
+                "X_train": np.asarray(
+                    preprocessor.fit_transform(data.X_train), dtype=np.float32
+                ),
+                "X_val": np.asarray(preprocessor.transform(data.X_val), dtype=np.float32),
+                "X_test": np.asarray(preprocessor.transform(data.X_test), dtype=np.float32),
+                "y_train": data.y_train,
+                "y_val": data.y_val,
+                "y_test": data.y_test,
+                "groups_train": data.sensitive_train,
+                "groups_test": data.sensitive_test,
+            }
+            result = run_control_seed(
+                control,
+                arrays,
+                num_shadows=args.shadows,
+                bootstrap_reps=args.bootstrap_reps,
+                seed=seed,
+                log=log,
+            )
+            control_results.append(result)
+            payload["seed_results"].append(result)
+
+        verdict, basis = classify_control(control, control_results)
+        completed = [r for r in control_results if r["attack_status"] == "completed"]
+        payload["decisions"].append(
+            {
+                "control": control.name,
+                "positive_control": control.positive_control,
+                "seeds_attacked": len(completed),
+                "mean_auc_gap": float(
+                    np.mean([r["memorisation"]["auc_gap"] for r in control_results])
+                ),
+                "mean_lira_auc": (
+                    float(np.mean([r["offline"]["aggregate"]["auc"] for r in completed]))
+                    if completed
+                    else None
+                ),
+                "verdict": verdict,
+                "basis": basis,
+            }
+        )
+        log(f"[{control.name}] verdict: {verdict} -- {basis}")
+
+    json_path = output_dir / "attack_power_control.json"
+    csv_path = output_dir / "attack_power_control.csv"
+    md_path = output_dir / "attack_power_control.md"
+    json_path.write_text(json.dumps(payload, indent=2, default=float))
+    pd.DataFrame(build_rows(payload)).to_csv(csv_path, index=False)
+    md_path.write_text(render_markdown(payload))
+
+    log("\n" + md_path.read_text())
+    log(f"JSON: {json_path}")
+    log(f"CSV: {csv_path}")
+    log(f"Markdown: {md_path}")
+    log_handle.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/powered_spike_runner.py
+++ b/research/powered_spike_runner.py
@@ -1,0 +1,132 @@
+"""Run the corrected spike with balanced fixed-size shadow coverage.
+
+The main spike harness already matches target/shadow training size. This runner
+replaces its independent shadow-set sampling with an evenly spaced cyclic design
+so every attack example receives a usable number of OUT observations without
+changing the training size, privacy target, accountant or model recipe.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import two_config_spike as spike
+
+
+def balanced_shadow_train_sets(
+    y_pool: np.ndarray,
+    train_size: int,
+    num_shadows: int,
+    seed: int,
+) -> tuple[list[np.ndarray], np.ndarray]:
+    """Create exact-size shadow sets with near-uniform OUT coverage."""
+    n = len(y_pool)
+    if train_size >= n:
+        raise ValueError("shadow train_size must be smaller than the shadow pool")
+    if num_shadows < 2:
+        raise ValueError("num_shadows must be at least two")
+
+    exclude_size = n - train_size
+    rng = np.random.default_rng(seed)
+    permutation = rng.permutation(n)
+    excluded_counts = np.zeros(n, dtype=int)
+    train_sets: list[np.ndarray] = []
+
+    for shadow_id in range(num_shadows):
+        start = (shadow_id * n) // num_shadows
+        positions = (start + np.arange(exclude_size)) % n
+        excluded_idx = permutation[positions]
+        excluded_counts[excluded_idx] += 1
+
+        in_mask = np.ones(n, dtype=bool)
+        in_mask[excluded_idx] = False
+        train_idx = np.flatnonzero(in_mask)
+        if len(train_idx) != train_size:
+            raise AssertionError("balanced schedule changed shadow train size")
+        if np.unique(y_pool[train_idx]).size != 2:
+            raise RuntimeError("balanced schedule produced a one-class shadow set")
+        train_sets.append(train_idx)
+
+    return train_sets, excluded_counts
+
+
+def collect_shadow_out_losses_balanced(
+    X_pool: np.ndarray,
+    y_pool: np.ndarray,
+    attack_idx: np.ndarray,
+    target_train_size: int,
+    target_noise_multiplier: float,
+    recipe: spike.Recipe,
+    num_shadows: int,
+    seed: int,
+) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
+    """Train size-matched shadows with balanced OUT observations."""
+    out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
+    metadata: list[dict[str, float | int | str]] = []
+    train_sets, excluded_counts = balanced_shadow_train_sets(
+        y_pool,
+        train_size=target_train_size,
+        num_shadows=num_shadows,
+        seed=seed,
+    )
+
+    for shadow_id, train_idx in enumerate(train_sets):
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
+
+        model, meta = spike.train_private_model(
+            X_pool[train_idx],
+            y_pool[train_idx],
+            recipe,
+            seed=seed + shadow_id + 1,
+        )
+        if int(meta["train_size"]) != target_train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        if not np.isclose(
+            float(meta["noise_multiplier"]),
+            target_noise_multiplier,
+            rtol=0.0,
+            atol=1e-10,
+        ):
+            raise AssertionError(
+                "matched shadow has different noise multiplier: "
+                f"target={target_noise_multiplier}, shadow={meta['noise_multiplier']}"
+            )
+
+        meta["shadow_id"] = shadow_id
+        metadata.append(meta)
+        losses = spike.per_example_bce(
+            y_pool[attack_idx],
+            spike.predict_probability(model, X_pool[attack_idx]),
+        )
+        attack_out = ~in_mask[attack_idx]
+        for local_idx in np.flatnonzero(attack_out):
+            out_losses[local_idx].append(float(losses[local_idx]))
+
+        print(
+            f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
+            f"n={meta['train_size']} achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"noise={meta['noise_multiplier']:.4f}",
+            flush=True,
+        )
+
+    expected_min = int(excluded_counts[attack_idx].min())
+    min_out = min(len(values) for values in out_losses)
+    if min_out != expected_min:
+        raise AssertionError(
+            f"recorded OUT losses ({min_out}) do not match schedule ({expected_min})"
+        )
+    if min_out < 8:
+        raise RuntimeError(
+            f"LiRA requires at least eight OUT observations; minimum was {min_out}"
+        )
+
+    matrix = np.vstack(
+        [np.asarray(values[:min_out], dtype=float) for values in out_losses]
+    )
+    return matrix, metadata, min_out
+
+
+if __name__ == "__main__":
+    spike.collect_shadow_out_losses = collect_shadow_out_losses_balanced
+    spike.main()

--- a/research/two_config_spike.py
+++ b/research/two_config_spike.py
@@ -1,0 +1,393 @@
+"""Two-configuration iso-epsilon subgroup-LiRA spike.
+
+This is deliberately a go/no-go experiment, not a benchmark grid. It trains two
+contrasting DP-SGD recipes at the same target epsilon on the insurance dataset,
+runs offline LiRA, equalises the attack cohort across sex and membership status,
+and reports the subgroup TPR@1% FPR gap Delta.
+
+Run from the repository root:
+
+    python research/two_config_spike.py --shadows 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from opacus import PrivacyEngine
+from sklearn.metrics import roc_auc_score
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from dp.attacks import lira_offline_attack
+from dp.pipeline import build_preprocessor
+from dp.tasks import get_task, prepare_task_data
+
+
+TARGET_EPSILON = 8.0
+DELTA = 1e-5
+ATTACK_FPRS = (0.001, 0.01, 0.1)
+
+
+@dataclass(frozen=True)
+class Recipe:
+    name: str
+    batch_size: int
+    epochs: int
+    max_grad_norm: float
+    hidden_units: int = 32
+    learning_rate: float = 1e-2
+
+
+RECIPES = (
+    Recipe(
+        name="small_batch_long_tight_clip",
+        batch_size=64,
+        epochs=30,
+        max_grad_norm=0.5,
+    ),
+    Recipe(
+        name="large_batch_short_loose_clip",
+        batch_size=256,
+        epochs=5,
+        max_grad_norm=2.0,
+    ),
+)
+
+
+def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
+    y_true = np.asarray(y_true, dtype=float)
+    return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+
+def build_model(n_features: int, hidden_units: int, seed: int) -> nn.Module:
+    torch.manual_seed(seed)
+    return nn.Sequential(
+        nn.Linear(n_features, hidden_units),
+        nn.ReLU(),
+        nn.Linear(hidden_units, 1),
+    )
+
+
+def train_private_model(
+    X: np.ndarray,
+    y: np.ndarray,
+    recipe: Recipe,
+    seed: int,
+) -> tuple[nn.Module, dict[str, float | int | str]]:
+    """Train one RDP-accounted, Poisson-sampled DP-SGD model at epsilon=8."""
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    order = rng.permutation(len(y))
+    X = np.asarray(X[order], dtype=np.float32)
+    y = np.asarray(y[order], dtype=np.float32)
+
+    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=min(recipe.batch_size, len(dataset)),
+        shuffle=True,
+        generator=generator,
+    )
+
+    model = build_model(X.shape[1], recipe.hidden_units, seed)
+    optimizer = torch.optim.Adam(model.parameters(), lr=recipe.learning_rate)
+    engine = PrivacyEngine(accountant="rdp")
+    model, optimizer, loader = engine.make_private_with_epsilon(
+        module=model,
+        optimizer=optimizer,
+        data_loader=loader,
+        epochs=recipe.epochs,
+        target_epsilon=TARGET_EPSILON,
+        target_delta=DELTA,
+        max_grad_norm=recipe.max_grad_norm,
+        poisson_sampling=True,
+    )
+
+    loss_fn = nn.BCEWithLogitsLoss()
+    for _ in range(recipe.epochs):
+        model.train()
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            loss = loss_fn(model(xb).squeeze(-1), yb)
+            loss.backward()
+            optimizer.step()
+
+    metadata: dict[str, float | int | str] = {
+        **asdict(recipe),
+        "target_epsilon": TARGET_EPSILON,
+        "achieved_epsilon": float(engine.get_epsilon(DELTA)),
+        "delta": DELTA,
+        "noise_multiplier": float(optimizer.noise_multiplier),
+        "accountant": "rdp",
+        "sampling": "poisson",
+        "seed": seed,
+        "train_size": int(len(dataset)),
+    }
+    return model, metadata
+
+
+def predict_probability(model: nn.Module, X: np.ndarray) -> np.ndarray:
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
+        return torch.sigmoid(logits).cpu().numpy()
+
+
+def make_equalised_attack_cohort(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    seed: int,
+) -> tuple[np.ndarray, dict[str, int]]:
+    """Equalise every group x membership cell to the smallest cell size."""
+    rng = np.random.default_rng(seed)
+    unique_groups = sorted(str(value) for value in np.unique(groups))
+    string_groups = groups.astype(str)
+    cells: dict[tuple[str, int], np.ndarray] = {}
+    for group in unique_groups:
+        for member in (0, 1):
+            idx = np.flatnonzero((string_groups == group) & (membership == member))
+            if idx.size == 0:
+                raise RuntimeError(f"empty attack cell group={group!r}, membership={member}")
+            cells[(group, member)] = idx
+
+    per_cell = min(len(idx) for idx in cells.values())
+    selected = []
+    counts: dict[str, int] = {}
+    for (group, member), idx in cells.items():
+        chosen = rng.choice(idx, size=per_cell, replace=False)
+        selected.extend(chosen.tolist())
+        counts[f"{group}|member={member}"] = int(per_cell)
+
+    selected_idx = np.asarray(sorted(selected), dtype=int)
+    return selected_idx, counts
+
+
+def collect_shadow_out_losses(
+    X_all: np.ndarray,
+    y_all: np.ndarray,
+    attack_idx: np.ndarray,
+    recipe: Recipe,
+    num_shadows: int,
+    seed: int,
+) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
+    """Train shadows and retain each example's losses only when it was OUT."""
+    rng = np.random.default_rng(seed)
+    out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
+    metadata: list[dict[str, float | int | str]] = []
+
+    for shadow_id in range(num_shadows):
+        mask = rng.random(len(y_all)) < 0.5
+        while np.unique(y_all[mask]).size < 2 or mask.sum() < 2:
+            mask = rng.random(len(y_all)) < 0.5
+
+        model, meta = train_private_model(
+            X_all[mask],
+            y_all[mask],
+            recipe,
+            seed=seed + shadow_id + 1,
+        )
+        meta["shadow_id"] = shadow_id
+        metadata.append(meta)
+
+        losses = per_example_bce(y_all[attack_idx], predict_probability(model, X_all[attack_idx]))
+        attack_out = ~mask[attack_idx]
+        for local_idx in np.flatnonzero(attack_out):
+            out_losses[local_idx].append(float(losses[local_idx]))
+
+        print(
+            f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
+            f"achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"noise={meta['noise_multiplier']:.4f}",
+            flush=True,
+        )
+
+    min_out = min(len(values) for values in out_losses)
+    if min_out < 2:
+        raise RuntimeError(
+            f"LiRA needs at least two OUT shadows per example; minimum was {min_out}. "
+            "Increase --shadows."
+        )
+    matrix = np.vstack([np.asarray(values[:min_out], dtype=float) for values in out_losses])
+    return matrix, metadata, min_out
+
+
+def run_recipe(
+    recipe: Recipe,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    groups_train: np.ndarray,
+    groups_test: np.ndarray,
+    num_shadows: int,
+    seed: int,
+) -> dict[str, object]:
+    X_all = np.vstack([X_train, X_test])
+    y_all = np.concatenate([y_train, y_test])
+    groups_all = np.concatenate([groups_train, groups_test]).astype(str)
+    membership = np.concatenate(
+        [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
+    )
+
+    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_all, membership, seed)
+
+    target, target_meta = train_private_model(X_train, y_train, recipe, seed=seed)
+    target_prob_all = predict_probability(target, X_all)
+    target_losses = per_example_bce(y_all[attack_idx], target_prob_all[attack_idx])
+    target_test_auc = float(roc_auc_score(y_test, target_prob_all[len(y_train) :]))
+
+    shadow_out, shadow_meta, min_out = collect_shadow_out_losses(
+        X_all,
+        y_all,
+        attack_idx,
+        recipe,
+        num_shadows=num_shadows,
+        seed=seed + 10_000,
+    )
+
+    subgroup_results: dict[str, dict[str, float | int]] = {}
+    attack_groups = groups_all[attack_idx]
+    attack_membership = membership[attack_idx]
+    for group in sorted(np.unique(attack_groups)):
+        group_mask = attack_groups == group
+        result = lira_offline_attack(
+            target_losses[group_mask],
+            attack_membership[group_mask],
+            shadow_out[group_mask],
+            fprs=ATTACK_FPRS,
+        )
+        subgroup_results[str(group)] = {
+            "n": int(group_mask.sum()),
+            "members": int(attack_membership[group_mask].sum()),
+            "auc": float(result.auc),
+            "tpr_at_fpr_0.001": float(result.tpr_at_fpr[0.001]),
+            "tpr_at_fpr_0.01": float(result.tpr_at_fpr[0.01]),
+            "tpr_at_fpr_0.1": float(result.tpr_at_fpr[0.1]),
+        }
+
+    tprs = [metrics["tpr_at_fpr_0.01"] for metrics in subgroup_results.values()]
+    delta_tpr_1pct = float(max(tprs) - min(tprs))
+
+    return {
+        "recipe": asdict(recipe),
+        "target": target_meta,
+        "target_test_auc": target_test_auc,
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "num_shadows": int(num_shadows),
+        "min_out_shadow_losses_per_example": int(min_out),
+        "subgroups": subgroup_results,
+        "delta_tpr_at_fpr_0.01": delta_tpr_1pct,
+        "shadow_metadata": shadow_meta,
+    }
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# Two-configuration iso-epsilon subgroup-LiRA spike",
+        "",
+        f"Target privacy: epsilon={TARGET_EPSILON}, delta={DELTA}.",
+        "Attack cohort: equal counts in every sex x membership cell.",
+        "Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-min gap Delta.",
+        "",
+        "| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |",
+        "|---|---:|---:|---:|---|---:|---:|",
+    ]
+    for result in payload["results"]:
+        target = result["target"]
+        for group, metrics in result["subgroups"].items():
+            lines.append(
+                f"| {result['recipe']['name']} | {target['achieved_epsilon']:.4f} | "
+                f"{target['noise_multiplier']:.4f} | {result['target_test_auc']:.4f} | "
+                f"{group} | {metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} |"
+            )
+        lines.append(
+            f"| **{result['recipe']['name']} Delta** |  |  |  | **max-min** |  | "
+            f"**{result['delta_tpr_at_fpr_0.01']:.4f}** |"
+        )
+
+    deltas = [result["delta_tpr_at_fpr_0.01"] for result in payload["results"]]
+    lines.extend(
+        [
+            "",
+            "## Go/no-go readout",
+            "",
+            f"Delta values: {', '.join(f'{value:.4f}' for value in deltas)}.",
+            f"Absolute between-recipe Delta separation: {abs(deltas[0] - deltas[1]):.4f}.",
+            "",
+            "This spike is directional only: one target seed and a small shadow ensemble. "
+            "A visible separation justifies a powered repeated-seed experiment; a null result "
+            "means the current dataset/attack/config contrast did not resolve the phenomenon.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--shadows", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", default="reports/spike")
+    args = parser.parse_args()
+
+    if args.shadows < 6:
+        raise ValueError("Use at least six shadows; 12 is the intended spike setting.")
+
+    torch.set_num_threads(2)
+    root = Path(__file__).resolve().parents[1]
+    df = pd.read_csv(root / "data" / "insurance.csv")
+    data = prepare_task_data(df, get_task("smoker_without_charges"), random_state=args.seed)
+
+    preprocessor = build_preprocessor(data.X_train)
+    X_train = np.asarray(preprocessor.fit_transform(data.X_train), dtype=np.float32)
+    X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
+
+    payload: dict[str, object] = {
+        "experiment": "two_config_iso_epsilon_subgroup_lira_spike",
+        "target_epsilon": TARGET_EPSILON,
+        "delta": DELTA,
+        "task": data.task.name,
+        "sensitive_attribute": "sex",
+        "seed": args.seed,
+        "results": [],
+    }
+
+    for recipe in RECIPES:
+        print(f"\n=== {recipe.name} ===", flush=True)
+        payload["results"].append(
+            run_recipe(
+                recipe,
+                X_train,
+                data.y_train,
+                X_test,
+                data.y_test,
+                data.sensitive_train,
+                data.sensitive_test,
+                num_shadows=args.shadows,
+                seed=args.seed,
+            )
+        )
+
+    output_dir = root / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "two_config_spike.json"
+    md_path = output_dir / "two_config_spike.md"
+    json_path.write_text(json.dumps(payload, indent=2))
+    md_path.write_text(render_markdown(payload))
+
+    print("\n" + md_path.read_text(), flush=True)
+    print(f"JSON: {json_path}")
+    print(f"Markdown: {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/two_config_spike.py
+++ b/research/two_config_spike.py
@@ -1,13 +1,20 @@
-"""Two-configuration iso-epsilon subgroup-LiRA spike.
+"""Powered two-configuration iso-epsilon subgroup-LiRA spike.
 
-This is deliberately a go/no-go experiment, not a benchmark grid. It trains two
-contrasting DP-SGD recipes at the same target epsilon on the insurance dataset,
-runs offline LiRA, equalises the attack cohort across sex and membership status,
-and reports the subgroup TPR@1% FPR gap Delta.
+This remains a go/no-go experiment rather than a benchmark grid. It corrects the
+first spike by:
+
+* using the learnable ``high_cost`` task;
+* refusing to run an attack when target ROC-AUC is below a hard gate;
+* training every shadow on exactly the target training-set size, so the DP-SGD
+  sampling rate and calibrated noise multiplier match the target;
+* using at least 32 shadows;
+* repeating three target seeds; and
+* reporting stratified-bootstrap confidence intervals for the subgroup
+  TPR@1% FPR gap Delta.
 
 Run from the repository root:
 
-    python research/two_config_spike.py --shadows 12
+    python research/two_config_spike.py --shadows 32 --seeds 42 43 44
 """
 
 from __future__ import annotations
@@ -16,12 +23,13 @@ import argparse
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Sequence
 
 import numpy as np
 import pandas as pd
 import torch
 from opacus import PrivacyEngine
-from sklearn.metrics import roc_auc_score
+from sklearn.metrics import roc_auc_score, roc_curve
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -32,7 +40,13 @@ from dp.tasks import get_task, prepare_task_data
 
 TARGET_EPSILON = 8.0
 DELTA = 1e-5
+TASK_NAME = "high_cost"
 ATTACK_FPRS = (0.001, 0.01, 0.1)
+HARD_AUC_GATE = 0.70
+PREFERRED_AUC = 0.75
+DEFAULT_SEEDS = (42, 43, 44)
+DEFAULT_SHADOWS = 32
+DEFAULT_BOOTSTRAP_REPS = 1000
 
 
 @dataclass(frozen=True)
@@ -62,12 +76,14 @@ RECIPES = (
 
 
 def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+    """Numerically stable per-example binary cross-entropy."""
     prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
     y_true = np.asarray(y_true, dtype=float)
     return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
 
 
 def build_model(n_features: int, hidden_units: int, seed: int) -> nn.Module:
+    """Build the target/shadow architecture."""
     torch.manual_seed(seed)
     return nn.Sequential(
         nn.Linear(n_features, hidden_units),
@@ -136,6 +152,7 @@ def train_private_model(
 
 
 def predict_probability(model: nn.Module, X: np.ndarray) -> np.ndarray:
+    """Return positive-class probabilities."""
     model.eval()
     with torch.no_grad():
         logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
@@ -160,103 +177,232 @@ def make_equalised_attack_cohort(
             cells[(group, member)] = idx
 
     per_cell = min(len(idx) for idx in cells.values())
-    selected = []
+    selected: list[int] = []
     counts: dict[str, int] = {}
     for (group, member), idx in cells.items():
         chosen = rng.choice(idx, size=per_cell, replace=False)
         selected.extend(chosen.tolist())
         counts[f"{group}|member={member}"] = int(per_cell)
 
-    selected_idx = np.asarray(sorted(selected), dtype=int)
-    return selected_idx, counts
+    return np.asarray(sorted(selected), dtype=int), counts
+
+
+def _fixed_size_shadow_indices(
+    y_pool: np.ndarray,
+    train_size: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Sample exactly ``train_size`` rows while retaining both target classes."""
+    if train_size >= len(y_pool):
+        raise ValueError("shadow train_size must be smaller than the shadow pool")
+    for _ in range(1000):
+        idx = rng.choice(len(y_pool), size=train_size, replace=False)
+        if np.unique(y_pool[idx]).size == 2:
+            return np.asarray(idx, dtype=int)
+    raise RuntimeError("could not draw a two-class fixed-size shadow training set")
 
 
 def collect_shadow_out_losses(
-    X_all: np.ndarray,
-    y_all: np.ndarray,
+    X_pool: np.ndarray,
+    y_pool: np.ndarray,
     attack_idx: np.ndarray,
+    target_train_size: int,
+    target_noise_multiplier: float,
     recipe: Recipe,
     num_shadows: int,
     seed: int,
 ) -> tuple[np.ndarray, list[dict[str, float | int | str]], int]:
-    """Train shadows and retain each example's losses only when it was OUT."""
+    """Train size-matched shadows and retain losses when each attack row is OUT."""
     rng = np.random.default_rng(seed)
     out_losses: list[list[float]] = [[] for _ in range(len(attack_idx))]
     metadata: list[dict[str, float | int | str]] = []
 
     for shadow_id in range(num_shadows):
-        mask = rng.random(len(y_all)) < 0.5
-        while np.unique(y_all[mask]).size < 2 or mask.sum() < 2:
-            mask = rng.random(len(y_all)) < 0.5
+        train_idx = _fixed_size_shadow_indices(y_pool, target_train_size, rng)
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
 
         model, meta = train_private_model(
-            X_all[mask],
-            y_all[mask],
+            X_pool[train_idx],
+            y_pool[train_idx],
             recipe,
             seed=seed + shadow_id + 1,
         )
+        if int(meta["train_size"]) != target_train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        if not np.isclose(
+            float(meta["noise_multiplier"]),
+            target_noise_multiplier,
+            rtol=0.0,
+            atol=1e-10,
+        ):
+            raise AssertionError(
+                "size-matched shadow has a different calibrated noise multiplier: "
+                f"target={target_noise_multiplier}, shadow={meta['noise_multiplier']}"
+            )
+
         meta["shadow_id"] = shadow_id
         metadata.append(meta)
 
-        losses = per_example_bce(y_all[attack_idx], predict_probability(model, X_all[attack_idx]))
-        attack_out = ~mask[attack_idx]
+        losses = per_example_bce(
+            y_pool[attack_idx],
+            predict_probability(model, X_pool[attack_idx]),
+        )
+        attack_out = ~in_mask[attack_idx]
         for local_idx in np.flatnonzero(attack_out):
             out_losses[local_idx].append(float(losses[local_idx]))
 
         print(
             f"[{recipe.name}] shadow {shadow_id + 1}/{num_shadows} "
-            f"achieved_eps={meta['achieved_epsilon']:.4f} "
+            f"n={meta['train_size']} achieved_eps={meta['achieved_epsilon']:.4f} "
             f"noise={meta['noise_multiplier']:.4f}",
             flush=True,
         )
 
     min_out = min(len(values) for values in out_losses)
-    if min_out < 2:
+    if min_out < 4:
         raise RuntimeError(
-            f"LiRA needs at least two OUT shadows per example; minimum was {min_out}. "
+            f"LiRA needs a usable OUT distribution; minimum was {min_out}. "
             "Increase --shadows."
         )
     matrix = np.vstack([np.asarray(values[:min_out], dtype=float) for values in out_losses])
     return matrix, metadata, min_out
 
 
-def run_recipe(
+def tpr_at_fpr(membership: np.ndarray, scores: np.ndarray, target_fpr: float) -> float:
+    """Highest TPR attainable without exceeding ``target_fpr``."""
+    fpr, tpr, _ = roc_curve(membership, scores)
+    allowed = fpr <= target_fpr
+    return float(tpr[allowed].max()) if allowed.any() else 0.0
+
+
+def stratified_bootstrap_delta(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    scores: np.ndarray,
+    target_fpr: float,
+    reps: int,
+    seed: int,
+) -> dict[str, float | int]:
+    """Bootstrap Delta while preserving every group x membership cell size."""
+    rng = np.random.default_rng(seed)
+    groups = groups.astype(str)
+    unique_groups = sorted(np.unique(groups))
+    cells = {
+        (group, member): np.flatnonzero((groups == group) & (membership == member))
+        for group in unique_groups
+        for member in (0, 1)
+    }
+    if any(len(idx) == 0 for idx in cells.values()):
+        raise RuntimeError("bootstrap requires non-empty group x membership cells")
+
+    deltas = np.empty(reps, dtype=float)
+    for rep in range(reps):
+        group_tprs = []
+        for group in unique_groups:
+            member_idx = rng.choice(
+                cells[(group, 1)], size=len(cells[(group, 1)]), replace=True
+            )
+            nonmember_idx = rng.choice(
+                cells[(group, 0)], size=len(cells[(group, 0)]), replace=True
+            )
+            idx = np.concatenate([member_idx, nonmember_idx])
+            group_tprs.append(tpr_at_fpr(membership[idx], scores[idx], target_fpr))
+        deltas[rep] = max(group_tprs) - min(group_tprs)
+
+    low, high = np.percentile(deltas, [2.5, 97.5])
+    return {
+        "reps": int(reps),
+        "mean": float(deltas.mean()),
+        "median": float(np.median(deltas)),
+        "ci95_low": float(low),
+        "ci95_high": float(high),
+    }
+
+
+def run_recipe_seed(
     recipe: Recipe,
     X_train: np.ndarray,
     y_train: np.ndarray,
+    X_val: np.ndarray,
+    y_val: np.ndarray,
     X_test: np.ndarray,
     y_test: np.ndarray,
     groups_train: np.ndarray,
     groups_test: np.ndarray,
     num_shadows: int,
+    bootstrap_reps: int,
+    auc_gate: float,
     seed: int,
 ) -> dict[str, object]:
-    X_all = np.vstack([X_train, X_test])
-    y_all = np.concatenate([y_train, y_test])
-    groups_all = np.concatenate([groups_train, groups_test]).astype(str)
+    """Run one recipe/target-seed cell, with an AUC gate before shadow training."""
+    X_attack = np.vstack([X_train, X_test])
+    y_attack = np.concatenate([y_train, y_test])
+    groups_attack = np.concatenate([groups_train, groups_test]).astype(str)
     membership = np.concatenate(
         [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
     )
-
-    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_all, membership, seed)
+    attack_idx, cohort_counts = make_equalised_attack_cohort(
+        groups_attack, membership, seed
+    )
 
     target, target_meta = train_private_model(X_train, y_train, recipe, seed=seed)
-    target_prob_all = predict_probability(target, X_all)
-    target_losses = per_example_bce(y_all[attack_idx], target_prob_all[attack_idx])
-    target_test_auc = float(roc_auc_score(y_test, target_prob_all[len(y_train) :]))
+    target_test_prob = predict_probability(target, X_test)
+    target_test_auc = float(roc_auc_score(y_test, target_test_prob))
+    preferred_auc_met = target_test_auc >= PREFERRED_AUC
 
+    base_result: dict[str, object] = {
+        "seed": int(seed),
+        "recipe": asdict(recipe),
+        "target": target_meta,
+        "target_test_auc": target_test_auc,
+        "auc_gate": float(auc_gate),
+        "preferred_auc": PREFERRED_AUC,
+        "preferred_auc_met": preferred_auc_met,
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "attack_status": "pending",
+    }
+
+    print(
+        f"[{recipe.name} seed={seed}] target AUC={target_test_auc:.4f} "
+        f"(gate={auc_gate:.2f}, preferred={PREFERRED_AUC:.2f})",
+        flush=True,
+    )
+    if target_test_auc < auc_gate:
+        base_result["attack_status"] = "skipped_target_auc_below_gate"
+        base_result["subgroups"] = {}
+        base_result["delta_tpr_at_fpr_0.01"] = None
+        base_result["bootstrap_delta"] = None
+        return base_result
+
+    X_pool = np.vstack([X_train, X_val, X_test])
+    y_pool = np.concatenate([y_train, y_val, y_test])
+
+    attack_pool_idx = attack_idx.copy()
+    train_n = len(y_train)
+    attack_pool_idx[attack_pool_idx >= train_n] += len(y_val)
+
+    target_prob_attack = predict_probability(target, X_attack)
+    target_losses = per_example_bce(
+        y_attack[attack_idx], target_prob_attack[attack_idx]
+    )
     shadow_out, shadow_meta, min_out = collect_shadow_out_losses(
-        X_all,
-        y_all,
-        attack_idx,
-        recipe,
+        X_pool,
+        y_pool,
+        attack_pool_idx,
+        target_train_size=len(y_train),
+        target_noise_multiplier=float(target_meta["noise_multiplier"]),
+        recipe=recipe,
         num_shadows=num_shadows,
         seed=seed + 10_000,
     )
 
-    subgroup_results: dict[str, dict[str, float | int]] = {}
-    attack_groups = groups_all[attack_idx]
+    attack_groups = groups_attack[attack_idx]
     attack_membership = membership[attack_idx]
+    subgroup_results: dict[str, dict[str, float | int]] = {}
+    all_scores = np.empty(len(attack_idx), dtype=float)
+
     for group in sorted(np.unique(attack_groups)):
         group_mask = attack_groups == group
         result = lira_offline_attack(
@@ -265,9 +411,11 @@ def run_recipe(
             shadow_out[group_mask],
             fprs=ATTACK_FPRS,
         )
+        all_scores[group_mask] = result.scores
         subgroup_results[str(group)] = {
             "n": int(group_mask.sum()),
             "members": int(attack_membership[group_mask].sum()),
+            "nonmembers": int((attack_membership[group_mask] == 0).sum()),
             "auc": float(result.auc),
             "tpr_at_fpr_0.001": float(result.tpr_at_fpr[0.001]),
             "tpr_at_fpr_0.01": float(result.tpr_at_fpr[0.01]),
@@ -275,58 +423,148 @@ def run_recipe(
         }
 
     tprs = [metrics["tpr_at_fpr_0.01"] for metrics in subgroup_results.values()]
-    delta_tpr_1pct = float(max(tprs) - min(tprs))
+    observed_delta = float(max(tprs) - min(tprs))
+    bootstrap = stratified_bootstrap_delta(
+        attack_groups,
+        attack_membership,
+        all_scores,
+        target_fpr=0.01,
+        reps=bootstrap_reps,
+        seed=seed + 20_000,
+    )
 
-    return {
+    base_result.update(
+        {
+            "attack_status": "completed",
+            "num_shadows": int(num_shadows),
+            "min_out_shadow_losses_per_example": int(min_out),
+            "subgroups": subgroup_results,
+            "delta_tpr_at_fpr_0.01": observed_delta,
+            "bootstrap_delta": bootstrap,
+            "shadow_train_size": int(len(y_train)),
+            "shadow_metadata": shadow_meta,
+        }
+    )
+    return base_result
+
+
+def summarize_recipe(recipe: Recipe, seed_results: Sequence[dict[str, object]]) -> dict[str, object]:
+    """Aggregate completed target seeds without hiding skipped cells."""
+    completed = [
+        result for result in seed_results if result["attack_status"] == "completed"
+    ]
+    deltas = np.asarray(
+        [result["delta_tpr_at_fpr_0.01"] for result in completed], dtype=float
+    )
+    aucs = np.asarray([result["target_test_auc"] for result in seed_results], dtype=float)
+    summary: dict[str, object] = {
         "recipe": asdict(recipe),
-        "target": target_meta,
-        "target_test_auc": target_test_auc,
-        "cohort_counts": cohort_counts,
-        "num_attack_examples": int(len(attack_idx)),
-        "num_shadows": int(num_shadows),
-        "min_out_shadow_losses_per_example": int(min_out),
-        "subgroups": subgroup_results,
-        "delta_tpr_at_fpr_0.01": delta_tpr_1pct,
-        "shadow_metadata": shadow_meta,
+        "target_seeds": int(len(seed_results)),
+        "completed_attacks": int(len(completed)),
+        "skipped_attacks": int(len(seed_results) - len(completed)),
+        "target_auc_mean": float(aucs.mean()),
+        "target_auc_min": float(aucs.min()),
+        "target_auc_max": float(aucs.max()),
     }
+    if len(deltas):
+        summary.update(
+            {
+                "delta_mean": float(deltas.mean()),
+                "delta_median": float(np.median(deltas)),
+                "delta_min": float(deltas.min()),
+                "delta_max": float(deltas.max()),
+            }
+        )
+    else:
+        summary.update(
+            {
+                "delta_mean": None,
+                "delta_median": None,
+                "delta_min": None,
+                "delta_max": None,
+            }
+        )
+    return summary
 
 
 def render_markdown(payload: dict[str, object]) -> str:
+    """Render an examiner-readable result summary."""
     lines = [
-        "# Two-configuration iso-epsilon subgroup-LiRA spike",
+        "# Powered two-configuration iso-epsilon subgroup-LiRA spike",
         "",
+        f"Task: `{payload['task']}`.",
         f"Target privacy: epsilon={TARGET_EPSILON}, delta={DELTA}.",
+        f"Hard attack gate: target test ROC-AUC >= {payload['auc_gate']:.2f}.",
+        f"Preferred target quality: ROC-AUC >= {PREFERRED_AUC:.2f}.",
+        (
+            "Shadows are trained on exactly the target training-set size, with the "
+            "same recipe, accountant, epsilon and delta."
+        ),
         "Attack cohort: equal counts in every sex x membership cell.",
         "Headline metric: subgroup offline-LiRA TPR at 1% FPR and max-min gap Delta.",
         "",
-        "| Recipe | Achieved epsilon | Noise multiplier | Test ROC-AUC | Group | LiRA AUC | TPR@1% FPR |",
-        "|---|---:|---:|---:|---|---:|---:|",
+        "| Recipe | Seed | Achieved epsilon | Noise | Test AUC | Attack | Group | LiRA AUC | TPR@1% | Delta | Bootstrap 95% CI |",
+        "|---|---:|---:|---:|---:|---|---|---:|---:|---:|---|",
     ]
-    for result in payload["results"]:
-        target = result["target"]
-        for group, metrics in result["subgroups"].items():
-            lines.append(
-                f"| {result['recipe']['name']} | {target['achieved_epsilon']:.4f} | "
-                f"{target['noise_multiplier']:.4f} | {result['target_test_auc']:.4f} | "
-                f"{group} | {metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} |"
-            )
-        lines.append(
-            f"| **{result['recipe']['name']} Delta** |  |  |  | **max-min** |  | "
-            f"**{result['delta_tpr_at_fpr_0.01']:.4f}** |"
-        )
 
-    deltas = [result["delta_tpr_at_fpr_0.01"] for result in payload["results"]]
+    for result in payload["seed_results"]:
+        target = result["target"]
+        if result["attack_status"] != "completed":
+            lines.append(
+                f"| {result['recipe']['name']} | {result['seed']} | "
+                f"{target['achieved_epsilon']:.4f} | {target['noise_multiplier']:.4f} | "
+                f"{result['target_test_auc']:.4f} | **SKIPPED: AUC gate** | - | - | - | - | - |"
+            )
+            continue
+
+        bootstrap = result["bootstrap_delta"]
+        ci = f"[{bootstrap['ci95_low']:.4f}, {bootstrap['ci95_high']:.4f}]"
+        first = True
+        for group, metrics in result["subgroups"].items():
+            delta = f"{result['delta_tpr_at_fpr_0.01']:.4f}" if first else ""
+            ci_cell = ci if first else ""
+            lines.append(
+                f"| {result['recipe']['name']} | {result['seed']} | "
+                f"{target['achieved_epsilon']:.4f} | {target['noise_multiplier']:.4f} | "
+                f"{result['target_test_auc']:.4f} | completed | {group} | "
+                f"{metrics['auc']:.4f} | {metrics['tpr_at_fpr_0.01']:.4f} | "
+                f"{delta} | {ci_cell} |"
+            )
+            first = False
+
     lines.extend(
         [
             "",
-            "## Go/no-go readout",
+            "## Across-seed summary",
             "",
-            f"Delta values: {', '.join(f'{value:.4f}' for value in deltas)}.",
-            f"Absolute between-recipe Delta separation: {abs(deltas[0] - deltas[1]):.4f}.",
+            "| Recipe | Seeds | Attacks completed | Mean target AUC | Min target AUC | Mean Delta | Delta range |",
+            "|---|---:|---:|---:|---:|---:|---|",
+        ]
+    )
+    for summary in payload["recipe_summaries"]:
+        mean_delta = (
+            "-" if summary["delta_mean"] is None else f"{summary['delta_mean']:.4f}"
+        )
+        delta_range = (
+            "-"
+            if summary["delta_min"] is None
+            else f"[{summary['delta_min']:.4f}, {summary['delta_max']:.4f}]"
+        )
+        lines.append(
+            f"| {summary['recipe']['name']} | {summary['target_seeds']} | "
+            f"{summary['completed_attacks']} | {summary['target_auc_mean']:.4f} | "
+            f"{summary['target_auc_min']:.4f} | {mean_delta} | {delta_range} |"
+        )
+
+    lines.extend(
+        [
             "",
-            "This spike is directional only: one target seed and a small shadow ensemble. "
-            "A visible separation justifies a powered repeated-seed experiment; a null result "
-            "means the current dataset/attack/config contrast did not resolve the phenomenon.",
+            "## Interpretation rule",
+            "",
+            "A non-zero point estimate is not called a signal when its bootstrap interval "
+            "includes zero or when it is driven by a single seed. The experiment only "
+            "supports expansion when target models learn the task and the subgroup gap "
+            "is stable across seeds.",
         ]
     )
     return "\n".join(lines) + "\n"
@@ -334,47 +572,73 @@ def render_markdown(payload: dict[str, object]) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--shadows", type=int, default=12)
-    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--shadows", type=int, default=DEFAULT_SHADOWS)
+    parser.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
+    parser.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
+    parser.add_argument("--auc-gate", type=float, default=HARD_AUC_GATE)
     parser.add_argument("--output-dir", default="reports/spike")
     args = parser.parse_args()
 
-    if args.shadows < 6:
-        raise ValueError("Use at least six shadows; 12 is the intended spike setting.")
+    if args.shadows < DEFAULT_SHADOWS:
+        raise ValueError(f"Use at least {DEFAULT_SHADOWS} shadows.")
+    if len(args.seeds) < 3:
+        raise ValueError("Use at least three target seeds.")
+    if args.bootstrap_reps < 200:
+        raise ValueError("Use at least 200 bootstrap replicates.")
+    if not (0.5 <= args.auc_gate <= 1.0):
+        raise ValueError("--auc-gate must be in [0.5, 1.0]")
 
     torch.set_num_threads(2)
     root = Path(__file__).resolve().parents[1]
     df = pd.read_csv(root / "data" / "insurance.csv")
-    data = prepare_task_data(df, get_task("smoker_without_charges"), random_state=args.seed)
-
-    preprocessor = build_preprocessor(data.X_train)
-    X_train = np.asarray(preprocessor.fit_transform(data.X_train), dtype=np.float32)
-    X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
 
     payload: dict[str, object] = {
-        "experiment": "two_config_iso_epsilon_subgroup_lira_spike",
+        "experiment": "powered_two_config_iso_epsilon_subgroup_lira_spike",
         "target_epsilon": TARGET_EPSILON,
         "delta": DELTA,
-        "task": data.task.name,
+        "task": TASK_NAME,
         "sensitive_attribute": "sex",
-        "seed": args.seed,
-        "results": [],
+        "auc_gate": float(args.auc_gate),
+        "preferred_auc": PREFERRED_AUC,
+        "seeds": [int(seed) for seed in args.seeds],
+        "num_shadows": int(args.shadows),
+        "bootstrap_reps": int(args.bootstrap_reps),
+        "seed_results": [],
+        "recipe_summaries": [],
     }
 
     for recipe in RECIPES:
-        print(f"\n=== {recipe.name} ===", flush=True)
-        payload["results"].append(
-            run_recipe(
+        recipe_seed_results = []
+        for seed in args.seeds:
+            print(f"\n=== {recipe.name} | target seed {seed} ===", flush=True)
+            data = prepare_task_data(df, get_task(TASK_NAME), random_state=seed)
+            preprocessor = build_preprocessor(data.X_train)
+            X_train = np.asarray(
+                preprocessor.fit_transform(data.X_train), dtype=np.float32
+            )
+            X_val = np.asarray(preprocessor.transform(data.X_val), dtype=np.float32)
+            X_test = np.asarray(preprocessor.transform(data.X_test), dtype=np.float32)
+
+            result = run_recipe_seed(
                 recipe,
                 X_train,
                 data.y_train,
+                X_val,
+                data.y_val,
                 X_test,
                 data.y_test,
                 data.sensitive_train,
                 data.sensitive_test,
                 num_shadows=args.shadows,
-                seed=args.seed,
+                bootstrap_reps=args.bootstrap_reps,
+                auc_gate=args.auc_gate,
+                seed=seed,
             )
+            recipe_seed_results.append(result)
+            payload["seed_results"].append(result)
+
+        payload["recipe_summaries"].append(
+            summarize_recipe(recipe, recipe_seed_results)
         )
 
     output_dir = root / args.output_dir

--- a/tests/test_attack_power_control.py
+++ b/tests/test_attack_power_control.py
@@ -1,0 +1,371 @@
+"""Unit tests for the attack-power control experiment.
+
+These exercise the pure logic only -- schedules, cohorts, gates, bootstrap and
+report rendering. Training shadow models is far too expensive for the unit
+suite, so the one end-to-end check is marked ``slow``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "attack_power_control", ROOT / "research" / "attack_power_control.py"
+)
+apc = importlib.util.module_from_spec(_SPEC)
+sys.modules["attack_power_control"] = apc
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(apc)
+
+
+# --------------------------------------------------------------------------- #
+# Shadow schedules
+# --------------------------------------------------------------------------- #
+
+
+def test_balanced_schedule_uses_exact_train_size():
+    y_pool = np.tile([0, 1], 150)
+    train_sets, _ = apc.balanced_shadow_train_sets(y_pool, train_size=200, num_shadows=16, seed=0)
+    assert len(train_sets) == 16
+    assert all(len(idx) == 200 for idx in train_sets)
+    assert all(len(np.unique(idx)) == 200 for idx in train_sets)
+
+
+def test_balanced_schedule_gives_every_example_in_and_out_coverage():
+    y_pool = np.tile([0, 1], 150)
+    n = len(y_pool)
+    num_shadows = 32
+    train_sets, excluded_counts = apc.balanced_shadow_train_sets(
+        y_pool, train_size=200, num_shadows=num_shadows, seed=7
+    )
+    in_counts = np.zeros(n, dtype=int)
+    for idx in train_sets:
+        in_counts[idx] += 1
+
+    assert np.array_equal(in_counts + excluded_counts, np.full(n, num_shadows))
+    assert excluded_counts.min() >= apc.MIN_GAUSSIAN_OBSERVATIONS
+    assert in_counts.min() >= apc.MIN_GAUSSIAN_OBSERVATIONS
+    # Coverage is balanced, not merely non-zero.
+    assert excluded_counts.max() - excluded_counts.min() <= 1
+
+
+def test_balanced_schedule_rejects_oversized_train_set():
+    y_pool = np.tile([0, 1], 10)
+    with pytest.raises(ValueError):
+        apc.balanced_shadow_train_sets(y_pool, train_size=20, num_shadows=4, seed=0)
+
+
+# --------------------------------------------------------------------------- #
+# Equalised cohorts
+# --------------------------------------------------------------------------- #
+
+
+def test_equalised_cohort_cells_are_equal_sized():
+    rng = np.random.default_rng(0)
+    groups = np.array(["female"] * 120 + ["male"] * 80)
+    membership = np.concatenate(
+        [
+            rng.permutation(np.array([1] * 90 + [0] * 30)),
+            rng.permutation(np.array([1] * 50 + [0] * 30)),
+        ]
+    )
+    idx, counts = apc.make_equalised_attack_cohort(groups, membership, seed=1)
+
+    assert len(set(counts.values())) == 1
+    per_cell = next(iter(counts.values()))
+    assert len(idx) == 4 * per_cell
+    for group in ("female", "male"):
+        for member in (0, 1):
+            mask = (groups[idx] == group) & (membership[idx] == member)
+            assert int(mask.sum()) == per_cell
+
+
+def test_equalised_cohort_rejects_empty_cell():
+    groups = np.array(["female"] * 4 + ["male"] * 4)
+    membership = np.array([1, 1, 1, 1, 1, 1, 1, 1])
+    with pytest.raises(RuntimeError):
+        apc.make_equalised_attack_cohort(groups, membership, seed=0)
+
+
+# --------------------------------------------------------------------------- #
+# Memorisation gate
+# --------------------------------------------------------------------------- #
+
+
+def test_memorisation_metrics_report_a_generalisation_gap():
+    y_train = np.array([0, 1, 0, 1])
+    y_test = np.array([0, 1, 0, 1])
+    train_prob = np.array([0.01, 0.99, 0.02, 0.98])  # memorised
+    test_prob = np.array([0.45, 0.55, 0.60, 0.40])  # barely better than chance
+    metrics = apc.memorisation_metrics(y_train, train_prob, y_test, test_prob)
+
+    assert metrics["train_auc"] == pytest.approx(1.0)
+    assert metrics["loss_gap"] > 0.5
+    assert metrics["auc_gap"] > 0.0
+    assert metrics["accuracy_gap"] > 0.0
+    assert apc.memorisation_gate_passed(metrics)
+
+
+@pytest.mark.parametrize(
+    ("auc_gap", "loss_gap", "acc_gap", "expected"),
+    [
+        (0.05, 0.0, 0.0, True),
+        (0.0, 0.05, 0.0, True),
+        (0.0, 0.0, 0.05, True),
+        (0.03, 0.0, 0.0, True),  # boundary is inclusive
+        (0.029, 0.029, 0.029, False),
+        (-0.2, -0.2, -0.2, False),
+    ],
+)
+def test_memorisation_gate_logic(auc_gap, loss_gap, acc_gap, expected):
+    metrics = {"auc_gap": auc_gap, "loss_gap": loss_gap, "accuracy_gap": acc_gap}
+    assert apc.memorisation_gate_passed(metrics) is expected
+
+
+# --------------------------------------------------------------------------- #
+# Subgroup gaps
+# --------------------------------------------------------------------------- #
+
+
+def test_signed_difference_is_male_minus_female():
+    assert apc.signed_subgroup_difference({"female": 0.10, "male": 0.25}) == pytest.approx(0.15)
+    assert apc.signed_subgroup_difference({"female": 0.30, "male": 0.05}) == pytest.approx(-0.25)
+
+
+def test_absolute_gap_is_max_minus_min():
+    assert apc.absolute_subgroup_gap({"female": 0.10, "male": 0.25}) == pytest.approx(0.15)
+    assert apc.absolute_subgroup_gap({"female": 0.30, "male": 0.05}) == pytest.approx(0.25)
+    assert apc.absolute_subgroup_gap({"female": 0.2, "male": 0.2}) == pytest.approx(0.0)
+
+
+def test_operating_point_counts_are_consistent():
+    membership = np.array([1] * 50 + [0] * 50)
+    scores = np.concatenate([np.linspace(1.0, 2.0, 50), np.linspace(-2.0, -1.0, 50)])
+    counts = apc.operating_point_counts(membership, scores, 0.01)
+    assert counts["n_members"] == 50
+    assert counts["n_nonmembers"] == 50
+    assert counts["detected_members"] == 50  # perfectly separable
+    assert counts["false_positives"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Bootstrap
+# --------------------------------------------------------------------------- #
+
+
+def _toy_cohort(seed: int = 0, signal: float = 1.0):
+    rng = np.random.default_rng(seed)
+    groups = np.array(["female"] * 100 + ["male"] * 100)
+    membership = np.tile(np.array([1] * 50 + [0] * 50), 2)
+    scores = rng.normal(size=200) + signal * membership
+    return groups, membership, scores
+
+
+def test_bootstrap_returns_finite_ordered_intervals():
+    groups, membership, scores = _toy_cohort()
+    summary = apc.stratified_bootstrap(groups, membership, scores, reps=200, seed=3)
+
+    for key in ("aggregate", "female", "male", "signed_difference", "absolute_gap"):
+        entry = summary[key]
+        assert np.isfinite(entry["ci95_low"])
+        assert np.isfinite(entry["ci95_high"])
+        assert entry["ci95_low"] <= entry["mean"] <= entry["ci95_high"]
+        assert entry["reps"] == 200
+    assert summary["absolute_gap"]["ci95_low"] >= 0.0
+
+
+def test_bootstrap_rejects_missing_cells():
+    groups = np.array(["female"] * 10 + ["male"] * 10)
+    membership = np.ones(20, dtype=int)
+    with pytest.raises(RuntimeError):
+        apc.stratified_bootstrap(groups, membership, np.zeros(20), reps=10, seed=0)
+
+
+def test_attack_metrics_shape_and_keys():
+    groups, membership, scores = _toy_cohort(signal=2.0)
+    metrics = apc.attack_metrics(membership, groups, scores, bootstrap_reps=100, seed=0)
+
+    assert metrics["aggregate"]["auc"] > 0.5
+    for fpr in apc.ATTACK_FPRS:
+        assert f"tpr_at_fpr_{fpr}" in metrics["aggregate"]
+    assert set(metrics["subgroups"]) == {"female", "male"}
+    assert np.isfinite(metrics["signed_subgroup_difference"])
+    assert metrics["absolute_subgroup_gap"] >= 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Decision table and reporting
+# --------------------------------------------------------------------------- #
+
+
+def _seed_result(control, seed, *, gate=True, status="completed", auc=0.5, ci_low=0.0):
+    groups, membership, scores = _toy_cohort(seed=seed)
+    metrics = (
+        apc.attack_metrics(membership, groups, scores, bootstrap_reps=50, seed=seed)
+        if status == "completed"
+        else None
+    )
+    if metrics is not None:
+        metrics["aggregate"]["auc"] = auc
+        metrics["bootstrap"]["aggregate"]["ci95_low"] = ci_low
+    return {
+        "control": control.name,
+        "kind": control.kind,
+        "architecture": control.architecture(),
+        "positive_control": control.positive_control,
+        "seed": seed,
+        "train_size": 856,
+        "val_size": 214,
+        "test_size": 268,
+        "cohort_counts": {"female|member=0": 60, "male|member=0": 60},
+        "num_attack_examples": 240,
+        "memorisation": {
+            "train_auc": 1.0,
+            "test_auc": 0.85,
+            "train_loss": 0.05,
+            "test_loss": 0.60,
+            "train_accuracy": 1.0,
+            "test_accuracy": 0.80,
+            "auc_gap": 0.15 if gate else 0.0,
+            "loss_gap": 0.55 if gate else 0.0,
+            "accuracy_gap": 0.20 if gate else 0.0,
+        },
+        "memorisation_gate": apc.MEMORISATION_GATE,
+        "memorisation_gate_passed": gate,
+        "attack_status": status,
+        "num_shadows": 32,
+        "min_out_observations": 11,
+        "min_in_observations": 21,
+        "offline": metrics,
+        "online": None,
+        "online_available": False,
+        "online_unavailable_reason": "test fixture",
+    }
+
+
+def test_classify_control_detects_leakage():
+    control = apc.CONTROLS[1]
+    results = [_seed_result(control, seed, auc=0.72, ci_low=0.08) for seed in (42, 43, 44)]
+    verdict, basis = apc.classify_control(control, results)
+    assert verdict == apc.DETECTS
+    assert basis
+
+
+def test_classify_control_fails_positive_control():
+    control = apc.CONTROLS[1]
+    results = [_seed_result(control, seed, auc=0.505, ci_low=0.0) for seed in (42, 43, 44)]
+    verdict, _ = apc.classify_control(control, results)
+    assert verdict == apc.FAILS_POSITIVE_CONTROL
+
+
+def test_classify_control_inconclusive_without_memorisation():
+    control = apc.CONTROLS[0]
+    results = [
+        _seed_result(control, seed, gate=False, status="skipped_memorisation_gate")
+        for seed in (42, 43, 44)
+    ]
+    verdict, basis = apc.classify_control(control, results)
+    assert verdict == apc.INCONCLUSIVE
+    assert "memorisation gate" in basis
+
+
+def test_classify_control_does_not_fail_non_positive_control():
+    control = apc.CONTROLS[0]
+    results = [_seed_result(control, seed, auc=0.505) for seed in (42, 43, 44)]
+    verdict, _ = apc.classify_control(control, results)
+    assert verdict == apc.INCONCLUSIVE
+
+
+def _payload(seed_results, decisions):
+    return {
+        "experiment": "attack_power_control",
+        "task": apc.TASK_NAME,
+        "sensitive_attribute": apc.SENSITIVE_ATTRIBUTE,
+        "seeds": [42, 43, 44],
+        "num_shadows": 32,
+        "bootstrap_reps": 1000,
+        "controls": [
+            {**dataclasses.asdict(apc.CONTROLS[0]), "architecture": apc.CONTROLS[0].architecture()}
+        ],
+        "seed_results": seed_results,
+        "decisions": decisions,
+    }
+
+
+def test_report_generator_handles_skipped_attacks():
+    control = apc.CONTROLS[0]
+    seed_results = [
+        _seed_result(control, seed, gate=False, status="skipped_memorisation_gate")
+        for seed in (42, 43, 44)
+    ]
+    decisions = [
+        {
+            "control": control.name,
+            "positive_control": control.positive_control,
+            "seeds_attacked": 0,
+            "mean_auc_gap": 0.0,
+            "mean_lira_auc": None,
+            "verdict": apc.INCONCLUSIVE,
+            "basis": "gate never passed",
+        }
+    ]
+    markdown = apc.render_markdown(_payload(seed_results, decisions))
+
+    assert "SKIPPED" in markdown
+    assert apc.INCONCLUSIVE in markdown
+    assert "Go/no-go" in markdown
+    rows = apc.build_rows(_payload(seed_results, decisions))
+    assert len(rows) == 3
+    assert all(row["attack_status"] == "skipped_memorisation_gate" for row in rows)
+
+
+def test_report_states_no_go_when_positive_control_fails():
+    control = apc.CONTROLS[1]
+    seed_results = [_seed_result(control, seed, auc=0.501) for seed in (42, 43, 44)]
+    decisions = [
+        {
+            "control": control.name,
+            "positive_control": True,
+            "seeds_attacked": 3,
+            "mean_auc_gap": 0.15,
+            "mean_lira_auc": 0.501,
+            "verdict": apc.FAILS_POSITIVE_CONTROL,
+            "basis": "clear gap, chance attack",
+        }
+    ]
+    markdown = apc.render_markdown(_payload(seed_results, decisions))
+
+    assert "Natural membership leakage is not reliably measurable" in markdown
+    assert "NO-GO" in markdown
+    rows = apc.build_rows(_payload(seed_results, decisions))
+    assert {row["attack"] for row in rows} == {"lira-offline"}
+
+
+@pytest.mark.slow
+def test_end_to_end_smoke_on_matched_capacity_control(tmp_path):
+    pytest.importorskip("torch")
+    apc.main(
+        [
+            "--shadows",
+            "32",
+            "--seeds",
+            "42",
+            "43",
+            "44",
+            "--bootstrap-reps",
+            "200",
+            "--controls",
+            "matched_capacity_mlp",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+    assert (tmp_path / "attack_power_control.json").exists()
+    assert (tmp_path / "attack_power_control.md").exists()

--- a/tests/test_attack_power_control.py
+++ b/tests/test_attack_power_control.py
@@ -190,7 +190,9 @@ def test_bootstrap_rejects_missing_cells():
 
 def test_attack_metrics_shape_and_keys():
     groups, membership, scores = _toy_cohort(signal=2.0)
-    metrics = apc.attack_metrics(membership, groups, scores, bootstrap_reps=100, seed=0)
+    metrics = apc.attack_metrics(
+        membership, groups, scores, bootstrap_reps=100, seed=0, permutation_reps=50
+    )
 
     assert metrics["aggregate"]["auc"] > 0.5
     for fpr in apc.ATTACK_FPRS:
@@ -200,21 +202,230 @@ def test_attack_metrics_shape_and_keys():
     assert metrics["absolute_subgroup_gap"] >= 0.0
 
 
+
+# --------------------------------------------------------------------------- #
+# Permutation null
+# --------------------------------------------------------------------------- #
+
+
+def _separated_cohort(members_per_group=50, separation=5.0, female_boost=0.0):
+    """Deterministic cohort: members score higher, optionally more so for one sex."""
+    groups = np.array(["female"] * (2 * members_per_group) + ["male"] * (2 * members_per_group))
+    membership = np.tile(np.array([1] * members_per_group + [0] * members_per_group), 2)
+    base = np.tile(np.linspace(0.0, 1.0, members_per_group), 4)
+    scores = base + separation * membership
+    scores[: 2 * members_per_group] += female_boost * membership[: 2 * members_per_group]
+    return groups, membership, scores
+
+
+def test_permutation_preserves_group_member_counts():
+    groups, membership, scores = _separated_cohort()
+    observed_counts = {
+        group: (
+            int((membership[groups == group] == 1).sum()),
+            int((membership[groups == group] == 0).sum()),
+        )
+        for group in ("female", "male")
+    }
+
+    # Reproduce the internal shuffle and assert the invariant it relies on.
+    rng = np.random.default_rng(0)
+    group_idx = {group: np.flatnonzero(groups == group) for group in ("female", "male")}
+    for _ in range(20):
+        permuted = membership.copy()
+        for idx in group_idx.values():
+            permuted[idx] = rng.permutation(membership[idx])
+        for group, idx in group_idx.items():
+            assert (
+                int((permuted[idx] == 1).sum()),
+                int((permuted[idx] == 0).sum()),
+            ) == observed_counts[group]
+        assert permuted.sum() == membership.sum()
+
+
+def test_permutation_null_is_not_significant_for_identical_distributions():
+    # Scores carry no membership information at all.
+    groups = np.array(["female"] * 100 + ["male"] * 100)
+    membership = np.tile(np.array([1] * 50 + [0] * 50), 2)
+    scores = np.tile(np.linspace(0.0, 1.0, 50), 4)
+
+    summary = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=200, seed=0
+    )
+    assert summary["aggregate_auc"]["p_value"] > apc.ALPHA
+    assert summary["aggregate_tpr"]["p_value"] > apc.ALPHA
+    assert summary["signed_difference"]["p_value"] > apc.ALPHA
+    assert summary["aggregate_auc"]["observed"] == pytest.approx(0.5, abs=0.05)
+
+
+def test_permutation_null_is_significant_for_separated_scores():
+    groups, membership, scores = _separated_cohort(separation=10.0)
+    summary = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=200, seed=0
+    )
+    assert summary["aggregate_auc"]["observed"] == pytest.approx(1.0)
+    assert summary["aggregate_auc"]["p_value"] < apc.ALPHA
+    assert summary["aggregate_tpr"]["p_value"] < apc.ALPHA
+    assert summary["aggregate_auc"]["null_mean"] == pytest.approx(0.5, abs=0.05)
+
+
+def test_reversing_group_advantage_reverses_signed_difference():
+    groups, membership, scores = _separated_cohort(separation=1.0, female_boost=10.0)
+    female_favoured = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=100, seed=0
+    )
+    # Swapping the labels swaps which group carries the advantage.
+    swapped_groups = np.where(groups == "female", "male", "female")
+    male_favoured = apc.stratified_membership_permutation_test(
+        swapped_groups, membership, scores, reps=100, seed=0
+    )
+
+    assert female_favoured["signed_difference"]["observed"] < 0
+    assert male_favoured["signed_difference"]["observed"] > 0
+    assert female_favoured["signed_difference"]["observed"] == pytest.approx(
+        -male_favoured["signed_difference"]["observed"]
+    )
+    assert female_favoured["absolute_gap"]["observed"] == pytest.approx(
+        male_favoured["absolute_gap"]["observed"]
+    )
+
+
+def test_permutation_results_are_reproducible_for_a_fixed_seed():
+    groups, membership, scores = _separated_cohort(separation=2.0)
+    first = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=100, seed=11
+    )
+    second = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=100, seed=11
+    )
+    different = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=100, seed=12
+    )
+
+    assert first == second
+    assert different["aggregate_auc"]["observed"] == first["aggregate_auc"]["observed"]
+
+
+@pytest.mark.parametrize("separation", [0.0, 0.5, 10.0])
+def test_p_values_stay_in_the_attainable_range(separation):
+    groups, membership, scores = _separated_cohort(separation=separation)
+    reps = 100
+    summary = apc.stratified_membership_permutation_test(
+        groups, membership, scores, reps=reps, seed=5
+    )
+    floor = 1.0 / (reps + 1)
+    for entry in summary.values():
+        assert floor <= entry["p_value"] <= 1.0
+        assert entry["reps"] == reps
+
+
+def test_permutation_pvalue_correction_and_alternatives():
+    null = np.array([-3.0, -1.0, 0.0, 1.0, 3.0])
+    # One-sided: two draws are >= 1.0, so (1 + 2) / (5 + 1).
+    assert apc._permutation_pvalue(1.0, null, "greater") == pytest.approx(3 / 6)
+    # Two-sided compares absolute values: |-3|, |3| and |1| and |-1| are >= 1.
+    assert apc._permutation_pvalue(1.0, null, "two-sided") == pytest.approx(5 / 6)
+    # Nothing is more extreme than the maximum, so p hits the attainable floor.
+    assert apc._permutation_pvalue(4.0, null, "greater") == pytest.approx(1 / 6)
+
+
+def test_permutation_requires_both_classes_in_every_group():
+    groups = np.array(["female"] * 10 + ["male"] * 10)
+    membership = np.concatenate([np.ones(10, dtype=int), np.tile([1, 0], 5)])
+    with pytest.raises(RuntimeError):
+        apc.stratified_membership_permutation_test(
+            groups, membership, np.linspace(0, 1, 20), reps=10, seed=0
+        )
+
+
+def test_attack_metrics_include_permutation_block():
+    groups, membership, scores = _toy_cohort(signal=2.0)
+    metrics = apc.attack_metrics(
+        membership, groups, scores, bootstrap_reps=50, seed=0, permutation_reps=100
+    )
+    perm = metrics["permutation"]
+    assert set(perm) >= {
+        "aggregate_auc",
+        "aggregate_tpr",
+        "signed_difference",
+        "absolute_gap",
+        "female",
+        "male",
+    }
+    assert perm["signed_difference"]["alternative"] == "two-sided"
+    assert perm["aggregate_auc"]["alternative"] == "greater"
+
+
+def test_subgroup_disparity_not_claimed_from_aggregate_signal():
+    """A strong aggregate attack with no stable subgroup direction stays unsupported."""
+    control = apc.CONTROLS[1]
+    results = [
+        _seed_result(control, seed, auc=0.80, ci_low=0.20, signed=sign * 0.02, signed_p=0.4)
+        for seed, sign in zip((42, 43, 44), (1, -1, 1))
+    ]
+    verdict, _ = apc.classify_control(control, results)
+    subgroup_verdict, basis = apc.assess_subgroup_disparity(results)
+
+    assert verdict == apc.DETECTS
+    assert subgroup_verdict == apc.SUBGROUP_UNSUPPORTED
+    assert basis
+
+
+def test_subgroup_disparity_supported_when_stable_and_significant():
+    control = apc.CONTROLS[1]
+    results = [
+        _seed_result(control, seed, auc=0.80, ci_low=0.20, signed=0.25, signed_p=0.001)
+        for seed in (42, 43, 44)
+    ]
+    verdict, _ = apc.assess_subgroup_disparity(results)
+    assert verdict == apc.SUBGROUP_SUPPORTED
+
+
+def test_subgroup_disparity_inconclusive_without_completed_attacks():
+    control = apc.CONTROLS[0]
+    results = [
+        _seed_result(control, seed, gate=False, status="skipped_memorisation_gate")
+        for seed in (42, 43, 44)
+    ]
+    verdict, _ = apc.assess_subgroup_disparity(results)
+    assert verdict == apc.SUBGROUP_INCONCLUSIVE
+
+
 # --------------------------------------------------------------------------- #
 # Decision table and reporting
 # --------------------------------------------------------------------------- #
 
 
-def _seed_result(control, seed, *, gate=True, status="completed", auc=0.5, ci_low=0.0):
+def _seed_result(
+    control,
+    seed,
+    *,
+    gate=True,
+    status="completed",
+    auc=0.5,
+    ci_low=0.0,
+    signed=0.0,
+    signed_p=1.0,
+):
     groups, membership, scores = _toy_cohort(seed=seed)
     metrics = (
-        apc.attack_metrics(membership, groups, scores, bootstrap_reps=50, seed=seed)
+        apc.attack_metrics(
+            membership, groups, scores, bootstrap_reps=50, seed=seed, permutation_reps=50
+        )
         if status == "completed"
         else None
     )
     if metrics is not None:
+        # Overwrite the headline statistics so the decision logic is exercised
+        # against known values rather than fixture noise.
         metrics["aggregate"]["auc"] = auc
         metrics["bootstrap"]["aggregate"]["ci95_low"] = ci_low
+        metrics["signed_subgroup_difference"] = signed
+        metrics["absolute_subgroup_gap"] = abs(signed)
+        metrics["permutation"]["aggregate_auc"]["p_value"] = 0.001 if auc > 0.6 else 0.5
+        metrics["permutation"]["aggregate_tpr"]["p_value"] = 0.001 if auc > 0.6 else 0.5
+        metrics["permutation"]["signed_difference"]["p_value"] = signed_p
+        metrics["permutation"]["absolute_gap"]["p_value"] = signed_p
     return {
         "control": control.name,
         "kind": control.kind,
@@ -346,6 +557,46 @@ def test_report_states_no_go_when_positive_control_fails():
     assert "NO-GO" in markdown
     rows = apc.build_rows(_payload(seed_results, decisions))
     assert {row["attack"] for row in rows} == {"lira-offline"}
+
+
+def test_report_includes_permutation_results_and_separate_conclusions():
+    control = apc.CONTROLS[1]
+    seed_results = [
+        _seed_result(control, seed, auc=0.80, ci_low=0.20, signed=0.02, signed_p=0.4)
+        for seed in (42, 43, 44)
+    ]
+    decisions = [
+        {
+            "control": control.name,
+            "positive_control": True,
+            "seeds_attacked": 3,
+            "mean_auc_gap": 0.15,
+            "mean_lira_auc": 0.80,
+            "mean_permutation_p_auc": 0.001,
+            "verdict": apc.DETECTS,
+            "basis": "permutation null rejected on 3/3 seeds",
+            "subgroup_verdict": apc.SUBGROUP_UNSUPPORTED,
+            "subgroup_basis": "signed direction not stable",
+        }
+    ]
+    payload = _payload(seed_results, decisions)
+    payload["permutation_reps"] = 50
+    markdown = apc.render_markdown(payload)
+
+    assert "permutation" in markdown.lower()
+    assert "Stratified permutation tests" in markdown
+    # The three questions are answered separately.
+    assert "Is aggregate membership leakage detectable?" in markdown
+    assert "Does subgroup leakage differ by sex?" in markdown
+    assert "still suitable for the iso-epsilon" in markdown
+    # Aggregate detection must not be reported as subgroup disparity.
+    assert apc.SUBGROUP_UNSUPPORTED in markdown
+    assert "CONDITIONAL GO" in markdown
+
+    rows = apc.build_rows(payload)
+    assert all("permutation_p_aggregate_auc" in row for row in rows)
+    assert all("permutation_p_signed_difference" in row for row in rows)
+    assert all("female_permutation_p" in row for row in rows)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Why

The powered two-configuration spike returned a null subgroup result: subgroup LiRA near chance under every DP-SGD recipe, all Δ intervals containing zero. That null is only interpretable if the matched-shadow LiRA pipeline can detect membership leakage *at all* on the insurance `high_cost` task. This PR is the control experiment that answers it, rather than a wider DP-SGD grid.

Branched from `research/two-config-spike`, so this PR also carries that branch's commits.

## What

`research/attack_power_control.py` — three **non-private** controls (no Opacus, no clipping, no noise), seeds 42/43/44:

| Control | Architecture | Role |
|---|---|---|
| `matched_capacity_mlp` | `Linear(d,32) → ReLU → Linear(32,1)`, Adam lr=1e-2, 30 epochs | matches the DP target recipe |
| `memorising_mlp` | `128 → 128 → 64 → 1`, 400 epochs, no regularisation | positive control |
| `unbounded_decision_tree` | unconstrained `DecisionTreeClassifier` | positive control |

Reuses the powered spike's balanced cyclic shadow schedule and equalised `sex × membership` cohort logic. Shadows are size-matched to the target (856 records); both IN and OUT losses are collected so online LiRA runs alongside offline, and the report marks online unavailable rather than fitting a Gaussian from fewer than 10 observations.

The old ROC-AUC ≥ 0.70 utility gate is replaced by a **memorisation gate**: the attack runs only when train−test AUC, test−train loss, or train−test accuracy reaches 0.03. A model can generalise well and still be an unattackable membership target.

### Permutation null testing

Stratified bootstrap intervals remain, but are no longer the sole test against chance. `stratified_membership_permutation_test` reshuffles membership labels *within each sensitive group* — preserving each group's exact member/non-member counts, scores fixed — and recomputes aggregate AUC, aggregate TPR@1% FPR, each subgroup TPR, the signed male−female difference and the absolute gap. It reports the observed statistic, null mean and 95% interval, and empirical p-values with the `(1+k)/(reps+1)` correction: one-sided for AUC, TPR and absolute gap; two-sided on absolute value for the signed difference.

Aggregate detection now requires the memorisation gate, mean AUC ≥ 0.55, permutation rejection on at least two of three seeds, and a consistent direction. **Subgroup disparity is judged separately** and needs a stable signed direction, rejection on ≥2 seeds, and an effect exceeding the discrete operating-point resolution — aggregate attack success is never carried over into a disparity claim.

## Evidence this matters

A local end-to-end run of the tree control (32 shadows, 3 seeds, 1000 bootstrap and 1000 permutation replicates) shows the permutation test doing real work. Seed 42 has a subgroup gap of 0.1094 that looks substantial under bootstrap alone, but only 1/3 seeds reject the signed-difference null and one gap sits inside the 0.0078 operating-point resolution. Result: **aggregate leakage detected** (mean AUC 0.599, p=0.001 on 3/3 seeds), **subgroup disparity unsupported**. Without the permutation layer this would have read as a subgroup finding.

Coverage at 32 shadows: 11 OUT and 20 IN observations per audited example, so online LiRA is available.

## Outputs

`reports/attack_power_control/` — `.json`, `.csv`, `.md`, `.log`. The Markdown report answers three questions separately: (1) is aggregate membership leakage detectable, (2) does subgroup leakage differ by sex, (3) is the insurance dataset still suitable for the iso-ε subgroup research question — ending in an explicit go/no-go.

## Workflow

`.github/workflows/attack-power-control.yml` — manual dispatch plus PRs to `main`, 240-minute timeout, artifacts uploaded, report appended to the step summary. Never runs on push to `main`, never commits results, never merges.

## Tests

39 unit tests covering shadow schedules and coverage, cohort equality, memorisation-gate boundaries, bootstrap ordering, permutation invariants (group member counts preserved, null cases non-significant, separated scores significant, reversed advantage reverses sign, fixed seeds reproducible, p-values within `[1/(reps+1), 1]`), gap arithmetic, and report generation with skipped attacks. The end-to-end run is marked `slow`. Full suite: 152 passed, 3 skipped. `ruff check src tests` clean.

## Not in scope

No new datasets, no MEPS ingestion, no gradient diagnostics, no adaptive clipping, no hyperparameter grid, no new privacy mechanism.

**Draft — do not merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMTeRjKungkzMW6PFKdL18)_