### PR TITLE
Worst-case neural auditability ladder (Amendment 1: attack every point)

### DIFF
--- a/.github/workflows/detectability-noise-ladder.yml
+++ b/.github/workflows/detectability-noise-ladder.yml
@@ -1,0 +1,156 @@
+name: Detectability noise ladder
+
+# Manual dispatch, plus PRs that touch the ladder itself. Never on push to main:
+# one full ladder is six points x three seeds x 33 models at 400 epochs.
+on:
+  workflow_dispatch:
+    inputs:
+      seeds:
+        description: Space-separated target seeds
+        required: false
+        default: "42 43 44"
+      shadows:
+        description: Shadow models per ladder point and seed
+        required: false
+        default: "32"
+      bootstrap_reps:
+        description: Stratified bootstrap replicates
+        required: false
+        default: "1000"
+      permutation_reps:
+        description: Stratified membership permutation replicates
+        required: false
+        default: "1000"
+  pull_request:
+    paths:
+      - research/detectability_noise_ladder.py
+      - tests/test_detectability_noise_ladder.py
+      - docs/THREAT_MODEL.md
+      - docs/NOISE_LADDER_PREREGISTRATION.md
+      - .github/workflows/detectability-noise-ladder.yml
+
+concurrency:
+  group: noise-ladder-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ladder-point:
+    name: "point ${{ matrix.label }}"
+    runs-on: ubuntu-latest
+    # 400-epoch DP-SGD shadow training: 33 models per seed, 3 seeds per point.
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: non-private
+            epsilon: "0"
+          - label: eps32
+            epsilon: "32"
+          - label: eps16
+            epsilon: "16"
+          - label: eps8
+            epsilon: "8"
+          - label: eps4
+            epsilon: "4"
+          - label: eps2
+            epsilon: "2"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Run ladder point ${{ matrix.label }}
+        shell: bash
+        run: |
+          mkdir -p reports/detectability_noise_ladder/points
+          set +e
+          python research/detectability_noise_ladder.py point \
+            --epsilon "${{ matrix.epsilon }}" \
+            --seeds ${{ github.event.inputs.seeds || '42 43 44' }} \
+            --shadows "${{ github.event.inputs.shadows || '32' }}" \
+            --bootstrap-reps "${{ github.event.inputs.bootstrap_reps || '1000' }}" \
+            --permutation-reps "${{ github.event.inputs.permutation_reps || '1000' }}" \
+            --output-dir reports/detectability_noise_ladder/points \
+            2>&1 | tee reports/detectability_noise_ladder/points/${{ matrix.label }}.console.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" \
+            >> reports/detectability_noise_ladder/points/${{ matrix.label }}.console.log
+          exit "$status"
+      - name: Upload ladder point artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ladder-point-${{ matrix.label }}
+          path: reports/detectability_noise_ladder/points
+          if-no-files-found: warn
+
+  aggregate:
+    name: Aggregate ladder and build report
+    runs-on: ubuntu-latest
+    needs: ladder-point
+    # Runs even if a point failed, so the aggregation step reports precisely
+    # which point is missing instead of the job silently not existing.
+    if: always()
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Download every ladder-point artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ladder-point-*
+          path: reports/detectability_noise_ladder/points
+          merge-multiple: true
+      - name: List downloaded points
+        run: ls -la reports/detectability_noise_ladder/points || true
+      - name: Aggregate, adjust and report
+        shell: bash
+        run: |
+          set +e
+          python research/detectability_noise_ladder.py aggregate \
+            --input-dir reports/detectability_noise_ladder/points \
+            --output-dir reports/detectability_noise_ladder \
+            --expect-all \
+            2>&1 | tee reports/detectability_noise_ladder/aggregate.console.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" >> reports/detectability_noise_ladder/aggregate.console.log
+          exit "$status"
+      - name: Append report to workflow summary
+        if: always()
+        run: |
+          if [ -f reports/detectability_noise_ladder/noise_ladder.md ]; then
+            cat reports/detectability_noise_ladder/noise_ladder.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Noise ladder aggregation did not produce a report' \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f reports/detectability_noise_ladder/aggregate.console.log ]; then
+            echo '```text' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 60 reports/detectability_noise_ladder/aggregate.console.log \
+              >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # Results are uploaded as artifacts only. Nothing is committed back to the
+      # repository and no pull request is merged by this workflow.
+      - name: Upload complete ladder results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detectability-noise-ladder
+          path: reports/detectability_noise_ladder
+          if-no-files-found: warn

--- a/.github/workflows/detectability-noise-ladder.yml
+++ b/.github/workflows/detectability-noise-ladder.yml
@@ -24,6 +24,7 @@ on:
   pull_request:
     paths:
       - research/detectability_noise_ladder.py
+      - research/canary_pilot.py
       - tests/test_detectability_noise_ladder.py
       - docs/THREAT_MODEL.md
       - docs/NOISE_LADDER_PREREGISTRATION.md
@@ -34,8 +35,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Pull requests get lint, unit tests and a reduced smoke run only. The full
+  # six-point experiment costs hours of runner time and must never start from a
+  # PR event -- it runs on explicit workflow_dispatch alone.
+  validate:
+    name: Lint, tests and reduced smoke run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental,dev]"
+      - name: Ruff lint
+        run: ruff check src tests research/detectability_noise_ladder.py research/canary_pilot.py
+      - name: Unit tests
+        run: python -m pytest tests/ -q -m "not slow"
+      - name: Reduced smoke run (two points, one seed, tiny budgets)
+        run: |
+          mkdir -p /tmp/smoke/points
+          python research/detectability_noise_ladder.py point \
+            --seeds 42 --shadows 8 --epochs 5 --smoke \
+            --bootstrap-reps 50 --permutation-reps 50 \
+            --output-dir /tmp/smoke/points
+          python research/detectability_noise_ladder.py point \
+            --epsilon 8 --seeds 42 --shadows 8 --epochs 5 --smoke \
+            --bootstrap-reps 50 --permutation-reps 50 \
+            --output-dir /tmp/smoke/points
+          python research/detectability_noise_ladder.py aggregate \
+            --input-dir /tmp/smoke/points --output-dir /tmp/smoke/out
+          test -f /tmp/smoke/out/noise_ladder.md
+          test -f /tmp/smoke/out/lira_auc_vs_bce_gap.png
+          ! grep -q skipped_memorisation_gate /tmp/smoke/out/noise_ladder.md
+      - name: Upload smoke output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ladder-smoke
+          path: /tmp/smoke/out
+          if-no-files-found: warn
+
   ladder-point:
     name: "point ${{ matrix.label }}"
+    # Full experiment: manual dispatch only.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # 400-epoch DP-SGD shadow training: 33 models per seed, 3 seeds per point.
     timeout-minutes: 350
@@ -96,8 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: ladder-point
     # Runs even if a point failed, so the aggregation step reports precisely
-    # which point is missing instead of the job silently not existing.
-    if: always()
+    # which point is missing instead of the job silently not existing -- but
+    # only for the dispatched full ladder, never for a pull request.
+    if: always() && github.event_name == 'workflow_dispatch'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/docs/NOISE_LADDER_PREREGISTRATION.md
+++ b/docs/NOISE_LADDER_PREREGISTRATION.md
@@ -167,3 +167,89 @@ declines to state a single threshold, and classifies the frontier as unstable.
 Any deviation from this document must be recorded in the results report with
 its reason. If exact ε calibration is not attainable, the nearest reproducible
 noise multiplier is used and the difference is documented.
+
+---
+
+## Preregistration Amendment 1 — attack all ladder points
+
+**Adopted before any corrected ladder run. The numerical detection thresholds
+below are unchanged from the original registration; only the execution rule and
+the classification vocabulary change.**
+
+### What the original version specified
+
+The original registration used the memorisation gate as an **execution gate**:
+a ladder point whose target failed the gate was recorded as
+`TARGET DID NOT MEMORISE` and the attack was never run against it. Only
+gate-passing points produced LiRA metrics.
+
+### Why that is wrong
+
+DP noise suppresses memorisation and attack power together. Gating execution on
+measured memorisation therefore removes observations **non-randomly, and
+precisely where the noise is highest** — the high-ε-noise end of the ladder is
+exactly where targets are least likely to clear the gate.
+
+That has two consequences. First, the ladder would be silent about attack
+behaviour in the regime the experiment exists to characterise. Second, and more
+seriously, the relationship between measured generalisation and measured
+leakage cannot be studied at all if every low-generalisation observation is
+discarded before it is measured: the sample would be truncated on a variable
+correlated with the outcome.
+
+Those low-memorisation observations are **necessary data**, not skippable
+cases.
+
+### What changes
+
+Every ladder point and every seed now receives the **complete matched-shadow
+attack**, regardless of the memorisation gate:
+
+* matched shadow training,
+* offline LiRA,
+* stratified membership permutation testing,
+* stratified bootstrap intervals,
+* subgroup metrics,
+* online LiRA where IN/OUT coverage permits.
+
+No result may carry the status `skipped_memorisation_gate`. Memorisation
+becomes **explanatory metadata** recorded alongside every observation, not a
+condition on whether the observation exists.
+
+### What does not change
+
+The aggregate detection rule is numerically identical to the original
+registration:
+
+* mean offline-LiRA AUC across seeds >= 0.55;
+* offline-LiRA AUC > 0.5 on every seed;
+* Holm-adjusted permutation null rejected on at least two of three seeds, at
+  alpha = 0.05, adjusted across ladder points within each seed.
+
+The memorisation criterion is also numerically unchanged — memorisation is
+**present** when any of `AUC gap >= 0.03`, `BCE gap >= 0.03`, or
+`accuracy gap >= 0.03` — but it is now read as a property of the target rather
+than a precondition for measurement.
+
+### Revised point classification
+
+Detection and memorisation are two independent binary decisions, and each point
+is classified by their combination:
+
+```text
+DETECTABLE WITH MEMORISATION
+DETECTABLE DESPITE LOW MEASURED MEMORISATION
+UNDETECTABLE DESPITE MEMORISATION
+UNDETECTABLE WITH LOW MEMORISATION
+```
+
+No point is ever labelled private, safe or verified. An undetected point means
+*not detected at this attack power and cohort size*, nothing more.
+
+### Status of the first workflow run
+
+Workflow run `30218898999` was launched automatically by the pull-request event
+**before this amendment existed**, and was cancelled roughly two and a half
+minutes into training. It produced no ladder-point results. It is retained as an
+**exploratory / timing run only** and is not the pre-registered ladder. No
+result in it may be cited as a finding.

--- a/docs/NOISE_LADDER_PREREGISTRATION.md
+++ b/docs/NOISE_LADDER_PREREGISTRATION.md
@@ -1,0 +1,169 @@
+# Pre-registration: DP-SGD detectability noise ladder
+
+**Committed before the full ladder workflow was run.** The decision rules below
+were fixed in advance; the analysis code implements them mechanically, and the
+report classifies each ladder point by applying them rather than by inspection.
+
+## Research question
+
+> At what privacy-noise level does aggregate natural membership leakage cease
+> to be reproducibly detectable on the insurance `high_cost` task?
+
+The contribution is the **empirical detectability frontier** — the bracket
+between the lowest ε at which leakage is still detected and the adjacent point
+where detection is lost. It is *not* another same-ε configuration comparison.
+
+## What is already settled
+
+These questions are closed and are not re-opened by this experiment:
+
+* The original matched-ε DP-SGD subgroup spike produced no stable subgroup
+  effect.
+* Absolute max-minus-min subgroup gaps are **positively biased under the null**
+  and must not be the primary inferential statistic. They are retained only as
+  descriptive statistics.
+* The corrected subgroup statistic is the signed contrast
+  `male TPR@1% FPR − female TPR@1% FPR`.
+* The matched-capacity non-private MLP did not memorise enough to support a
+  useful attack.
+* The deliberately memorising non-private MLP did leak: offline LiRA AUC
+  ≈ 0.558–0.586, permutation-significant on all three seeds.
+* The unbounded decision tree also leaked.
+* Neither positive control produced a stable, reproducible sex-specific
+  leakage difference.
+* Aggregate membership leakage is therefore **measurable on this dataset when a
+  model memorises**.
+
+What remains unknown, and what this ladder measures: **where the attack loses
+power as DP-SGD noise increases.**
+
+## Fixed design
+
+| Parameter | Value |
+|---|---|
+| Task | `high_cost` |
+| Sensitive attribute | `sex` |
+| δ | 1e-5 |
+| Accountant | RDP |
+| Sampling | Poisson |
+| Seeds | 42, 43, 44 |
+| Shadows per point per seed | 32 |
+| Bootstrap replicates | 1000 |
+| Permutation replicates | 1000 |
+| Target/shadow training size | 856 (exactly matched) |
+| Architecture | `Linear(d,128) → ReLU → Linear(128,128) → ReLU → Linear(128,64) → ReLU → Linear(64,1)` |
+| Epochs | 400 |
+| Batch size | 64 |
+| Optimiser | Adam, lr = 1e-3 |
+| Regularisation | none (no dropout, no weight decay, no early stopping) |
+| Clipping norm | 1.0, fixed and public at every finite point |
+
+**Only the noise multiplier changes between finite ladder points.** The
+cohort indices, the shadow inclusion schedule, the shadow base seeds, the model
+initialisation seeds and the batch-ordering seeds are all derived from the
+target seed alone, never from the ladder point, so every point is paired.
+
+Ladder points: **non-private**, ε = 32, 16, 8, 4, 2.
+
+For each finite point the noise multiplier is solved from the requested ε via
+the repository's accounting utilities, then training runs at that **fixed**
+noise multiplier and the **achieved** ε is read back from the RDP accountant.
+Requested ε is an input, not a result; the report shows requested ε, achieved ε
+and noise multiplier side by side.
+
+The architecture and optimiser are **not** retuned at each privacy level. The
+object of study is how attack detectability changes with noise, not how well
+each privacy level can be made to perform.
+
+## Primary outcome
+
+* **Aggregate offline-LiRA ROC-AUC** (primary),
+* supported by **aggregate TPR@1% FPR**,
+* assessed with **stratified membership-label permutation tests** — labels
+  reshuffled within each sensitive group, preserving exact per-group member and
+  non-member counts, with attack scores held fixed.
+
+The subgroup outcome is **secondary**.
+
+## Pre-registered aggregate detection rule
+
+A ladder point is classified `AGGREGATE LEAKAGE DETECTABLE` only when **all** of:
+
+1. The target passes the memorisation gate on all three seeds.
+2. Mean offline-LiRA AUC across seeds ≥ 0.55.
+3. Offline-LiRA AUC > 0.5 on every seed.
+4. The stratified permutation null is rejected on at least two of three seeds.
+5. p-values are **Holm-adjusted across ladder points within each seed**.
+6. The adjusted significance threshold is 0.05.
+
+`UNDETECTABLE AT CURRENT POWER` — the memorisation gate passes, but the
+detection rule above is not met.
+
+`TARGET DID NOT MEMORISE` — the memorisation gate fails. The point stays in the
+report; it is never dropped.
+
+**An undetected point is never labelled private, safe, or verified.**
+
+### Memorisation gate
+
+Passes when any of:
+
+```
+train AUC − test AUC   >= 0.03
+test BCE − train BCE   >= 0.03
+train acc − test acc   >= 0.03
+```
+
+## Pre-registered subgroup rule
+
+The **signed contrast** `male TPR@1% − female TPR@1%` is the only inferential
+subgroup statistic. A disparity is `SUPPORTED` only when all of:
+
+1. The signed direction is the same across all non-zero seeds.
+2. The signed-difference or absolute-gap permutation null is rejected on at
+   least two of three seeds, after multiplicity adjustment.
+3. The effect exceeds one-person TPR resolution, `1 / subgroup_member_count`.
+4. The result is not driven by a single seed.
+
+Otherwise: `UNSUPPORTED` (criteria assessable and not met) or `INCONCLUSIVE`
+(no attack completed).
+
+The absolute max-minus-min gap is retained **as a descriptive statistic only**.
+Aggregate attack success is never interpreted as subgroup disparity.
+
+## Detectability frontier
+
+Reported as a **bracket**, not an interpolated threshold:
+
+```
+detectable at epsilon = X
+not detectable at epsilon = Y
+therefore the empirical transition lies between Y and X
+```
+
+Six points do not support interpolating a precise crossing. If detection is
+**non-monotonic** in ε, the report flags the non-monotonicity explicitly,
+declines to state a single threshold, and classifies the frontier as unstable.
+
+## Coverage requirements
+
+* At least 10 OUT observations per attacked example — offline LiRA otherwise
+  aborts.
+* At least 10 IN *and* 10 OUT per attacked example for online LiRA — otherwise
+  online LiRA is reported as unavailable.
+* No Gaussian is fitted from fewer than 10 observations.
+
+## Assertions enforced in code
+
+* Target and shadow training sizes match exactly.
+* Target and shadow noise multipliers match exactly at finite points.
+* Target and shadow achieved ε agree within accounting tolerance.
+* Cohort indices are identical across ladder points for a given seed.
+* Shadow inclusion schedules are identical across ladder points for a given
+  seed.
+
+## Deviations
+
+Any deviation from this document must be recorded in the results report with
+its reason. If exact ε calibration is not attainable, the nearest reproducible
+noise multiplier is used and the difference is documented.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,112 @@
+# Threat model for membership-inference auditing
+
+This document fixes the adversary model used by every membership-inference
+experiment in this repository. It is written before the detectability noise
+ladder is run, so that the experiment's interpretation is constrained by a
+model chosen in advance rather than by whatever the results turn out to be.
+
+## Asset
+
+The **target training dataset** is private. It is a fixed subset of 856 records
+drawn from the insurance benchmark pool, used to fit one target model for the
+`high_cost` task.
+
+## What the adversary knows
+
+The adversary is given full knowledge of the training *recipe*, and no
+knowledge of the training *set*. Specifically, they know:
+
+* the model architecture, layer by layer;
+* the optimiser family and its hyperparameters;
+* the batch size;
+* the number of epochs;
+* the gradient-clipping norm;
+* the preprocessing pipeline, including how it was fitted;
+* the task definition, including the training-only high-cost threshold rule;
+* the broad source distribution the training data was drawn from;
+* under DP-SGD: the noise multiplier, the sampling scheme, the accountant and
+  the claimed (ε, δ).
+
+This is the standard white-box-recipe / black-box-weights setting used in the
+LiRA literature. It is deliberately generous: a weaker adversary would produce
+a weaker audit, and an audit is only useful as a lower bound.
+
+## What the adversary does not know
+
+* The exact membership set of the target's training data. This is the secret
+  the attack tries to recover.
+* The random seeds used for target initialisation and batch ordering.
+
+## What the adversary can do
+
+The adversary can draw auxiliary samples from the same benchmark pool and train
+**matched shadow models** on them: same architecture, same optimiser, same
+epochs, same batch size, same clipping norm, same noise multiplier, and exactly
+the same training-set size as the target. They can train as many shadows as
+their budget allows; these experiments use 32 per target seed.
+
+The adversary cannot see the target's weights or gradients, and cannot
+influence the target's training data.
+
+## Membership definition
+
+Membership is **record-level inclusion in the target's training set**. A record
+is a member if that exact row was used to fit the target model, and a
+non-member otherwise. Non-members are drawn from the held-out test partition.
+
+There is no canary insertion in these experiments: the leakage under study is
+*natural* memorisation of real records, not worst-case memorisation of crafted
+ones. Canary-based auditing (see `src/dp/canaries.py` and `src/dp/audit.py`)
+answers a different, worst-case question and is not part of this threat model.
+
+## Sensitive attribute
+
+The sensitive attribute is `sex`, taking values `female` and `male`. It is both
+a model feature and the grouping variable for subgroup analysis. Attack cohorts
+are equalised so that every `sex × membership` cell holds the same number of
+records.
+
+## Attacks
+
+* **Offline LiRA is the primary attack.** Each example's target loss is
+  standardised against a Gaussian fitted to its losses under shadow models
+  trained *without* it. This is the realistic setting: the adversary does not
+  know which records the target trained on, so they cannot condition on it.
+* **Online LiRA is secondary.** It additionally fits an IN distribution per
+  example, which requires shadow models that contain the target example. It is
+  reported **only when every attacked example has at least 10 IN and at least
+  10 OUT shadow observations**. No Gaussian is ever fitted from fewer than 10
+  observations.
+
+Where the two disagree, the offline result is the one the pre-registered
+decision rules act on.
+
+## Three separate objects
+
+These are kept distinct throughout, and conclusions about one are never
+transferred to another:
+
+1. **Formal DP accounting** — the (ε, δ) an accountant certifies. An upper
+   bound on worst-case privacy loss, over all datasets and all adversaries.
+2. **Empirical attack performance** — what this specific adversary recovers
+   from this specific model. A lower bound on leakage, and only for the attack
+   actually run.
+3. **Subgroup disparity** — whether leakage differs between `female` and
+   `male`. This is a *comparison* of empirical attack performance, and is
+   never inferred from aggregate attack success.
+
+## The central caveat
+
+**Failure to detect leakage is not proof that leakage is absent, and is not
+verification of a DP guarantee.**
+
+A null attack result is consistent with at least four different worlds: the
+mechanism genuinely leaks little; the attack is too weak; the cohort is too
+small to resolve the effect; or the operating point is too coarse. This
+repository's experiments are designed to tell these apart where possible — that
+is what the non-private positive controls and the permutation nulls are for —
+but a non-detection is always reported as *not detected at this power*, never
+as *private* or *safe*.
+
+Symmetrically, a detected leak is a genuine finding: attacks only certify
+leakage that is really present.

--- a/reports/spike/METHODOLOGICAL_NOTE.md
+++ b/reports/spike/METHODOLOGICAL_NOTE.md
@@ -1,0 +1,79 @@
+# Methodological note on the powered two-configuration spike
+
+**Added by the detectability-noise-ladder work. The spike's recorded results in
+`two_config_spike.json`, `two_config_spike.md` and `CONCLUSION.md` are
+unchanged; this note records how they should now be read.**
+
+## Raw scores are not available
+
+The spike computed per-example LiRA scores (`all_scores` in
+`research/two_config_spike.py`) but never persisted them. The committed JSON
+contains only aggregated per-subgroup metrics — `n`, `members`, `nonmembers`,
+`auc` and TPR at each FPR — together with bootstrap Delta summaries and shadow
+metadata. The GitHub Actions artifact (run 30212921872, artifact 8635033599)
+holds that same payload, so it does not contain score-level data either.
+
+Score-level permutation testing therefore **cannot be applied retrospectively**
+to the spike. The spike was not re-run for this purpose.
+
+## What the spike's Delta actually was
+
+The spike's headline subgroup statistic was the **absolute max-minus-min gap**
+
+```text
+Delta = max_group_TPR@1% - min_group_TPR@1%
+```
+
+reported as differing by approximately 0.0027 in mean between the two DP-SGD
+configurations.
+
+That statistic is **positively biased under the null**. Taking a maximum minus
+a minimum over noisy per-group estimates yields a positive expected value even
+when no subgroup difference exists, because the max and min are selected
+*after* seeing the noise. A small positive Delta is therefore not evidence of
+a small positive effect, and a difference between two configurations' mean
+Deltas is not evidence that they differ in subgroup leakage.
+
+The corrected primary statistic — used in the attack-power control and in the
+noise ladder — is the **signed contrast** `male TPR@1% − female TPR@1%`, which
+is centred on zero under the null. The absolute gap is retained only as a
+descriptive statistic.
+
+## What this means for the spike's conclusion
+
+The spike's conclusion — that the corrected high-cost spike is a **null** for
+subgroup privacy redistribution across the two tested iso-ε recipes — is not
+overturned by this note. Its stated basis is strengthened in one respect and
+weakened in another:
+
+* **Strengthened**: bootstrap intervals for Delta all included zero and the
+  direction of the gap was unstable across seeds. Both remain true and both are
+  consistent with no detectable subgroup effect.
+* **Weakened**: the ~0.0027 mean-Delta difference between configurations was a
+  **descriptive** quantity computed from a biased statistic without a
+  score-level null. It cannot support a claim about subgroup leakage in either
+  direction — neither that a small difference exists, nor that the
+  configurations are equivalent.
+
+The honest reading is: **the spike did not measure a subgroup effect, and its
+Delta comparison was never capable of supporting a subgroup claim.** Any future
+subgroup claim must come from signed contrasts assessed against a stratified
+membership permutation null on retained per-example scores.
+
+## A caution about borrowed null distributions
+
+The attack-power control measured a non-zero permutation-null mean for the
+absolute gap on its own cohorts. That figure belongs to **that** experiment —
+its models, its cohort sizes, its score distributions. It is **not** the DP
+spike's null distribution and must not be substituted for one. The bias
+direction described above is a general property of a max-minus-min statistic;
+the specific magnitude of that bias is experiment-dependent and, for the spike,
+was never measured because the scores were not retained.
+
+## Change adopted going forward
+
+Experiments in this repository now retain what is needed to test their own
+statistics: the noise ladder records per-point, per-seed permutation nulls
+(observed value, null mean, null interval, raw and Holm-adjusted p-values) for
+the aggregate AUC, aggregate TPR, each subgroup TPR, the signed contrast and
+the absolute gap.

--- a/research/canary_pilot.py
+++ b/research/canary_pilot.py
@@ -1,0 +1,308 @@
+"""Conditional canary pilot for the worst-case neural auditability ladder.
+
+The ladder measures *natural* memorisation of real records. Canary auditing asks
+a different, worst-case question: insert crafted records whose inclusion you
+control, and invert the attacker's success into an epsilon lower bound
+(Steinke, Nasr & Jagielski, NeurIPS 2023). That bound does not depend on natural
+memorisation existing in the data at all, which makes it a useful second
+instrument -- *if* it has power against this particular target.
+
+This script establishes whether it does, and refuses to go further if it does
+not. It runs a **non-private pilot only**. Extending to DP sentinel points is
+gated on the pilot clearing:
+
+    attacker accuracy >= 0.70  and  epsilon lower bound > 0
+
+If no construction clears that bar, the pilot reports
+
+    CANARY AUDITOR UNDERPOWERED FOR THIS NEURAL TARGET
+
+and stops. There is no automatic six-point canary ladder: a weak auditor run
+across a privacy sweep would produce six uninformative bounds, not evidence.
+
+The target matches the ladder exactly: 128->128->64->1, 400 epochs, Adam at
+1e-3, batch 64, no regularisation, same leakage-safe ``high_cost`` preparation.
+
+Run::
+
+    python research/canary_pilot.py --epochs 400
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from detectability_noise_ladder import (  # noqa: E402
+    BATCH_SIZE,
+    EPOCHS,
+    HIDDEN_UNITS,
+    LEARNING_RATE,
+    TASK_NAME,
+    prepare_seed_arrays,
+)
+
+#: Pilot must clear both to justify any DP sentinel run.
+MIN_ATTACKER_ACCURACY = 0.70
+MIN_EPSILON_LOWER_BOUND = 0.0
+
+UNDERPOWERED = "CANARY AUDITOR UNDERPOWERED FOR THIS NEURAL TARGET"
+PILOT_PASSED = "CANARY AUDITOR HAS POWER AGAINST THIS NEURAL TARGET"
+
+
+def build_ladder_scorer(canary_labels: np.ndarray, epochs: int, seed: int):
+    """`train_and_score` callback training the exact ladder architecture.
+
+    Non-private: no Opacus, no clipping, no noise. Scores each canary by its
+    negative loss, so a lower loss reads as more member-like.
+    """
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    from dp.attacks import logit_confidence_from_bce
+
+    def per_example_bce(y_true: np.ndarray, prob: np.ndarray) -> np.ndarray:
+        prob = np.clip(np.asarray(prob, dtype=float), 1e-7, 1 - 1e-7)
+        y_true = np.asarray(y_true, dtype=float)
+        return -(y_true * np.log(prob) + (1 - y_true) * np.log(1 - prob))
+
+    def train_and_score(x_aug, y_aug, canary_features):
+        torch.manual_seed(seed)
+        x = torch.tensor(np.asarray(x_aug, dtype=np.float32))
+        y = torch.tensor(np.asarray(y_aug, dtype=np.float32))
+        generator = torch.Generator().manual_seed(seed)
+        loader = DataLoader(
+            TensorDataset(x, y),
+            batch_size=min(BATCH_SIZE, len(y)),
+            shuffle=True,
+            generator=generator,
+        )
+
+        layers: list[nn.Module] = []
+        in_dim = x.shape[1]
+        for units in HIDDEN_UNITS:
+            layers += [nn.Linear(in_dim, units), nn.ReLU()]
+            in_dim = units
+        layers.append(nn.Linear(in_dim, 1))
+        net = nn.Sequential(*layers)
+
+        optimizer = torch.optim.Adam(net.parameters(), lr=LEARNING_RATE)
+        loss_fn = nn.BCEWithLogitsLoss()
+        net.train()
+        for _ in range(epochs):
+            for xb, yb in loader:
+                optimizer.zero_grad()
+                loss_fn(net(xb).squeeze(-1), yb).backward()
+                optimizer.step()
+
+        net.eval()
+        with torch.no_grad():
+            logits = net(
+                torch.tensor(np.asarray(canary_features, dtype=np.float32))
+            ).squeeze(-1)
+            prob = torch.sigmoid(logits).cpu().numpy()
+        losses = per_example_bce(canary_labels, prob)
+        # Logit confidence is monotone in -loss and numerically better behaved.
+        return logit_confidence_from_bce(losses)
+
+    return train_and_score
+
+
+def run_pilot(
+    epochs: int,
+    seed: int,
+    num_canaries: int,
+    duplication: int,
+    log,
+) -> dict[str, object]:
+    """Non-private pilot over the two requested canary constructions."""
+    from dp.audit import one_run_model_audit
+    from dp.canaries import make_duplicated_canaries, make_label_flip_canaries
+
+    root = Path(__file__).resolve().parents[1]
+    df = pd.read_csv(root / "data" / "insurance.csv")
+    arrays = prepare_seed_arrays(df, seed)
+    X_train, y_train = arrays["X_train"], arrays["y_train"]
+    X_test, y_test = arrays["X_test"], arrays["y_test"]
+    n_features = X_train.shape[1]
+
+    constructions = {
+        "label-flip": {
+            "canaries": make_label_flip_canaries(
+                X_test, y_test, min(num_canaries, len(y_test)), random_state=1
+            ),
+            "probe": "record-level membership",
+        },
+        f"duplicated-x{duplication}": {
+            "canaries": make_duplicated_canaries(
+                num_canaries, n_features, duplication=duplication, random_state=1
+            ),
+            # Duplication amplifies influence k-fold, so the bound must be read
+            # against a group-privacy budget of roughly k*epsilon, not epsilon.
+            "probe": f"GROUP-privacy probe (group size {duplication})",
+        },
+    }
+
+    results = []
+    for name, spec in constructions.items():
+        canaries = spec["canaries"]
+        scorer = build_ladder_scorer(canaries.labels, epochs, seed)
+        audit = one_run_model_audit(
+            canaries,
+            X_train,
+            y_train,
+            scorer,
+            delta=0.0,
+            confidence=0.95,
+            random_state=seed,
+        )
+        accuracy = (
+            float(audit.num_correct / audit.num_guesses) if audit.num_guesses else 0.0
+        )
+        passed = (
+            accuracy >= MIN_ATTACKER_ACCURACY
+            and float(audit.epsilon_lower_bound) > MIN_EPSILON_LOWER_BOUND
+        )
+        entry = {
+            "construction": name,
+            "probe": spec["probe"],
+            "num_canaries": int(len(canaries.labels)),
+            "duplication": int(getattr(canaries, "duplication", 1)),
+            "num_guesses": int(audit.num_guesses),
+            "num_correct": int(audit.num_correct),
+            "attacker_accuracy": accuracy,
+            "epsilon_lower_bound": float(audit.epsilon_lower_bound),
+            "confidence": float(audit.confidence),
+            "passes_pilot": bool(passed),
+        }
+        results.append(entry)
+        log(
+            f"[canary {name}] guesses={entry['num_guesses']} "
+            f"correct={entry['num_correct']} accuracy={accuracy:.4f} "
+            f"eps_lb={entry['epsilon_lower_bound']:.4f} "
+            f"{'PASS' if passed else 'FAIL'}"
+        )
+
+    any_passed = any(r["passes_pilot"] for r in results)
+    verdict = PILOT_PASSED if any_passed else UNDERPOWERED
+    return {
+        "experiment": "canary_pilot_non_private",
+        "task": TASK_NAME,
+        "private": False,
+        "epochs": epochs,
+        "architecture": f"Linear(d,{'->'.join(map(str, HIDDEN_UNITS))}->1) + ReLU",
+        "batch_size": BATCH_SIZE,
+        "learning_rate": LEARNING_RATE,
+        "seed": seed,
+        "min_attacker_accuracy": MIN_ATTACKER_ACCURACY,
+        "min_epsilon_lower_bound": MIN_EPSILON_LOWER_BOUND,
+        "results": results,
+        "verdict": verdict,
+        "extend_to_dp_sentinels": bool(any_passed),
+    }
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    """Short report; its only job is the go/no-go on canary work."""
+    lines = [
+        "# Canary auditor pilot (non-private)",
+        "",
+        "Conditional pilot for the worst-case neural auditability ladder. The target "
+        "matches the ladder exactly: "
+        f"`{payload['architecture']}`, {payload['epochs']} epochs, Adam at "
+        f"{payload['learning_rate']}, batch {payload['batch_size']}, no regularisation, "
+        f"same leakage-safe `{payload['task']}` preparation. **Non-private only** -- no "
+        "canary ladder is run across privacy points.",
+        "",
+        "Extension to DP sentinel points requires a construction reaching "
+        f"attacker accuracy >= {payload['min_attacker_accuracy']} **and** an epsilon "
+        f"lower bound > {payload['min_epsilon_lower_bound']}.",
+        "",
+        "| Construction | Probe | Canaries | Guesses | Correct | Accuracy | eps lower "
+        "bound | Pilot |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for entry in payload["results"]:
+        lines.append(
+            f"| {entry['construction']} | {entry['probe']} | {entry['num_canaries']} | "
+            f"{entry['num_guesses']} | {entry['num_correct']} | "
+            f"{entry['attacker_accuracy']:.4f} | {entry['epsilon_lower_bound']:.4f} | "
+            f"{'PASS' if entry['passes_pilot'] else 'FAIL'} |"
+        )
+
+    lines += ["", f"## Verdict: {payload['verdict']}", ""]
+    if payload["extend_to_dp_sentinels"]:
+        lines.append(
+            "At least one construction has power against this target, so extending the "
+            "canary auditor to sentinel DP points is justified. That extension is a "
+            "separate, explicitly requested run -- it does not start automatically."
+        )
+    else:
+        lines += [
+            f"**{UNDERPOWERED}**",
+            "",
+            "No construction reached the required attacker accuracy with a positive "
+            "epsilon lower bound. The canary experiment stops here: running this "
+            "auditor across DP privacy points would produce uninformative bounds at "
+            "every point, which is not evidence about privacy.",
+            "",
+            "A loose bound means *not detected at this power*, never *proven private*.",
+        ]
+    lines += [
+        "",
+        "The duplicated construction is a **group-privacy** probe: duplication "
+        "amplifies a record's influence k-fold, so its bound must be read against a "
+        "budget of roughly k*epsilon, not the single-record epsilon.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epochs", type=int, default=EPOCHS)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--canaries", type=int, default=200)
+    parser.add_argument("--duplication", type=int, default=8)
+    parser.add_argument("--output-dir", default="reports/canary_pilot")
+    args = parser.parse_args(argv)
+
+    import torch
+
+    torch.set_num_threads(2)
+    root = Path(__file__).resolve().parents[1]
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    handle = (output_dir / "canary_pilot.log").open("w", encoding="utf-8")
+
+    def log(message: str) -> None:
+        print(message, flush=True)
+        handle.write(message + "\n")
+        handle.flush()
+
+    payload = run_pilot(
+        epochs=args.epochs,
+        seed=args.seed,
+        num_canaries=args.canaries,
+        duplication=args.duplication,
+        log=log,
+    )
+    (output_dir / "canary_pilot.json").write_text(json.dumps(payload, indent=2, default=float))
+    (output_dir / "canary_pilot.md").write_text(render_markdown(payload))
+    log(f"\nVerdict: {payload['verdict']}")
+    log(f"Extend to DP sentinels: {payload['extend_to_dp_sentinels']}")
+    handle.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/detectability_noise_ladder.py
+++ b/research/detectability_noise_ladder.py
@@ -1,4 +1,9 @@
-"""DP-SGD detectability noise ladder for the insurance ``high_cost`` task.
+"""Worst-case neural auditability ladder for the insurance ``high_cost`` task.
+
+This is an **auditability ladder for a deliberately memorising neural target**,
+not a universal DP-SGD detectability frontier. Its subject is one intentionally
+attackable architecture; nothing here characterises DP-SGD in general, or any
+other model family, or any other dataset.
 
 The attack-power control (``research/attack_power_control.py``) established that
 aggregate membership leakage *is* measurable on this dataset when a model
@@ -82,9 +87,13 @@ TRAIN_SIZE = 856
 LADDER_EPSILONS: tuple[float | None, ...] = (None, 32.0, 16.0, 8.0, 4.0, 2.0)
 NON_PRIVATE_LABEL = "non-private"
 
-DETECTABLE = "AGGREGATE LEAKAGE DETECTABLE"
-UNDETECTABLE = "UNDETECTABLE AT CURRENT POWER"
-DID_NOT_MEMORISE = "TARGET DID NOT MEMORISE"
+#: Amendment 1 classifications: detection and memorisation are two independent
+#: binary decisions, and every point is labelled by their combination.
+DETECTABLE_WITH_MEMORISATION = "DETECTABLE WITH MEMORISATION"
+DETECTABLE_LOW_MEMORISATION = "DETECTABLE DESPITE LOW MEASURED MEMORISATION"
+UNDETECTABLE_WITH_MEMORISATION = "UNDETECTABLE DESPITE MEMORISATION"
+UNDETECTABLE_LOW_MEMORISATION = "UNDETECTABLE WITH LOW MEMORISATION"
+DETECTABLE_STATUSES = (DETECTABLE_WITH_MEMORISATION, DETECTABLE_LOW_MEMORISATION)
 
 SUBGROUP_SUPPORTED = "SUBGROUP DISPARITY SUPPORTED"
 SUBGROUP_UNSUPPORTED = "SUBGROUP DISPARITY UNSUPPORTED"
@@ -281,27 +290,28 @@ def holm_adjust(p_values: Sequence[float]) -> list[float]:
 # --------------------------------------------------------------------------- #
 
 
-def classify_ladder_point(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
-    """Apply the pre-registered aggregate detection rule to one ladder point.
+def memorisation_present(seed_results: Sequence[dict[str, object]]) -> bool:
+    """Whether the target memorised, as metadata rather than a gate.
 
-    Requires: gate passed on all seeds; mean offline AUC >= 0.55; AUC > 0.5 on
-    every seed; Holm-adjusted permutation null rejected on >= 2 of 3 seeds.
+    A point counts as memorising when the pre-registered criterion holds on
+    every seed. Unchanged numerically from the original registration; only its
+    role changed under Amendment 1.
     """
     if not seed_results:
-        return DID_NOT_MEMORISE, "No seed produced a target model."
+        return False
+    return all(bool(r["memorisation_gate_passed"]) for r in seed_results)
 
-    gates = [bool(r["memorisation_gate_passed"]) for r in seed_results]
-    if not all(gates):
-        failed = sum(1 for g in gates if not g)
-        return (
-            DID_NOT_MEMORISE,
-            f"The memorisation gate failed on {failed}/{len(gates)} seeds, so the "
-            "pre-registered rule cannot classify detectability here.",
-        )
 
+def aggregate_detected(seed_results: Sequence[dict[str, object]]) -> tuple[bool, str]:
+    """Apply the pre-registered aggregate detection rule.
+
+    Thresholds are numerically identical to the original registration: mean
+    offline AUC >= 0.55, AUC > 0.5 on every seed, and the Holm-adjusted
+    permutation null rejected on at least two of three seeds.
+    """
     completed = [r for r in seed_results if r["attack_status"] == "completed"]
     if not completed:
-        return UNDETECTABLE, "Gate passed but no attack completed."
+        return False, "no attack completed"
 
     aucs = np.asarray(
         [float(r["offline"]["aggregate"]["auc"]) for r in completed], dtype=float
@@ -316,34 +326,63 @@ def classify_ladder_point(seed_results: Sequence[dict[str, object]]) -> tuple[st
     mean_auc = float(np.nanmean(aucs))
     significant = int(np.sum(adjusted < ALPHA))
     above_chance = bool(np.all(aucs > 0.5))
-    # The pre-registered rule is "2 of 3 seeds". Reduced-seed smoke runs would
-    # otherwise be unsatisfiable; at the pre-registered three seeds this is
-    # exactly MIN_SIGNIFICANT_SEEDS.
+    # "2 of 3" at the pre-registered three seeds; reduced-seed smoke runs would
+    # otherwise be unsatisfiable.
     required = min(MIN_SIGNIFICANT_SEEDS, len(completed))
 
     if mean_auc >= DETECT_MEAN_AUC and above_chance and significant >= required:
-        return (
-            DETECTABLE,
-            f"Mean offline-LiRA AUC {mean_auc:.4f} (>= {DETECT_MEAN_AUC}), above 0.5 on "
+        return True, (
+            f"mean offline-LiRA AUC {mean_auc:.4f} (>= {DETECT_MEAN_AUC}), above 0.5 on "
             f"every seed, Holm-adjusted permutation null rejected on "
-            f"{significant}/{len(completed)} seeds (>= {required} required).",
+            f"{significant}/{len(completed)} seeds (>= {required} required)"
         )
 
     reasons = []
     if mean_auc < DETECT_MEAN_AUC:
         reasons.append(f"mean AUC {mean_auc:.4f} < {DETECT_MEAN_AUC}")
     if not above_chance:
-        reasons.append("at least one seed is at or below chance")
+        reasons.append("at least one seed at or below chance")
     if significant < required:
         reasons.append(
             f"Holm-adjusted rejection on only {significant}/{len(completed)} seeds "
             f"({required} required)"
         )
-    return (
-        UNDETECTABLE,
-        "Target memorised but " + "; ".join(reasons) + ". Not detected at this power -- "
-        "this is not evidence of privacy.",
-    )
+    return False, "; ".join(reasons)
+
+
+def classify_ladder_point(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
+    """Classify one ladder point by combining detection and memorisation.
+
+    Under Amendment 1 these are two independent binary decisions, and every
+    point receives one of four statuses. No point is ever labelled private,
+    safe or verified: an undetected point means *not detected at this attack
+    power and cohort size*.
+    """
+    detected, detection_basis = aggregate_detected(seed_results)
+    memorised = memorisation_present(seed_results)
+
+    if detected and memorised:
+        status = DETECTABLE_WITH_MEMORISATION
+        basis = f"Detected ({detection_basis}); target memorised on every seed."
+    elif detected and not memorised:
+        status = DETECTABLE_LOW_MEMORISATION
+        basis = (
+            f"Detected ({detection_basis}) even though measured memorisation is below "
+            f"the {MEMORISATION_GATE} criterion on at least one seed."
+        )
+    elif memorised:
+        status = UNDETECTABLE_WITH_MEMORISATION
+        basis = (
+            f"Target memorised on every seed, yet not detected: {detection_basis}. "
+            "Not detected at this attack power -- not a privacy claim."
+        )
+    else:
+        status = UNDETECTABLE_LOW_MEMORISATION
+        basis = (
+            f"Not detected ({detection_basis}) and measured memorisation is below the "
+            f"{MEMORISATION_GATE} criterion on at least one seed."
+        )
+    return status, basis
 
 
 def classify_subgroup(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
@@ -432,8 +471,9 @@ def detectability_frontier(points: Sequence[dict[str, object]]) -> dict[str, obj
         ),
         reverse=True,
     )
-    classified = [p for p in ordered if p["decision"] != DID_NOT_MEMORISE]
-    flags = [p["decision"] == DETECTABLE for p in classified]
+    # Amendment 1: every point is attacked, so every point is classifiable.
+    classified = list(ordered)
+    flags = [p["decision"] in DETECTABLE_STATUSES for p in classified]
 
     # Monotone means: every detectable point precedes every undetectable one.
     non_monotonic = any(
@@ -515,6 +555,129 @@ def detectability_frontier(points: Sequence[dict[str, object]]) -> dict[str, obj
     return result
 
 
+
+# --------------------------------------------------------------------------- #
+# Generalisation-gap association analysis
+# --------------------------------------------------------------------------- #
+
+#: Verbatim caveat required on every report carrying this analysis.
+ASSOCIATION_ONLY_STATEMENT = (
+    "These analyses measure association only. DP noise changes both "
+    "generalisation and leakage, so this experiment does not identify an effect "
+    "of DP on membership leakage independently of its effect on memorisation."
+)
+
+GAP_METRICS = ("bce_gap", "auc_gap", "accuracy_gap")
+LEAKAGE_METRICS = ("lira_auc", "tpr_at_1pct")
+
+
+def collect_observations(summaries: Sequence[dict[str, object]]) -> list[dict[str, object]]:
+    """One record per seed-level observation, including low-memorisation points.
+
+    Every observation is retained. Under Amendment 1 there are no skipped
+    points, and none may be filtered out here either -- dropping the
+    low-memorisation end is exactly the truncation the amendment exists to
+    prevent.
+    """
+    observations: list[dict[str, object]] = []
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            metrics = result.get("offline")
+            memo = result["memorisation"]
+            observations.append(
+                {
+                    "label": result["label"],
+                    "seed": int(result["seed"]),
+                    "requested_epsilon": result["requested_epsilon"],
+                    "achieved_epsilon": result.get("achieved_epsilon"),
+                    "noise_multiplier": result.get("noise_multiplier"),
+                    "private": result["requested_epsilon"] is not None,
+                    "train_auc": memo["train_auc"],
+                    "test_auc": memo["test_auc"],
+                    "train_bce": memo["train_loss"],
+                    "test_bce": memo["test_loss"],
+                    "train_accuracy": memo["train_accuracy"],
+                    "test_accuracy": memo["test_accuracy"],
+                    "auc_gap": memo["auc_gap"],
+                    "bce_gap": memo["loss_gap"],
+                    "accuracy_gap": memo["accuracy_gap"],
+                    "memorisation_threshold_passed": bool(result["memorisation_gate_passed"]),
+                    "lira_auc": (
+                        float(metrics["aggregate"]["auc"]) if metrics else float("nan")
+                    ),
+                    "tpr_at_1pct": (
+                        float(metrics["aggregate"][f"tpr_at_fpr_{HEADLINE_FPR}"])
+                        if metrics
+                        else float("nan")
+                    ),
+                }
+            )
+    return observations
+
+
+def _spearman(x: np.ndarray, y: np.ndarray) -> float:
+    """Spearman rank correlation, NaN when it is undefined."""
+    mask = np.isfinite(x) & np.isfinite(y)
+    if mask.sum() < 3:
+        return float("nan")
+    from scipy import stats
+
+    xr = stats.rankdata(x[mask])
+    yr = stats.rankdata(y[mask])
+    if np.std(xr) == 0 or np.std(yr) == 0:
+        return float("nan")
+    return float(np.corrcoef(xr, yr)[0, 1])
+
+
+def gap_associations(
+    observations: Sequence[dict[str, object]],
+    reps: int = 1000,
+    seed: int = 0,
+) -> dict[str, dict[str, float]]:
+    """Spearman associations with seed-stratified bootstrap intervals.
+
+    Resampling is stratified by target seed, so each replicate keeps the same
+    number of observations per seed and the interval reflects variation across
+    ladder points rather than across an arbitrary pooled sample.
+    """
+    rng = np.random.default_rng(seed)
+    seeds = sorted({int(o["seed"]) for o in observations})
+    by_seed = {s: [o for o in observations if int(o["seed"]) == s] for s in seeds}
+
+    results: dict[str, dict[str, float]] = {}
+    for gap in GAP_METRICS:
+        for leak in LEAKAGE_METRICS:
+            x = np.asarray([float(o[gap]) for o in observations], dtype=float)
+            y = np.asarray([float(o[leak]) for o in observations], dtype=float)
+            observed = _spearman(x, y)
+
+            draws = np.empty(reps, dtype=float)
+            for rep in range(reps):
+                sampled: list[dict[str, object]] = []
+                for s in seeds:
+                    pool = by_seed[s]
+                    idx = rng.integers(0, len(pool), size=len(pool))
+                    sampled.extend(pool[i] for i in idx)
+                draws[rep] = _spearman(
+                    np.asarray([float(o[gap]) for o in sampled], dtype=float),
+                    np.asarray([float(o[leak]) for o in sampled], dtype=float),
+                )
+            finite = draws[np.isfinite(draws)]
+            low, high = (
+                np.percentile(finite, [2.5, 97.5]) if finite.size else (np.nan, np.nan)
+            )
+            results[f"{gap}__{leak}"] = {
+                "gap_metric": gap,
+                "leakage_metric": leak,
+                "n_observations": int(np.sum(np.isfinite(x) & np.isfinite(y))),
+                "spearman": observed,
+                "reps": int(reps),
+                "ci95_low": float(low),
+                "ci95_high": float(high),
+            }
+    return results
+
+
 # --------------------------------------------------------------------------- #
 # One ladder point
 # --------------------------------------------------------------------------- #
@@ -550,12 +713,18 @@ def run_seed(
     bootstrap_reps: int,
     permutation_reps: int,
     epochs_override: int | None,
+    smoke: bool,
     log,
 ) -> dict[str, object]:
     """Train one target plus its shadows at one ladder point, then attack."""
-    from dp.attacks import lira_offline_attack, lira_online_attack
+    from dp.attacks import ONLINE_VARIANTS, lira_offline_attack, lira_online_attack
 
     epochs = EPOCHS if epochs_override is None else int(epochs_override)
+    # Smoke mode exists so CI can exercise the whole code path in minutes. It
+    # lowers the Gaussian floor, which the pre-registered configuration never
+    # does, so every artifact it produces is stamped `smoke: true` and the
+    # report refuses to present it as a pre-registered result.
+    min_observations = 2 if smoke else MIN_GAUSSIAN_OBSERVATIONS
 
     X_train, y_train = arrays["X_train"], arrays["y_train"]
     X_val, y_val = arrays["X_val"], arrays["y_val"]
@@ -620,9 +789,12 @@ def run_seed(
         "memorisation": metrics,
         "memorisation_gate": MEMORISATION_GATE,
         "memorisation_gate_passed": bool(gate_passed),
+        "smoke": bool(smoke),
         "attack_status": "pending",
         "offline": None,
         "online": None,
+        "online_raw_loss": None,
+        "online_logit_confidence": None,
         "online_available": False,
     }
 
@@ -631,12 +803,12 @@ def run_seed(
         f"achieved_eps={target_meta['achieved_epsilon']} "
         f"train_auc={metrics['train_auc']:.4f} test_auc={metrics['test_auc']:.4f} "
         f"auc_gap={metrics['auc_gap']:.4f} loss_gap={metrics['loss_gap']:.4f} "
-        f"gate={'PASS' if gate_passed else 'FAIL'}"
+        f"memorisation={'present' if gate_passed else 'low'} (metadata only)"
     )
-    if not gate_passed:
-        # Kept in the report as TARGET DID NOT MEMORISE, never dropped.
-        result["attack_status"] = "skipped_memorisation_gate"
-        return result
+    # Amendment 1: the attack runs at every point and seed. Memorisation is
+    # recorded as explanatory metadata, never as a condition on measurement --
+    # discarding low-memorisation observations would truncate the sample on a
+    # variable correlated with the outcome.
 
     X_pool = np.vstack([X_train, X_val, X_test])
     y_pool = np.concatenate([y_train, y_val, y_test])
@@ -700,9 +872,9 @@ def run_seed(
     min_in = min(len(v) for v in in_losses)
     if min_out != int(excluded_counts[attack_pool_idx].min()):
         raise AssertionError("recorded OUT losses do not match the schedule")
-    if min_out < MIN_GAUSSIAN_OBSERVATIONS:
+    if min_out < min_observations:
         raise RuntimeError(
-            f"offline LiRA needs >= {MIN_GAUSSIAN_OBSERVATIONS} OUT observations; got {min_out}"
+            f"offline LiRA needs >= {min_observations} OUT observations; got {min_out}"
         )
 
     out_matrix = np.vstack([np.asarray(v[:min_out], dtype=float) for v in out_losses])
@@ -736,24 +908,31 @@ def run_seed(
         }
     )
 
-    if min_in >= MIN_GAUSSIAN_OBSERVATIONS:
+    if min_in >= min_observations:
         in_matrix = np.vstack([np.asarray(v[:min_in], dtype=float) for v in in_losses])
-        online = lira_online_attack(
-            target_losses, attack_membership, in_matrix, out_matrix, fprs=ATTACK_FPRS
-        )
         result["online_available"] = True
-        result["online"] = attack_metrics(
-            attack_membership,
-            attack_groups,
-            online.scores,
-            bootstrap_reps,
-            seed + 30_000,
-            permutation_reps,
-        )
+        for offset, variant in enumerate(ONLINE_VARIANTS):
+            online = lira_online_attack(
+                target_losses,
+                attack_membership,
+                in_matrix,
+                out_matrix,
+                fprs=ATTACK_FPRS,
+                variant=variant,
+            )
+            result[variant] = attack_metrics(
+                attack_membership,
+                attack_groups,
+                online.scores,
+                bootstrap_reps,
+                seed + 30_000 + 1_000 * offset,
+                permutation_reps,
+            )
+        # Back-compatible alias: "online" is the raw-loss variant.
+        result["online"] = result["online_raw_loss"]
     else:
         result["online_unavailable_reason"] = (
-            f"only {min_in} IN observations per example; "
-            f"{MIN_GAUSSIAN_OBSERVATIONS} required"
+            f"only {min_in} IN observations per example; {min_observations} required"
         )
 
     log(
@@ -800,6 +979,7 @@ def run_point(args: argparse.Namespace) -> None:
                 bootstrap_reps=args.bootstrap_reps,
                 permutation_reps=args.permutation_reps,
                 epochs_override=args.epochs,
+                smoke=bool(args.smoke),
                 log=log,
             )
         )
@@ -816,6 +996,7 @@ def run_point(args: argparse.Namespace) -> None:
         "bootstrap_reps": int(args.bootstrap_reps),
         "permutation_reps": int(args.permutation_reps),
         "epochs": int(args.epochs) if args.epochs is not None else EPOCHS,
+        "smoke": bool(args.smoke),
         "seed_results": seed_results,
     }
     out_path = output_dir / f"{label}.json"
@@ -1037,8 +1218,30 @@ def render_markdown(payload: dict[str, object]) -> str:
     """Render the pre-registered report."""
     summaries: list[dict[str, object]] = payload["points"]
     frontier: dict[str, object] = payload["frontier"]
-    lines = [
-        "# DP-SGD detectability noise ladder",
+    lines = ["# Worst-case neural auditability ladder", ""]
+    if payload.get("smoke"):
+        lines += [
+            "> **SMOKE RUN -- NOT A PRE-REGISTERED RESULT.** Produced with a lowered "
+            "Gaussian observation floor and reduced budgets to exercise the pipeline. "
+            "No number below may be cited as a finding.",
+            "",
+        ]
+    lines += [
+        "",
+        "**Auditability ladder for a deliberately memorising neural target.** This is "
+        "not the universal DP-SGD detectability frontier: it characterises one "
+        "intentionally attackable architecture on one dataset, chosen because the "
+        "attack-power control showed it is attackable at all.",
+        "",
+        "Context from the attack-power control that motivates this design:",
+        "",
+        "| Control | Outcome |",
+        "|---|---|",
+        "| Matched-capacity MLP (mirrors the DP target recipe) | attack inconclusive -- "
+        "generalised rather than memorised |",
+        "| Deliberately memorising MLP | aggregate leakage detected |",
+        "| This ladder | effect of DP noise on an intentionally attackable neural "
+        "target |",
         "",
         "## 1. Pre-registered question and rules",
         "",
@@ -1048,15 +1251,24 @@ def render_markdown(payload: dict[str, object]) -> str:
         "Rules were fixed in `docs/NOISE_LADDER_PREREGISTRATION.md` and the adversary in "
         "`docs/THREAT_MODEL.md`, both committed before this experiment ran.",
         "",
-        f"A point is **{DETECTABLE}** only when the memorisation gate passes on all "
-        f"seeds, mean offline-LiRA AUC >= {DETECT_MEAN_AUC}, AUC > 0.5 on every seed, and "
-        f"the Holm-adjusted permutation null is rejected on >= {MIN_SIGNIFICANT_SEEDS} of "
-        f"3 seeds at alpha = {ALPHA}. Holm adjustment runs across ladder points within "
+        "**Detection rule** (unchanged from the original registration): mean "
+        f"offline-LiRA AUC >= {DETECT_MEAN_AUC}, AUC > 0.5 on every seed, and the "
+        f"Holm-adjusted permutation null rejected on >= {MIN_SIGNIFICANT_SEEDS} of 3 "
+        f"seeds at alpha = {ALPHA}. Holm adjustment runs across ladder points within "
         "each seed.",
         "",
-        f"**{UNDETECTABLE}**: gate passes, rule not met. "
-        f"**{DID_NOT_MEMORISE}**: gate fails. An undetected point is never called "
-        "private, safe or verified.",
+        "**Amendment 1**: every ladder point and seed receives the complete "
+        "matched-shadow attack. Memorisation is explanatory metadata, never an "
+        "execution gate, because discarding low-memorisation observations would "
+        "truncate the sample on a variable correlated with the outcome. Points are "
+        "classified by combining two independent decisions:",
+        "",
+        f"* `{DETECTABLE_WITH_MEMORISATION}`",
+        f"* `{DETECTABLE_LOW_MEMORISATION}`",
+        f"* `{UNDETECTABLE_WITH_MEMORISATION}`",
+        f"* `{UNDETECTABLE_LOW_MEMORISATION}`",
+        "",
+        "No point is ever called private, safe or verified.",
         "",
         "## 2. Threat model summary",
         "",
@@ -1302,12 +1514,46 @@ def render_markdown(payload: dict[str, object]) -> str:
             f"{summary['subgroup_basis']} |"
         )
 
+    # ---- Generalisation-gap association ------------------------------------ #
+    associations = payload.get("gap_associations") or {}
+    observations = payload.get("observations") or []
+    lines += [
+        "",
+        "## 10b. Generalisation gap and measured leakage",
+        "",
+        f"**{ASSOCIATION_ONLY_STATEMENT}**",
+        "",
+        f"Every seed-level observation is retained ({len(observations)} in total), "
+        "including those below the memorisation criterion. Spearman rank "
+        "correlations, with seed-stratified bootstrap intervals:",
+        "",
+        "| Generalisation gap | Leakage metric | n | Spearman rho | 95% CI |",
+        "|---|---|---:|---:|---|",
+    ]
+    for entry in associations.values():
+        lines.append(
+            f"| {entry['gap_metric']} | {entry['leakage_metric']} | "
+            f"{entry['n_observations']} | {_fmt(entry['spearman'])} | "
+            f"[{_fmt(entry['ci95_low'])}, {_fmt(entry['ci95_high'])}] |"
+        )
+    if not associations:
+        lines.append("| - | - | - | - | - |")
+    lines += [
+        "",
+        "Figures `lira_auc_vs_bce_gap.png`, `lira_auc_vs_auc_gap.png`, "
+        "`lira_auc_vs_accuracy_gap.png` and `tpr_vs_bce_gap.png` plot every "
+        "observation, distinguishing non-private from DP-SGD and "
+        "threshold-passing from low-memorisation points.",
+        "",
+        "No causal, mediation or \"beyond generalisation\" claim is made or implied.",
+    ]
+
     # ---- Conclusion -------------------------------------------------------- #
     non_private = next(
         (s for s in summaries if s["requested_epsilon"] is None), None
     )
     finite = [s for s in summaries if s["requested_epsilon"] is not None]
-    detectable_finite = [s for s in finite if s["decision"] == DETECTABLE]
+    detectable_finite = [s for s in finite if s["decision"] in DETECTABLE_STATUSES]
     supported = [s for s in summaries if s["subgroup_verdict"] == SUBGROUP_SUPPORTED]
 
     lines += ["", "## 11. Conclusion", ""]
@@ -1315,16 +1561,11 @@ def render_markdown(payload: dict[str, object]) -> str:
     lines += ["### 1. Does the attack detect aggregate leakage without DP?", ""]
     if non_private is None:
         lines.append("The non-private point was not run, so this cannot be answered here.")
-    elif non_private["decision"] == DETECTABLE:
+    elif non_private["decision"] in DETECTABLE_STATUSES:
         lines.append(
             f"Yes. The non-private target reaches mean offline-LiRA AUC "
             f"{_fmt(non_private['mean_offline_auc'])} with the Holm-adjusted permutation "
             "null rejected on the required number of seeds. The instrument works."
-        )
-    elif non_private["decision"] == DID_NOT_MEMORISE:
-        lines.append(
-            "Cannot be assessed: the non-private target failed the memorisation gate, so "
-            "there was nothing for the attack to find."
         )
     else:
         lines.append(
@@ -1366,7 +1607,7 @@ def render_markdown(payload: dict[str, object]) -> str:
         )
 
     lines += ["", "### 5. Is the insurance dataset adequate for aggregate auditing?", ""]
-    if non_private is not None and non_private["decision"] == DETECTABLE:
+    if non_private is not None and non_private["decision"] in DETECTABLE_STATUSES:
         lines.append(
             "Yes, at non-private capacity, and "
             + (
@@ -1531,6 +1772,84 @@ def make_figures(summaries: list[dict[str, object]], output_dir: Path) -> list[s
     return written
 
 
+
+def make_gap_figures(
+    observations: Sequence[dict[str, object]], output_dir: Path
+) -> list[str]:
+    """Scatter every seed-level observation of leakage against generalisation gap.
+
+    All observations appear, including those below the memorisation criterion --
+    they are the point of the amended design. Non-private and DP-SGD
+    observations use different markers; threshold-passing and low-memorisation
+    observations use filled and hollow faces.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    specs = [
+        ("bce_gap", "lira_auc", "lira_auc_vs_bce_gap.png",
+         "test - train BCE", "Offline-LiRA AUC"),
+        ("auc_gap", "lira_auc", "lira_auc_vs_auc_gap.png",
+         "train - test ROC-AUC", "Offline-LiRA AUC"),
+        ("accuracy_gap", "lira_auc", "lira_auc_vs_accuracy_gap.png",
+         "train - test accuracy", "Offline-LiRA AUC"),
+        ("bce_gap", "tpr_at_1pct", "tpr_vs_bce_gap.png",
+         "test - train BCE", "Offline-LiRA TPR @ 1% FPR"),
+    ]
+    written: list[str] = []
+    for gap, leak, filename, xlabel, ylabel in specs:
+        fig, ax = plt.subplots(figsize=(7, 4.8))
+        for private, marker, family in ((False, "s", "non-private"), (True, "o", "DP-SGD")):
+            for passed, face in ((True, "full"), (False, "none")):
+                subset = [
+                    o
+                    for o in observations
+                    if bool(o["private"]) is private
+                    and bool(o["memorisation_threshold_passed"]) is passed
+                ]
+                if not subset:
+                    continue
+                ax.scatter(
+                    [float(o[gap]) for o in subset],
+                    [float(o[leak]) for o in subset],
+                    marker=marker,
+                    s=44,
+                    facecolors="none" if face == "none" else None,
+                    edgecolors="tab:blue" if private else "tab:red",
+                    color=None if face == "none" else ("tab:blue" if private else "tab:red"),
+                    label=(
+                        f"{family}, "
+                        f"{'memorisation present' if passed else 'low memorisation'}"
+                    ),
+                )
+        if leak == "lira_auc":
+            ax.axhline(0.5, color="grey", linestyle="--", linewidth=1, label="AUC = 0.5")
+            ax.axhline(
+                DETECT_MEAN_AUC, color="darkorange", linestyle="-.", linewidth=1,
+                label=f"detection floor {DETECT_MEAN_AUC}",
+            )
+        else:
+            ax.axhline(
+                0.01, color="grey", linestyle="--", linewidth=1, label="1% random TPR"
+            )
+        ax.axvline(
+            MEMORISATION_GATE, color="green", linestyle=":", linewidth=1,
+            label=f"memorisation criterion {MEMORISATION_GATE}",
+        )
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"{ylabel} vs {xlabel} (association only)")
+        ax.legend(fontsize=7)
+        ax.grid(alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(output_dir / filename, dpi=150)
+        plt.close(fig)
+        written.append(filename)
+    return written
+
+
 def run_aggregate(args: argparse.Namespace) -> None:
     """Combine ladder-point artifacts into the final report."""
     root = Path(__file__).resolve().parents[1]
@@ -1581,6 +1900,10 @@ def run_aggregate(args: argparse.Namespace) -> None:
     apply_holm_across_points(points)
     summaries = summarise_points(points)
     frontier = detectability_frontier(summaries)
+    observations = collect_observations(summaries)
+    associations = gap_associations(
+        observations, reps=int(points[0].get("bootstrap_reps", 1000)), seed=7
+    )
 
     payload = {
         "experiment": "detectability_noise_ladder",
@@ -1592,15 +1915,21 @@ def run_aggregate(args: argparse.Namespace) -> None:
         "bootstrap_reps": points[0]["bootstrap_reps"],
         "permutation_reps": points[0]["permutation_reps"],
         "epochs": points[0].get("epochs", EPOCHS),
+        "smoke": any(bool(p.get("smoke")) for p in points),
         "alpha": ALPHA,
         "points": summaries,
         "frontier": frontier,
+        "observations": observations,
+        "gap_associations": associations,
+        "association_only_statement": ASSOCIATION_ONLY_STATEMENT,
     }
 
     (output_dir / "noise_ladder.json").write_text(json.dumps(payload, indent=2, default=float))
     pd.DataFrame(build_rows(summaries)).to_csv(output_dir / "noise_ladder.csv", index=False)
     (output_dir / "noise_ladder.md").write_text(render_markdown(payload))
     figures = make_figures(summaries, output_dir)
+    figures += make_gap_figures(observations, output_dir)
+    pd.DataFrame(observations).to_csv(output_dir / "observations.csv", index=False)
 
     for summary in summaries:
         log(f"[{summary['label']}] {summary['decision']} -- {summary['basis']}")
@@ -1626,6 +1955,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     point.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
     point.add_argument("--permutation-reps", type=int, default=DEFAULT_PERMUTATION_REPS)
     point.add_argument("--epochs", type=int, default=None, help="smoke-test override")
+    point.add_argument(
+        "--smoke",
+        action="store_true",
+        help=(
+            "CI smoke mode: lowers the Gaussian observation floor so a few shadows "
+            "suffice. Stamps the artifact as smoke; never a pre-registered result."
+        ),
+    )
     point.add_argument("--output-dir", default="reports/detectability_noise_ladder/points")
     point.set_defaults(func=run_point)
 

--- a/research/detectability_noise_ladder.py
+++ b/research/detectability_noise_ladder.py
@@ -1,0 +1,1647 @@
+"""DP-SGD detectability noise ladder for the insurance ``high_cost`` task.
+
+The attack-power control (``research/attack_power_control.py``) established that
+aggregate membership leakage *is* measurable on this dataset when a model
+memorises: the deliberately over-parameterised MLP reached offline-LiRA AUC
+0.558-0.586 with the permutation null rejected on all three seeds. What it did
+not establish is where that detectability ends once DP-SGD noise is applied.
+
+This script traces that frontier. It takes the same memorising architecture and
+runs it at six privacy levels -- non-private, then epsilon = 32, 16, 8, 4, 2 --
+changing **only the noise multiplier** between finite points. Cohort indices,
+shadow inclusion schedules, shadow base seeds and model-initialisation seeds are
+all derived from the target seed alone, never from the ladder point, so every
+point is paired against every other.
+
+Decision rules are pre-registered in ``docs/NOISE_LADDER_PREREGISTRATION.md``
+and the adversary is fixed in ``docs/THREAT_MODEL.md``. Both were committed
+before this experiment was run. The classification functions below implement
+those rules mechanically.
+
+Run one ladder point (matrix-friendly)::
+
+    python research/detectability_noise_ladder.py point --epsilon 8 --seeds 42 43 44
+
+Aggregate completed points into the final report::
+
+    python research/detectability_noise_ladder.py aggregate --input-dir <dir>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The attack-power control is the tested implementation of every statistic used
+# here. Reuse it rather than growing a second experiment framework.
+from attack_power_control import (  # noqa: E402
+    ATTACK_FPRS,
+    HEADLINE_FPR,
+    MEMORISATION_GATE,
+    MIN_GAUSSIAN_OBSERVATIONS,
+    attack_metrics,
+    balanced_shadow_train_sets,
+    build_mlp,
+    make_equalised_attack_cohort,
+    memorisation_gate_passed,
+    memorisation_metrics,
+    per_example_bce,
+)
+
+TASK_NAME = "high_cost"
+SENSITIVE_ATTRIBUTE = "sex"
+DELTA = 1e-5
+ACCOUNTANT = "rdp"
+DEFAULT_SEEDS = (42, 43, 44)
+DEFAULT_SHADOWS = 32
+DEFAULT_BOOTSTRAP_REPS = 1000
+DEFAULT_PERMUTATION_REPS = 1000
+ALPHA = 0.05
+
+#: Pre-registered aggregate detection thresholds.
+DETECT_MEAN_AUC = 0.55
+MIN_SIGNIFICANT_SEEDS = 2
+
+#: Fixed training recipe -- identical at every ladder point.
+HIDDEN_UNITS = (128, 128, 64)
+EPOCHS = 400
+BATCH_SIZE = 64
+LEARNING_RATE = 1e-3
+MAX_GRAD_NORM = 1.0
+TRAIN_SIZE = 856
+
+#: Requested privacy points. ``None`` is the non-private control.
+LADDER_EPSILONS: tuple[float | None, ...] = (None, 32.0, 16.0, 8.0, 4.0, 2.0)
+NON_PRIVATE_LABEL = "non-private"
+
+DETECTABLE = "AGGREGATE LEAKAGE DETECTABLE"
+UNDETECTABLE = "UNDETECTABLE AT CURRENT POWER"
+DID_NOT_MEMORISE = "TARGET DID NOT MEMORISE"
+
+SUBGROUP_SUPPORTED = "SUBGROUP DISPARITY SUPPORTED"
+SUBGROUP_UNSUPPORTED = "SUBGROUP DISPARITY UNSUPPORTED"
+SUBGROUP_INCONCLUSIVE = "SUBGROUP DISPARITY INCONCLUSIVE"
+
+
+def point_label(epsilon: float | None) -> str:
+    """Stable identifier for a ladder point, used in filenames and tables."""
+    if epsilon is None:
+        return NON_PRIVATE_LABEL
+    return f"eps{epsilon:g}"
+
+
+# --------------------------------------------------------------------------- #
+# Privacy accounting
+# --------------------------------------------------------------------------- #
+
+
+def solve_noise_multiplier(
+    target_epsilon: float,
+    sample_rate: float,
+    epochs: int,
+    delta: float = DELTA,
+) -> float:
+    """Noise multiplier reaching ``target_epsilon`` under RDP accounting.
+
+    Requested epsilon is an *input*; the achieved epsilon read back from the
+    accountant after training is the reported result.
+    """
+    from opacus.accountants.utils import get_noise_multiplier
+
+    return float(
+        get_noise_multiplier(
+            target_epsilon=target_epsilon,
+            target_delta=delta,
+            sample_rate=sample_rate,
+            epochs=epochs,
+            accountant=ACCOUNTANT,
+        )
+    )
+
+
+def epsilon_for_noise(
+    noise_multiplier: float,
+    sample_rate: float,
+    steps: int,
+    delta: float = DELTA,
+) -> float:
+    """Achieved epsilon for a fixed noise multiplier, via the RDP accountant."""
+    from dp.dpsgd import epsilon_for_noise_multiplier
+
+    return float(
+        epsilon_for_noise_multiplier(
+            noise_multiplier=noise_multiplier,
+            sample_rate=sample_rate,
+            steps=steps,
+            target_delta=delta,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Training -- identical recipe at every point, only the noise changes
+# --------------------------------------------------------------------------- #
+
+
+def train_ladder_model(
+    X: np.ndarray,
+    y: np.ndarray,
+    noise_multiplier: float | None,
+    seed: int,
+    epochs: int = EPOCHS,
+) -> tuple[object, dict[str, float | int | str | None]]:
+    """Train one target or shadow model at a given noise level.
+
+    ``noise_multiplier=None`` trains the non-private control: no Opacus, no
+    clipping, no noise. Everything else -- architecture, optimiser, epochs,
+    batch size, initialisation seed and batch ordering seed -- is identical
+    across all ladder points, so the noise multiplier is the only difference.
+    """
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    torch.manual_seed(seed)
+    X = np.asarray(X, dtype=np.float32)
+    y = np.asarray(y, dtype=np.float32)
+    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=min(BATCH_SIZE, len(dataset)),
+        shuffle=True,
+        generator=generator,
+    )
+
+    model = build_mlp(X.shape[1], HIDDEN_UNITS, seed)
+    optimizer = torch.optim.Adam(model.parameters(), lr=LEARNING_RATE)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    metadata: dict[str, float | int | str | None] = {
+        "train_size": int(len(dataset)),
+        "epochs": int(epochs),
+        "batch_size": BATCH_SIZE,
+        "learning_rate": LEARNING_RATE,
+        "seed": int(seed),
+        "noise_multiplier": None,
+        "achieved_epsilon": None,
+        "max_grad_norm": None,
+        "accountant": None,
+        "sampling": None,
+        "private": noise_multiplier is not None,
+    }
+
+    engine = None
+    if noise_multiplier is not None:
+        from opacus import PrivacyEngine
+
+        engine = PrivacyEngine(accountant=ACCOUNTANT)
+        model, optimizer, loader = engine.make_private(
+            module=model,
+            optimizer=optimizer,
+            data_loader=loader,
+            noise_multiplier=noise_multiplier,
+            max_grad_norm=MAX_GRAD_NORM,
+            poisson_sampling=True,
+        )
+        metadata.update(
+            {
+                "noise_multiplier": float(noise_multiplier),
+                "max_grad_norm": MAX_GRAD_NORM,
+                "accountant": ACCOUNTANT,
+                "sampling": "poisson",
+            }
+        )
+
+    model.train()
+    for _ in range(epochs):
+        for xb, yb in loader:
+            optimizer.zero_grad()
+            loss = loss_fn(model(xb).squeeze(-1), yb)
+            loss.backward()
+            optimizer.step()
+
+    if engine is not None:
+        metadata["achieved_epsilon"] = float(engine.get_epsilon(DELTA))
+    return model, metadata
+
+
+def predict_probability(model, X: np.ndarray) -> np.ndarray:
+    """Positive-class probabilities from a (possibly Opacus-wrapped) model."""
+    import torch
+
+    model.eval()
+    with torch.no_grad():
+        logits = model(torch.from_numpy(np.asarray(X, dtype=np.float32))).squeeze(-1)
+        return torch.sigmoid(logits).cpu().numpy()
+
+
+# --------------------------------------------------------------------------- #
+# Multiplicity adjustment
+# --------------------------------------------------------------------------- #
+
+
+def holm_adjust(p_values: Sequence[float]) -> list[float]:
+    """Holm-Bonferroni step-down adjustment.
+
+    Sorts ascending, scales the i-th smallest by ``m - i``, enforces monotone
+    non-decreasing adjusted values, clips at 1, and restores the input order.
+    NaNs are passed through untouched so a missing point cannot silently
+    inflate or deflate its neighbours.
+    """
+    values = np.asarray(list(p_values), dtype=float)
+    finite_idx = np.flatnonzero(np.isfinite(values))
+    adjusted = np.full(values.shape, np.nan, dtype=float)
+    if finite_idx.size == 0:
+        return adjusted.tolist()
+
+    finite = values[finite_idx]
+    order = np.argsort(finite, kind="stable")
+    m = finite.size
+    running = 0.0
+    scaled = np.empty(m, dtype=float)
+    for rank, idx in enumerate(order):
+        candidate = (m - rank) * finite[idx]
+        running = max(running, candidate)
+        scaled[idx] = min(1.0, running)
+    adjusted[finite_idx] = scaled
+    return adjusted.tolist()
+
+
+# --------------------------------------------------------------------------- #
+# Pre-registered classification
+# --------------------------------------------------------------------------- #
+
+
+def classify_ladder_point(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
+    """Apply the pre-registered aggregate detection rule to one ladder point.
+
+    Requires: gate passed on all seeds; mean offline AUC >= 0.55; AUC > 0.5 on
+    every seed; Holm-adjusted permutation null rejected on >= 2 of 3 seeds.
+    """
+    if not seed_results:
+        return DID_NOT_MEMORISE, "No seed produced a target model."
+
+    gates = [bool(r["memorisation_gate_passed"]) for r in seed_results]
+    if not all(gates):
+        failed = sum(1 for g in gates if not g)
+        return (
+            DID_NOT_MEMORISE,
+            f"The memorisation gate failed on {failed}/{len(gates)} seeds, so the "
+            "pre-registered rule cannot classify detectability here.",
+        )
+
+    completed = [r for r in seed_results if r["attack_status"] == "completed"]
+    if not completed:
+        return UNDETECTABLE, "Gate passed but no attack completed."
+
+    aucs = np.asarray(
+        [float(r["offline"]["aggregate"]["auc"]) for r in completed], dtype=float
+    )
+    adjusted = np.asarray(
+        [
+            float(r["offline"]["permutation"]["aggregate_auc"].get("p_value_holm", np.nan))
+            for r in completed
+        ],
+        dtype=float,
+    )
+    mean_auc = float(np.nanmean(aucs))
+    significant = int(np.sum(adjusted < ALPHA))
+    above_chance = bool(np.all(aucs > 0.5))
+    # The pre-registered rule is "2 of 3 seeds". Reduced-seed smoke runs would
+    # otherwise be unsatisfiable; at the pre-registered three seeds this is
+    # exactly MIN_SIGNIFICANT_SEEDS.
+    required = min(MIN_SIGNIFICANT_SEEDS, len(completed))
+
+    if mean_auc >= DETECT_MEAN_AUC and above_chance and significant >= required:
+        return (
+            DETECTABLE,
+            f"Mean offline-LiRA AUC {mean_auc:.4f} (>= {DETECT_MEAN_AUC}), above 0.5 on "
+            f"every seed, Holm-adjusted permutation null rejected on "
+            f"{significant}/{len(completed)} seeds (>= {required} required).",
+        )
+
+    reasons = []
+    if mean_auc < DETECT_MEAN_AUC:
+        reasons.append(f"mean AUC {mean_auc:.4f} < {DETECT_MEAN_AUC}")
+    if not above_chance:
+        reasons.append("at least one seed is at or below chance")
+    if significant < required:
+        reasons.append(
+            f"Holm-adjusted rejection on only {significant}/{len(completed)} seeds "
+            f"({required} required)"
+        )
+    return (
+        UNDETECTABLE,
+        "Target memorised but " + "; ".join(reasons) + ". Not detected at this power -- "
+        "this is not evidence of privacy.",
+    )
+
+
+def classify_subgroup(seed_results: Sequence[dict[str, object]]) -> tuple[str, str]:
+    """Apply the pre-registered signed-contrast subgroup rule."""
+    completed = [r for r in seed_results if r["attack_status"] == "completed"]
+    if not completed:
+        return SUBGROUP_INCONCLUSIVE, "No attack completed, so no subgroup comparison."
+
+    signed = np.asarray(
+        [float(r["offline"]["signed_subgroup_difference"]) for r in completed], dtype=float
+    )
+    signed_p = np.asarray(
+        [
+            float(
+                r["offline"]["permutation"]["signed_difference"].get(
+                    "p_value_holm", np.nan
+                )
+            )
+            for r in completed
+        ],
+        dtype=float,
+    )
+    gap_p = np.asarray(
+        [
+            float(r["offline"]["permutation"]["absolute_gap"].get("p_value_holm", np.nan))
+            for r in completed
+        ],
+        dtype=float,
+    )
+    resolutions = [float(r["subgroup_resolution"]) for r in completed]
+    resolution = float(max(resolutions)) if resolutions else float("inf")
+
+    nonzero = signed[signed != 0.0]
+    stable = bool(nonzero.size and np.all(np.sign(nonzero) == np.sign(nonzero[0])))
+    significant = int(np.sum((signed_p < ALPHA) | (gap_p < ALPHA)))
+    resolvable = bool(signed.size and np.all(np.abs(signed) >= resolution))
+    # The subgroup rule is NOT relaxed for reduced-seed runs: pre-registered
+    # criterion 4 forbids single-seed effects outright, so a one-seed run can
+    # never support a disparity claim.
+    required = MIN_SIGNIFICANT_SEEDS
+    carrying = int(np.sum(np.abs(signed) >= resolution))
+    multi_seed = carrying >= required
+
+    if stable and significant >= required and resolvable and multi_seed:
+        direction = "male" if float(np.mean(signed)) > 0 else "female"
+        return (
+            SUBGROUP_SUPPORTED,
+            f"Signed male-female TPR@1% contrast keeps one sign across seeds "
+            f"({direction} more exposed), adjusted permutation p<{ALPHA} on "
+            f"{significant}/{len(completed)} seeds, and every effect exceeds the "
+            f"{resolution:.4f} one-person resolution.",
+        )
+
+    reasons = []
+    if not stable:
+        reasons.append("the signed direction is not stable across non-zero seeds")
+    if significant < required:
+        reasons.append(
+            f"the adjusted permutation null is rejected on only "
+            f"{significant}/{len(completed)} seeds ({required} required)"
+        )
+    if not resolvable:
+        reasons.append(
+            f"at least one contrast is within the {resolution:.4f} one-person resolution"
+        )
+    elif not multi_seed:
+        reasons.append("the effect is carried by a single seed")
+    return SUBGROUP_UNSUPPORTED, "; ".join(reasons).capitalize() + "."
+
+
+def detectability_frontier(points: Sequence[dict[str, object]]) -> dict[str, object]:
+    """Bracket the transition, or report the pattern as unstable.
+
+    Points are ordered by descending achieved epsilon (non-private first, as the
+    least noisy). Detection is expected to be monotone -- detectable at low
+    noise, lost at high noise. Any detectable point appearing *below* an
+    undetectable one breaks that, and is reported as non-monotonic rather than
+    smoothed into a single threshold.
+    """
+    ordered = sorted(
+        points,
+        key=lambda p: (
+            float("inf")
+            if p["requested_epsilon"] is None
+            else float(p["requested_epsilon"])
+        ),
+        reverse=True,
+    )
+    classified = [p for p in ordered if p["decision"] != DID_NOT_MEMORISE]
+    flags = [p["decision"] == DETECTABLE for p in classified]
+
+    # Monotone means: every detectable point precedes every undetectable one.
+    non_monotonic = any(
+        flags[i] and not flags[i - 1] for i in range(1, len(flags))
+    )
+
+    result: dict[str, object] = {
+        "ordered_points": [
+            {
+                "label": p["label"],
+                "requested_epsilon": p["requested_epsilon"],
+                "achieved_epsilon": p.get("achieved_epsilon"),
+                "noise_multiplier": p.get("noise_multiplier"),
+                "decision": p["decision"],
+            }
+            for p in ordered
+        ],
+        "non_monotonic": bool(non_monotonic),
+        "last_detectable": None,
+        "first_undetectable": None,
+        "bracket": None,
+        "stable": not non_monotonic,
+    }
+    if non_monotonic:
+        result["summary"] = (
+            "Detection is NON-MONOTONIC across the ladder: a lower-epsilon point is "
+            "detectable while a higher-epsilon point is not. No single threshold is "
+            "reported; the frontier is classified as UNSTABLE."
+        )
+        return result
+
+    detectable = [p for p, f in zip(classified, flags) if f]
+    undetectable = [p for p, f in zip(classified, flags) if not f]
+    if detectable:
+        result["last_detectable"] = detectable[-1]["label"]
+    if undetectable:
+        result["first_undetectable"] = undetectable[0]["label"]
+
+    if detectable and undetectable:
+        low = detectable[-1]
+        high = undetectable[0]
+        low_eps = low.get("achieved_epsilon") or low["requested_epsilon"]
+        high_eps = high.get("achieved_epsilon") or high["requested_epsilon"]
+        result["bracket"] = {
+            "detectable_at": low["label"],
+            "detectable_epsilon": low_eps,
+            "not_detectable_at": high["label"],
+            "not_detectable_epsilon": high_eps,
+        }
+        result["summary"] = (
+            f"detectable at epsilon = {low_eps if low_eps is None else f'{float(low_eps):.4f}'} "
+            f"({low['label']}); not detectable at epsilon = "
+            f"{high_eps if high_eps is None else f'{float(high_eps):.4f}'} ({high['label']}); "
+            "therefore the empirical transition lies between them. Six points do not "
+            "support interpolating a precise threshold."
+        )
+    elif detectable:
+        finite_classified = [
+            p for p in classified if p["requested_epsilon"] is not None
+        ]
+        if not finite_classified:
+            result["summary"] = (
+                "Only the non-private point could be classified; every finite privacy "
+                "point failed the memorisation gate, so the frontier cannot be "
+                "bracketed. This is a statement about the targets, not about privacy."
+            )
+        else:
+            result["summary"] = (
+                "Leakage remains detectable at every classified ladder point, including "
+                "the noisiest tested. The transition lies below the lowest epsilon "
+                "tested."
+            )
+    else:
+        result["summary"] = (
+            "No classified ladder point shows detectable leakage, including the "
+            "non-private control. The frontier cannot be bracketed; this indicates an "
+            "attack-power problem rather than a privacy result."
+        )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# One ladder point
+# --------------------------------------------------------------------------- #
+
+
+def prepare_seed_arrays(df: pd.DataFrame, seed: int) -> dict[str, np.ndarray]:
+    """Leakage-safe split and preprocessing for one target seed.
+
+    Depends only on the seed, so every ladder point sees identical partitions.
+    """
+    from dp.pipeline import build_preprocessor
+    from dp.tasks import get_task, prepare_task_data
+
+    data = prepare_task_data(df, get_task(TASK_NAME), random_state=seed)
+    preprocessor = build_preprocessor(data.X_train)
+    return {
+        "X_train": np.asarray(preprocessor.fit_transform(data.X_train), dtype=np.float32),
+        "X_val": np.asarray(preprocessor.transform(data.X_val), dtype=np.float32),
+        "X_test": np.asarray(preprocessor.transform(data.X_test), dtype=np.float32),
+        "y_train": data.y_train,
+        "y_val": data.y_val,
+        "y_test": data.y_test,
+        "groups_train": data.sensitive_train,
+        "groups_test": data.sensitive_test,
+    }
+
+
+def run_seed(
+    arrays: dict[str, np.ndarray],
+    requested_epsilon: float | None,
+    seed: int,
+    num_shadows: int,
+    bootstrap_reps: int,
+    permutation_reps: int,
+    epochs_override: int | None,
+    log,
+) -> dict[str, object]:
+    """Train one target plus its shadows at one ladder point, then attack."""
+    from dp.attacks import lira_offline_attack, lira_online_attack
+
+    epochs = EPOCHS if epochs_override is None else int(epochs_override)
+
+    X_train, y_train = arrays["X_train"], arrays["y_train"]
+    X_val, y_val = arrays["X_val"], arrays["y_val"]
+    X_test, y_test = arrays["X_test"], arrays["y_test"]
+
+    X_attack = np.vstack([X_train, X_test])
+    y_attack = np.concatenate([y_train, y_test])
+    groups_attack = np.concatenate([arrays["groups_train"], arrays["groups_test"]]).astype(str)
+    membership = np.concatenate(
+        [np.ones(len(y_train), dtype=int), np.zeros(len(y_test), dtype=int)]
+    )
+    # Cohort seeded by target seed only -> identical at every ladder point.
+    attack_idx, cohort_counts = make_equalised_attack_cohort(groups_attack, membership, seed)
+
+    sample_rate = min(BATCH_SIZE, len(y_train)) / len(y_train)
+    steps = epochs * int(np.ceil(len(y_train) / min(BATCH_SIZE, len(y_train))))
+    noise_multiplier = None
+    if requested_epsilon is not None:
+        noise_multiplier = solve_noise_multiplier(
+            requested_epsilon, sample_rate, epochs, DELTA
+        )
+
+    target, target_meta = train_ladder_model(
+        X_train, y_train, noise_multiplier, seed=seed, epochs=epochs
+    )
+    if int(target_meta["train_size"]) != len(y_train):
+        raise AssertionError("target train size does not match the training partition")
+
+    metrics = memorisation_metrics(
+        y_train,
+        predict_probability(target, X_train),
+        y_test,
+        predict_probability(target, X_test),
+    )
+    gate_passed = memorisation_gate_passed(metrics)
+
+    result: dict[str, object] = {
+        "label": point_label(requested_epsilon),
+        "requested_epsilon": requested_epsilon,
+        "seed": int(seed),
+        "delta": DELTA,
+        "accountant": ACCOUNTANT if requested_epsilon is not None else None,
+        "sampling": "poisson" if requested_epsilon is not None else None,
+        "noise_multiplier": noise_multiplier,
+        "achieved_epsilon": target_meta["achieved_epsilon"],
+        "accountant_epsilon": (
+            epsilon_for_noise(noise_multiplier, sample_rate, steps, DELTA)
+            if noise_multiplier is not None
+            else None
+        ),
+        "max_grad_norm": MAX_GRAD_NORM if requested_epsilon is not None else None,
+        "epochs": epochs,
+        "batch_size": BATCH_SIZE,
+        "learning_rate": LEARNING_RATE,
+        "architecture": f"Linear(d,{'->'.join(map(str, HIDDEN_UNITS))}->1) + ReLU",
+        "train_size": int(len(y_train)),
+        "val_size": int(len(y_val)),
+        "test_size": int(len(y_test)),
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(attack_idx)),
+        "cohort_index_digest": int(np.sum(attack_idx.astype(np.int64) * 2654435761) % (2**31)),
+        "memorisation": metrics,
+        "memorisation_gate": MEMORISATION_GATE,
+        "memorisation_gate_passed": bool(gate_passed),
+        "attack_status": "pending",
+        "offline": None,
+        "online": None,
+        "online_available": False,
+    }
+
+    log(
+        f"[{result['label']} seed={seed}] noise={noise_multiplier} "
+        f"achieved_eps={target_meta['achieved_epsilon']} "
+        f"train_auc={metrics['train_auc']:.4f} test_auc={metrics['test_auc']:.4f} "
+        f"auc_gap={metrics['auc_gap']:.4f} loss_gap={metrics['loss_gap']:.4f} "
+        f"gate={'PASS' if gate_passed else 'FAIL'}"
+    )
+    if not gate_passed:
+        # Kept in the report as TARGET DID NOT MEMORISE, never dropped.
+        result["attack_status"] = "skipped_memorisation_gate"
+        return result
+
+    X_pool = np.vstack([X_train, X_val, X_test])
+    y_pool = np.concatenate([y_train, y_val, y_test])
+    attack_pool_idx = attack_idx.copy()
+    attack_pool_idx[attack_pool_idx >= len(y_train)] += len(y_val)
+
+    # Schedule seeded by target seed only -> identical at every ladder point.
+    schedule_seed = seed + 10_000
+    train_sets, excluded_counts = balanced_shadow_train_sets(
+        y_pool, train_size=len(y_train), num_shadows=num_shadows, seed=schedule_seed
+    )
+    result["shadow_schedule_digest"] = int(
+        np.sum(np.concatenate(train_sets).astype(np.int64) * 2654435761) % (2**31)
+    )
+
+    target_losses = per_example_bce(
+        y_attack[attack_idx], predict_probability(target, X_attack)[attack_idx]
+    )
+    out_losses: list[list[float]] = [[] for _ in attack_pool_idx]
+    in_losses: list[list[float]] = [[] for _ in attack_pool_idx]
+
+    for shadow_id, train_idx in enumerate(train_sets):
+        if len(train_idx) != len(y_train):
+            raise AssertionError("shadow and target train sizes differ")
+        # Shadow base seed depends on target seed and shadow id only.
+        shadow_model, shadow_meta = train_ladder_model(
+            X_pool[train_idx],
+            y_pool[train_idx],
+            noise_multiplier,
+            seed=schedule_seed + shadow_id + 1,
+            epochs=epochs,
+        )
+        if int(shadow_meta["train_size"]) != int(target_meta["train_size"]):
+            raise AssertionError("shadow and target train sizes differ")
+        if noise_multiplier is not None:
+            if not np.isclose(
+                float(shadow_meta["noise_multiplier"]), float(noise_multiplier), atol=1e-12
+            ):
+                raise AssertionError("shadow noise multiplier differs from target")
+            if not np.isclose(
+                float(shadow_meta["achieved_epsilon"]),
+                float(target_meta["achieved_epsilon"]),
+                rtol=1e-6,
+            ):
+                raise AssertionError(
+                    "shadow achieved epsilon differs from target beyond accounting tolerance"
+                )
+
+        in_mask = np.zeros(len(y_pool), dtype=bool)
+        in_mask[train_idx] = True
+        losses = per_example_bce(
+            y_pool[attack_pool_idx], predict_probability(shadow_model, X_pool[attack_pool_idx])
+        )
+        for local_idx, is_in in enumerate(in_mask[attack_pool_idx]):
+            (in_losses if is_in else out_losses)[local_idx].append(float(losses[local_idx]))
+
+        if (shadow_id + 1) % 8 == 0 or shadow_id == 0:
+            log(f"[{result['label']} seed={seed}] shadow {shadow_id + 1}/{num_shadows}")
+
+    min_out = min(len(v) for v in out_losses)
+    min_in = min(len(v) for v in in_losses)
+    if min_out != int(excluded_counts[attack_pool_idx].min()):
+        raise AssertionError("recorded OUT losses do not match the schedule")
+    if min_out < MIN_GAUSSIAN_OBSERVATIONS:
+        raise RuntimeError(
+            f"offline LiRA needs >= {MIN_GAUSSIAN_OBSERVATIONS} OUT observations; got {min_out}"
+        )
+
+    out_matrix = np.vstack([np.asarray(v[:min_out], dtype=float) for v in out_losses])
+    attack_groups = groups_attack[attack_idx]
+    attack_membership = membership[attack_idx]
+    member_counts = {
+        group: int(((attack_groups == group) & (attack_membership == 1)).sum())
+        for group in np.unique(attack_groups)
+    }
+    resolution = 1.0 / max(min(member_counts.values()), 1)
+
+    offline = lira_offline_attack(
+        target_losses, attack_membership, out_matrix, fprs=ATTACK_FPRS
+    )
+    result.update(
+        {
+            "attack_status": "completed",
+            "num_shadows": int(num_shadows),
+            "min_out_observations": int(min_out),
+            "min_in_observations": int(min_in),
+            "subgroup_member_counts": member_counts,
+            "subgroup_resolution": resolution,
+            "offline": attack_metrics(
+                attack_membership,
+                attack_groups,
+                offline.scores,
+                bootstrap_reps,
+                seed + 20_000,
+                permutation_reps,
+            ),
+        }
+    )
+
+    if min_in >= MIN_GAUSSIAN_OBSERVATIONS:
+        in_matrix = np.vstack([np.asarray(v[:min_in], dtype=float) for v in in_losses])
+        online = lira_online_attack(
+            target_losses, attack_membership, in_matrix, out_matrix, fprs=ATTACK_FPRS
+        )
+        result["online_available"] = True
+        result["online"] = attack_metrics(
+            attack_membership,
+            attack_groups,
+            online.scores,
+            bootstrap_reps,
+            seed + 30_000,
+            permutation_reps,
+        )
+    else:
+        result["online_unavailable_reason"] = (
+            f"only {min_in} IN observations per example; "
+            f"{MIN_GAUSSIAN_OBSERVATIONS} required"
+        )
+
+    log(
+        f"[{result['label']} seed={seed}] offline AUC="
+        f"{result['offline']['aggregate']['auc']:.4f} "
+        f"TPR@1%={result['offline']['aggregate'][f'tpr_at_fpr_{HEADLINE_FPR}']:.4f} "
+        f"perm_p={result['offline']['permutation']['aggregate_auc']['p_value']:.4f}"
+    )
+    return result
+
+
+def run_point(args: argparse.Namespace) -> None:
+    """Run every seed for a single ladder point and write its artifact."""
+    import torch
+
+    torch.set_num_threads(2)
+    root = Path(__file__).resolve().parents[1]
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    requested = None if args.epsilon is None or args.epsilon <= 0 else float(args.epsilon)
+    label = point_label(requested)
+    log_path = output_dir / f"{label}.log"
+    handle = log_path.open("w", encoding="utf-8")
+
+    def log(message: str) -> None:
+        print(message, flush=True)
+        handle.write(message + "\n")
+        handle.flush()
+
+    log(f"=== ladder point {label} (requested epsilon={requested}) ===")
+    df = pd.read_csv(root / "data" / "insurance.csv")
+    seed_results = []
+    for seed in args.seeds:
+        arrays = prepare_seed_arrays(df, seed)
+        seed_results.append(
+            run_seed(
+                arrays,
+                requested,
+                seed,
+                num_shadows=args.shadows,
+                bootstrap_reps=args.bootstrap_reps,
+                permutation_reps=args.permutation_reps,
+                epochs_override=args.epochs,
+                log=log,
+            )
+        )
+
+    payload = {
+        "experiment": "detectability_noise_ladder_point",
+        "label": label,
+        "requested_epsilon": requested,
+        "task": TASK_NAME,
+        "sensitive_attribute": SENSITIVE_ATTRIBUTE,
+        "delta": DELTA,
+        "seeds": [int(s) for s in args.seeds],
+        "num_shadows": int(args.shadows),
+        "bootstrap_reps": int(args.bootstrap_reps),
+        "permutation_reps": int(args.permutation_reps),
+        "epochs": int(args.epochs) if args.epochs is not None else EPOCHS,
+        "seed_results": seed_results,
+    }
+    out_path = output_dir / f"{label}.json"
+    out_path.write_text(json.dumps(payload, indent=2, default=float))
+    log(f"Wrote {out_path}")
+    handle.close()
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation
+# --------------------------------------------------------------------------- #
+
+
+def apply_holm_across_points(points: list[dict[str, object]]) -> None:
+    """Holm-adjust permutation p-values across ladder points, within each seed.
+
+    Each (seed, attack variant, statistic) family is adjusted over the ladder
+    points, which is the multiplicity actually introduced by the ladder.
+    """
+    statistics = ("aggregate_auc", "aggregate_tpr", "signed_difference", "absolute_gap")
+    seeds = sorted({int(r["seed"]) for p in points for r in p["seed_results"]})
+    for seed in seeds:
+        for variant in ("offline", "online"):
+            for statistic in statistics:
+                entries = []
+                for point in points:
+                    for result in point["seed_results"]:
+                        if int(result["seed"]) != seed:
+                            continue
+                        metrics = result.get(variant)
+                        if not metrics:
+                            continue
+                        entry = metrics["permutation"].get(statistic)
+                        if entry is not None:
+                            entries.append(entry)
+                if not entries:
+                    continue
+                adjusted = holm_adjust([float(e["p_value"]) for e in entries])
+                for entry, value in zip(entries, adjusted):
+                    entry["p_value_holm"] = float(value)
+
+
+def summarise_points(points: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Per-point summary plus the pre-registered decisions."""
+    summaries = []
+    for point in points:
+        seed_results = point["seed_results"]
+        completed = [r for r in seed_results if r["attack_status"] == "completed"]
+        decision, basis = classify_ladder_point(seed_results)
+        subgroup_verdict, subgroup_basis = classify_subgroup(seed_results)
+        achieved = [
+            float(r["achieved_epsilon"])
+            for r in seed_results
+            if r.get("achieved_epsilon") is not None
+        ]
+        noises = [
+            float(r["noise_multiplier"])
+            for r in seed_results
+            if r.get("noise_multiplier") is not None
+        ]
+        summaries.append(
+            {
+                "label": point["label"],
+                "requested_epsilon": point["requested_epsilon"],
+                "achieved_epsilon": float(np.mean(achieved)) if achieved else None,
+                "noise_multiplier": float(np.mean(noises)) if noises else None,
+                "seeds": [int(r["seed"]) for r in seed_results],
+                "seeds_attacked": len(completed),
+                "gate_passed_seeds": int(
+                    sum(1 for r in seed_results if r["memorisation_gate_passed"])
+                ),
+                "mean_auc_gap": float(
+                    np.mean([r["memorisation"]["auc_gap"] for r in seed_results])
+                ),
+                "mean_loss_gap": float(
+                    np.mean([r["memorisation"]["loss_gap"] for r in seed_results])
+                ),
+                "mean_offline_auc": (
+                    float(np.mean([r["offline"]["aggregate"]["auc"] for r in completed]))
+                    if completed
+                    else None
+                ),
+                "mean_offline_tpr_1pct": (
+                    float(
+                        np.mean(
+                            [
+                                r["offline"]["aggregate"][f"tpr_at_fpr_{HEADLINE_FPR}"]
+                                for r in completed
+                            ]
+                        )
+                    )
+                    if completed
+                    else None
+                ),
+                "min_holm_p": (
+                    float(
+                        np.nanmin(
+                            [
+                                r["offline"]["permutation"]["aggregate_auc"].get(
+                                    "p_value_holm", np.nan
+                                )
+                                for r in completed
+                            ]
+                        )
+                    )
+                    if completed
+                    else None
+                ),
+                "decision": decision,
+                "basis": basis,
+                "subgroup_verdict": subgroup_verdict,
+                "subgroup_basis": subgroup_basis,
+                "seed_results": seed_results,
+            }
+        )
+    return summaries
+
+
+def build_rows(summaries: list[dict[str, object]]) -> list[dict[str, object]]:
+    """One CSV row per ladder point, seed and attack variant."""
+    rows = []
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            variants = [v for v in ("offline", "online") if result.get(v)] or [None]
+            for variant in variants:
+                row: dict[str, object] = {
+                    "label": result["label"],
+                    "requested_epsilon": result["requested_epsilon"],
+                    "achieved_epsilon": result.get("achieved_epsilon"),
+                    "noise_multiplier": result.get("noise_multiplier"),
+                    "seed": result["seed"],
+                    "attack": f"lira-{variant}" if variant else "none",
+                    "attack_status": result["attack_status"],
+                    "decision": summary["decision"],
+                    "memorisation_gate_passed": result["memorisation_gate_passed"],
+                    "train_size": result["train_size"],
+                    "train_auc": result["memorisation"]["train_auc"],
+                    "test_auc": result["memorisation"]["test_auc"],
+                    "auc_gap": result["memorisation"]["auc_gap"],
+                    "loss_gap": result["memorisation"]["loss_gap"],
+                    "accuracy_gap": result["memorisation"]["accuracy_gap"],
+                    "min_out_observations": result.get("min_out_observations"),
+                    "min_in_observations": result.get("min_in_observations"),
+                    "subgroup_resolution": result.get("subgroup_resolution"),
+                }
+                if variant:
+                    metrics = result[variant]
+                    agg = metrics["aggregate"]
+                    perm = metrics["permutation"]
+                    boot = metrics["bootstrap"]
+                    row.update(
+                        {
+                            "lira_auc": agg["auc"],
+                            "tpr_at_fpr_0.001": agg["tpr_at_fpr_0.001"],
+                            "tpr_at_fpr_0.01": agg["tpr_at_fpr_0.01"],
+                            "tpr_at_fpr_0.1": agg["tpr_at_fpr_0.1"],
+                            "detected_members_at_1pct": agg["operating_point"][
+                                "detected_members"
+                            ],
+                            "false_positives_at_1pct": agg["operating_point"][
+                                "false_positives"
+                            ],
+                            "permutation_null_auc_mean": perm["aggregate_auc"]["null_mean"],
+                            "permutation_null_auc_ci_low": perm["aggregate_auc"][
+                                "null_ci95_low"
+                            ],
+                            "permutation_null_auc_ci_high": perm["aggregate_auc"][
+                                "null_ci95_high"
+                            ],
+                            "permutation_p_auc": perm["aggregate_auc"]["p_value"],
+                            "permutation_p_auc_holm": perm["aggregate_auc"].get(
+                                "p_value_holm"
+                            ),
+                            "permutation_p_tpr": perm["aggregate_tpr"]["p_value"],
+                            "permutation_p_tpr_holm": perm["aggregate_tpr"].get(
+                                "p_value_holm"
+                            ),
+                            "bootstrap_tpr_ci_low": boot["aggregate"]["ci95_low"],
+                            "bootstrap_tpr_ci_high": boot["aggregate"]["ci95_high"],
+                            "signed_gap": metrics["signed_subgroup_difference"],
+                            "absolute_gap": metrics["absolute_subgroup_gap"],
+                            "permutation_p_signed_holm": perm["signed_difference"].get(
+                                "p_value_holm"
+                            ),
+                            "permutation_p_absolute_holm": perm["absolute_gap"].get(
+                                "p_value_holm"
+                            ),
+                        }
+                    )
+                    for group, gm in metrics["subgroups"].items():
+                        row[f"{group}_auc"] = gm["auc"]
+                        row[f"{group}_tpr_at_fpr_0.01"] = gm["tpr_at_fpr_0.01"]
+                        row[f"{group}_detected_members"] = gm["operating_point"][
+                            "detected_members"
+                        ]
+                        row[f"{group}_false_positives"] = gm["operating_point"][
+                            "false_positives"
+                        ]
+                        row[f"{group}_tpr_ci_low"] = boot[group]["ci95_low"]
+                        row[f"{group}_tpr_ci_high"] = boot[group]["ci95_high"]
+                        row[f"{group}_permutation_p"] = perm[group]["p_value"]
+                rows.append(row)
+    return rows
+
+
+def _fmt(value: object, digits: int = 4) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, str):
+        return value
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return f"{number:.{digits}f}" if np.isfinite(number) else "-"
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    """Render the pre-registered report."""
+    summaries: list[dict[str, object]] = payload["points"]
+    frontier: dict[str, object] = payload["frontier"]
+    lines = [
+        "# DP-SGD detectability noise ladder",
+        "",
+        "## 1. Pre-registered question and rules",
+        "",
+        "> At what privacy-noise level does aggregate natural membership leakage cease "
+        "to be reproducibly detectable on the insurance `high_cost` task?",
+        "",
+        "Rules were fixed in `docs/NOISE_LADDER_PREREGISTRATION.md` and the adversary in "
+        "`docs/THREAT_MODEL.md`, both committed before this experiment ran.",
+        "",
+        f"A point is **{DETECTABLE}** only when the memorisation gate passes on all "
+        f"seeds, mean offline-LiRA AUC >= {DETECT_MEAN_AUC}, AUC > 0.5 on every seed, and "
+        f"the Holm-adjusted permutation null is rejected on >= {MIN_SIGNIFICANT_SEEDS} of "
+        f"3 seeds at alpha = {ALPHA}. Holm adjustment runs across ladder points within "
+        "each seed.",
+        "",
+        f"**{UNDETECTABLE}**: gate passes, rule not met. "
+        f"**{DID_NOT_MEMORISE}**: gate fails. An undetected point is never called "
+        "private, safe or verified.",
+        "",
+        "## 2. Threat model summary",
+        "",
+        "The adversary knows the architecture, optimiser, batch size, epochs, clipping "
+        "norm, preprocessing, task definition, source distribution and (at finite "
+        "points) the noise multiplier and claimed (epsilon, delta). They do not know "
+        "the target's membership set. They train matched shadows on the same pool. "
+        "Membership is record-level inclusion; the sensitive attribute is `sex`. "
+        "Offline LiRA is primary, online LiRA secondary and reported only with >= 10 IN "
+        "and >= 10 OUT observations per example.",
+        "",
+        "## 3. Fixed experimental design",
+        "",
+        "| Parameter | Value |",
+        "|---|---|",
+        f"| Task | `{payload['task']}` |",
+        f"| Sensitive attribute | `{payload['sensitive_attribute']}` |",
+        f"| Architecture | `Linear(d,{'->'.join(map(str, HIDDEN_UNITS))}->1)` with ReLU |",
+        f"| Epochs | {payload.get('epochs', EPOCHS)} |",
+        f"| Batch size | {BATCH_SIZE} |",
+        f"| Optimiser | Adam, lr = {LEARNING_RATE} |",
+        f"| Clipping norm | {MAX_GRAD_NORM} (fixed, public) |",
+        f"| delta | {DELTA} |",
+        f"| Accountant | {ACCOUNTANT.upper()} |",
+        "| Sampling | Poisson |",
+        f"| Seeds | {', '.join(str(s) for s in payload['seeds'])} |",
+        f"| Shadows per point per seed | {payload['num_shadows']} |",
+        f"| Bootstrap / permutation replicates | {payload['bootstrap_reps']} / "
+        f"{payload['permutation_reps']} |",
+        "",
+        "Only the noise multiplier changes between finite points. Cohort indices, "
+        "shadow schedules and model seeds derive from the target seed alone, so points "
+        "are paired.",
+        "",
+        "## 4. Privacy accounting",
+        "",
+        "| Point | Requested epsilon | Noise multiplier | Achieved epsilon | Clipping |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for summary in summaries:
+        requested = (
+            NON_PRIVATE_LABEL
+            if summary["requested_epsilon"] is None
+            else f"{float(summary['requested_epsilon']):g}"
+        )
+        lines.append(
+            f"| {summary['label']} | {requested} | {_fmt(summary['noise_multiplier'])} | "
+            f"{_fmt(summary['achieved_epsilon'])} | "
+            f"{'-' if summary['noise_multiplier'] is None else MAX_GRAD_NORM} |"
+        )
+    lines += [
+        "",
+        "Requested epsilon is an input. The achieved epsilon read back from the RDP "
+        "accountant after training is the reported figure.",
+        "",
+        "## 5. Memorisation metrics",
+        "",
+        "| Point | Seed | Train AUC | Test AUC | AUC gap | Train BCE | Test BCE | "
+        "Loss gap | Acc gap | Gate |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            m = result["memorisation"]
+            lines.append(
+                f"| {result['label']} | {result['seed']} | {_fmt(m['train_auc'])} | "
+                f"{_fmt(m['test_auc'])} | {_fmt(m['auc_gap'])} | {_fmt(m['train_loss'])} | "
+                f"{_fmt(m['test_loss'])} | {_fmt(m['loss_gap'])} | "
+                f"{_fmt(m['accuracy_gap'])} | "
+                f"{'PASS' if result['memorisation_gate_passed'] else 'FAIL'} |"
+            )
+
+    lines += [
+        "",
+        "## 6. Aggregate LiRA results",
+        "",
+        "| Point | Seed | Attack | LiRA AUC | TPR@0.1% | TPR@1% | TPR@10% | "
+        "Detected @1% | FP @1% | OUT | IN |",
+        "|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            if result["attack_status"] != "completed":
+                lines.append(
+                    f"| {result['label']} | {result['seed']} | - | "
+                    f"**{result['attack_status']}** | - | - | - | - | - | - | - |"
+                )
+                continue
+            for variant in ("offline", "online"):
+                metrics = result.get(variant)
+                if not metrics:
+                    lines.append(
+                        f"| {result['label']} | {result['seed']} | lira-{variant} | "
+                        f"**unavailable: {result.get('online_unavailable_reason', 'n/a')}** "
+                        "| - | - | - | - | - | - | - |"
+                    )
+                    continue
+                agg = metrics["aggregate"]
+                op = agg["operating_point"]
+                lines.append(
+                    f"| {result['label']} | {result['seed']} | lira-{variant} | "
+                    f"{_fmt(agg['auc'])} | {_fmt(agg['tpr_at_fpr_0.001'])} | "
+                    f"{_fmt(agg['tpr_at_fpr_0.01'])} | {_fmt(agg['tpr_at_fpr_0.1'])} | "
+                    f"{op['detected_members']}/{op['n_members']} | "
+                    f"{op['false_positives']}/{op['n_nonmembers']} | "
+                    f"{result['min_out_observations']} | {result['min_in_observations']} |"
+                )
+
+    lines += [
+        "",
+        "## 7. Permutation and bootstrap results",
+        "",
+        "Permutation nulls reshuffle membership within each sex, preserving exact cell "
+        "counts with scores fixed. Holm adjustment is across ladder points within each "
+        "seed.",
+        "",
+        "| Point | Seed | Attack | AUC | Null AUC 95% | p | Holm p | TPR@1% | p | "
+        "Holm p | Bootstrap TPR 95% |",
+        "|---|---:|---|---:|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            for variant in ("offline", "online"):
+                metrics = result.get(variant)
+                if not metrics:
+                    continue
+                agg, perm, boot = (
+                    metrics["aggregate"],
+                    metrics["permutation"],
+                    metrics["bootstrap"],
+                )
+                lines.append(
+                    f"| {result['label']} | {result['seed']} | lira-{variant} | "
+                    f"{_fmt(agg['auc'])} | [{_fmt(perm['aggregate_auc']['null_ci95_low'])}, "
+                    f"{_fmt(perm['aggregate_auc']['null_ci95_high'])}] | "
+                    f"{_fmt(perm['aggregate_auc']['p_value'])} | "
+                    f"{_fmt(perm['aggregate_auc'].get('p_value_holm'))} | "
+                    f"{_fmt(agg['tpr_at_fpr_0.01'])} | "
+                    f"{_fmt(perm['aggregate_tpr']['p_value'])} | "
+                    f"{_fmt(perm['aggregate_tpr'].get('p_value_holm'))} | "
+                    f"[{_fmt(boot['aggregate']['ci95_low'])}, "
+                    f"{_fmt(boot['aggregate']['ci95_high'])}] |"
+                )
+
+    lines += [
+        "",
+        "## 8. Detectability decision per ladder point",
+        "",
+        "| Point | Achieved epsilon | Noise | Gate passed | Mean offline AUC | "
+        "Mean TPR@1% | Min Holm p | Decision | Basis |",
+        "|---|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for summary in summaries:
+        lines.append(
+            f"| {summary['label']} | {_fmt(summary['achieved_epsilon'])} | "
+            f"{_fmt(summary['noise_multiplier'])} | "
+            f"{summary['gate_passed_seeds']}/{len(summary['seeds'])} | "
+            f"{_fmt(summary['mean_offline_auc'])} | "
+            f"{_fmt(summary['mean_offline_tpr_1pct'])} | "
+            f"{_fmt(summary['min_holm_p'])} | **{summary['decision']}** | "
+            f"{summary['basis']} |"
+        )
+
+    lines += ["", "## 9. Detectability-frontier bracket", ""]
+    if frontier["non_monotonic"]:
+        lines += [
+            "**FRONTIER UNSTABLE -- NON-MONOTONIC.**",
+            "",
+            str(frontier["summary"]),
+            "",
+            "The full ordered pattern is reported rather than a manufactured threshold:",
+            "",
+            "| Point | Achieved epsilon | Decision |",
+            "|---|---:|---|",
+        ]
+        for entry in frontier["ordered_points"]:
+            lines.append(
+                f"| {entry['label']} | {_fmt(entry['achieved_epsilon'])} | "
+                f"{entry['decision']} |"
+            )
+    else:
+        lines.append(str(frontier["summary"]))
+        if frontier["bracket"]:
+            bracket = frontier["bracket"]
+            lines += [
+                "",
+                "```text",
+                f"detectable at epsilon = {_fmt(bracket['detectable_epsilon'])} "
+                f"({bracket['detectable_at']})",
+                f"not detectable at epsilon = {_fmt(bracket['not_detectable_epsilon'])} "
+                f"({bracket['not_detectable_at']})",
+                "therefore the empirical transition lies between them",
+                "```",
+            ]
+    lines.append("")
+    lines.append(
+        "No interpolation is performed across six points, and no point is described as "
+        "private on the basis of non-detection."
+    )
+
+    lines += [
+        "",
+        "## 10. Secondary subgroup analysis",
+        "",
+        "Primary statistic: signed contrast `male TPR@1% - female TPR@1%`. The absolute "
+        "max-minus-min gap is descriptive only -- it is positively biased under the "
+        "null. `resolution = 1 / subgroup_member_count` is the smallest movement a "
+        "single member can produce.",
+        "",
+        "| Point | Seed | Female TPR@1% | Male TPR@1% | Signed gap | Absolute gap "
+        "(descriptive) | Resolution | Signed Holm p |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for summary in summaries:
+        for result in summary["seed_results"]:
+            metrics = result.get("offline")
+            if not metrics:
+                continue
+            groups = metrics["subgroups"]
+
+            def group_tpr(name: str) -> object:
+                for candidate, values in groups.items():
+                    if candidate.lower() == name:
+                        return values["tpr_at_fpr_0.01"]
+                return None
+
+            lines.append(
+                f"| {result['label']} | {result['seed']} | "
+                f"{_fmt(group_tpr('female'))} | {_fmt(group_tpr('male'))} | "
+                f"{_fmt(metrics['signed_subgroup_difference'])} | "
+                f"{_fmt(metrics['absolute_subgroup_gap'])} | "
+                f"{_fmt(result.get('subgroup_resolution'))} | "
+                f"{_fmt(metrics['permutation']['signed_difference'].get('p_value_holm'))} |"
+            )
+    lines += [
+        "",
+        "| Point | Subgroup verdict | Basis |",
+        "|---|---|---|",
+    ]
+    for summary in summaries:
+        lines.append(
+            f"| {summary['label']} | **{summary['subgroup_verdict']}** | "
+            f"{summary['subgroup_basis']} |"
+        )
+
+    # ---- Conclusion -------------------------------------------------------- #
+    non_private = next(
+        (s for s in summaries if s["requested_epsilon"] is None), None
+    )
+    finite = [s for s in summaries if s["requested_epsilon"] is not None]
+    detectable_finite = [s for s in finite if s["decision"] == DETECTABLE]
+    supported = [s for s in summaries if s["subgroup_verdict"] == SUBGROUP_SUPPORTED]
+
+    lines += ["", "## 11. Conclusion", ""]
+
+    lines += ["### 1. Does the attack detect aggregate leakage without DP?", ""]
+    if non_private is None:
+        lines.append("The non-private point was not run, so this cannot be answered here.")
+    elif non_private["decision"] == DETECTABLE:
+        lines.append(
+            f"Yes. The non-private target reaches mean offline-LiRA AUC "
+            f"{_fmt(non_private['mean_offline_auc'])} with the Holm-adjusted permutation "
+            "null rejected on the required number of seeds. The instrument works."
+        )
+    elif non_private["decision"] == DID_NOT_MEMORISE:
+        lines.append(
+            "Cannot be assessed: the non-private target failed the memorisation gate, so "
+            "there was nothing for the attack to find."
+        )
+    else:
+        lines.append(
+            f"**No.** The non-private target memorised (mean AUC gap "
+            f"{_fmt(non_private['mean_auc_gap'])}) yet aggregate leakage was not "
+            "detectable. Every finite point below is therefore uninterpretable as a "
+            "privacy result -- this is an attack-power failure."
+        )
+
+    lines += ["", "### 2. At which DP noise levels is aggregate leakage detectable?", ""]
+    if detectable_finite:
+        names = ", ".join(
+            f"{s['label']} (achieved eps {_fmt(s['achieved_epsilon'])})"
+            for s in detectable_finite
+        )
+        lines.append(f"Detectable at: {names}.")
+    else:
+        lines.append(
+            "At none of the finite privacy points tested. Detection survives only in the "
+            "non-private control, if at all."
+        )
+
+    lines += ["", "### 3. Where does detection disappear?", ""]
+    lines.append(str(frontier["summary"]))
+
+    lines += ["", "### 4. Are subgroup differences supported?", ""]
+    if supported:
+        names = ", ".join(s["label"] for s in supported)
+        lines.append(
+            f"Supported at: {names} -- stable signed direction, adjusted permutation "
+            "rejection on the required seeds, and an effect exceeding one-person "
+            "resolution."
+        )
+    else:
+        lines.append(
+            "**No.** No ladder point satisfies the pre-registered signed-contrast rule. "
+            "Aggregate detection, where it occurs, is reported as aggregate leakage only "
+            "and is never read as subgroup disparity."
+        )
+
+    lines += ["", "### 5. Is the insurance dataset adequate for aggregate auditing?", ""]
+    if non_private is not None and non_private["decision"] == DETECTABLE:
+        lines.append(
+            "Yes, at non-private capacity, and "
+            + (
+                "at the finite privacy points listed above."
+                if detectable_finite
+                else "only there -- every finite point tested falls below detectability."
+            )
+        )
+    else:
+        lines.append(
+            "Not demonstrated. Without a detectable non-private control the pipeline "
+            "cannot support aggregate auditing claims on this dataset."
+        )
+
+    lines += [
+        "",
+        "### 6. Is it adequate for small subgroup-leakage comparisons?",
+        "",
+    ]
+    resolutions = [
+        float(r["subgroup_resolution"])
+        for s in summaries
+        for r in s["seed_results"]
+        if r.get("subgroup_resolution") is not None
+    ]
+    if resolutions:
+        lines.append(
+            f"**No.** Subgroup TPR@1% FPR moves in steps of {max(resolutions):.4f} "
+            f"(one member out of {int(round(1 / max(resolutions)))}), and at a 1% FPR the "
+            "operating point admits roughly one false positive per group. The "
+            "measurement grid is coarser than the effects a subgroup claim would need "
+            "to resolve, independently of how much noise is applied."
+        )
+    else:
+        lines.append(
+            "**No.** No completed attack produced a subgroup cohort large enough to "
+            "assess."
+        )
+
+    lines += [
+        "",
+        "---",
+        "",
+        "Non-detection is reported as *not detected at this power*, never as privacy, "
+        "safety or verification of a DP guarantee. No subgroup claim is made from "
+        "unstable or single-seed results.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def make_figures(summaries: list[dict[str, object]], output_dir: Path) -> list[str]:
+    """Publication-readable figures. No smoothing, no interpolation."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    def axis_positions() -> tuple[list[int], list[str]]:
+        labels = []
+        for summary in summaries:
+            if summary["requested_epsilon"] is None:
+                labels.append("non-private\n(separate category)")
+            else:
+                achieved = summary["achieved_epsilon"]
+                labels.append(
+                    f"eps={float(summary['requested_epsilon']):g}\nachieved="
+                    f"{achieved:.2f}" if achieved is not None else
+                    f"eps={float(summary['requested_epsilon']):g}"
+                )
+        return list(range(len(summaries))), labels
+
+    positions, labels = axis_positions()
+    written: list[str] = []
+
+    def finish(fig, ax, path: Path, title: str, ylabel: str) -> None:
+        ax.set_xticks(positions)
+        ax.set_xticklabels(labels, fontsize=8)
+        ax.set_xlabel("Ladder point (non-private shown as a separate category)")
+        ax.set_ylabel(ylabel)
+        ax.set_title(title)
+        ax.legend(fontsize=8)
+        ax.grid(alpha=0.3)
+        # A visual break: the non-private point is not an arbitrary finite epsilon.
+        if summaries and summaries[0]["requested_epsilon"] is None:
+            ax.axvline(0.5, color="grey", linestyle=":", linewidth=1)
+        fig.tight_layout()
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        written.append(path.name)
+
+    # -- aggregate AUC ---------------------------------------------------- #
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    for offset, seed in enumerate(sorted({r["seed"] for s in summaries for r in s["seed_results"]})):
+        xs, ys = [], []
+        for pos, summary in zip(positions, summaries):
+            for result in summary["seed_results"]:
+                if result["seed"] == seed and result.get("offline"):
+                    xs.append(pos + (offset - 1) * 0.08)
+                    ys.append(result["offline"]["aggregate"]["auc"])
+        ax.scatter(xs, ys, s=28, alpha=0.75, label=f"seed {seed}")
+    means_x = [p for p, s in zip(positions, summaries) if s["mean_offline_auc"] is not None]
+    means_y = [s["mean_offline_auc"] for s in summaries if s["mean_offline_auc"] is not None]
+    ax.scatter(means_x, means_y, marker="_", s=420, color="black", label="across-seed mean")
+    ax.axhline(0.5, color="red", linestyle="--", linewidth=1, label="AUC = 0.5 (chance)")
+    ax.axhline(
+        DETECT_MEAN_AUC, color="darkorange", linestyle="-.", linewidth=1,
+        label=f"pre-registered {DETECT_MEAN_AUC}",
+    )
+    finish(fig, ax, output_dir / "detectability_auc.png",
+           "Offline-LiRA aggregate AUC across the noise ladder", "Offline-LiRA ROC-AUC")
+
+    # -- aggregate TPR@1% ------------------------------------------------- #
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    for offset, seed in enumerate(sorted({r["seed"] for s in summaries for r in s["seed_results"]})):
+        xs, ys = [], []
+        for pos, summary in zip(positions, summaries):
+            for result in summary["seed_results"]:
+                if result["seed"] == seed and result.get("offline"):
+                    xs.append(pos + (offset - 1) * 0.08)
+                    ys.append(result["offline"]["aggregate"]["tpr_at_fpr_0.01"])
+        ax.scatter(xs, ys, s=28, alpha=0.75, label=f"seed {seed}")
+    mx = [p for p, s in zip(positions, summaries) if s["mean_offline_tpr_1pct"] is not None]
+    my = [s["mean_offline_tpr_1pct"] for s in summaries if s["mean_offline_tpr_1pct"] is not None]
+    ax.scatter(mx, my, marker="_", s=420, color="black", label="across-seed mean")
+    ax.axhline(0.01, color="red", linestyle="--", linewidth=1, label="1% random TPR baseline")
+    finish(fig, ax, output_dir / "detectability_tpr_1pct.png",
+           "Offline-LiRA TPR at 1% FPR across the noise ladder", "TPR @ 1% FPR")
+
+    # -- memorisation gap -------------------------------------------------- #
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    for pos, summary in zip(positions, summaries):
+        for result in summary["seed_results"]:
+            ax.scatter(pos - 0.1, result["memorisation"]["auc_gap"], color="tab:blue", s=26)
+            ax.scatter(pos + 0.1, result["memorisation"]["accuracy_gap"], color="tab:green", s=26)
+    ax.scatter([], [], color="tab:blue", label="train-test AUC gap")
+    ax.scatter([], [], color="tab:green", label="train-test accuracy gap")
+    ax.axhline(MEMORISATION_GATE, color="darkorange", linestyle="-.", linewidth=1,
+               label=f"memorisation gate = {MEMORISATION_GATE}")
+    ax.axhline(0.0, color="red", linestyle="--", linewidth=1)
+    finish(fig, ax, output_dir / "memorisation_gap.png",
+           "Target memorisation across the noise ladder", "Generalisation gap")
+
+    # -- signed subgroup contrast ------------------------------------------ #
+    fig, ax = plt.subplots(figsize=(8, 4.5))
+    resolution = None
+    for offset, seed in enumerate(sorted({r["seed"] for s in summaries for r in s["seed_results"]})):
+        xs, ys = [], []
+        for pos, summary in zip(positions, summaries):
+            for result in summary["seed_results"]:
+                if result["seed"] == seed and result.get("offline"):
+                    xs.append(pos + (offset - 1) * 0.08)
+                    ys.append(result["offline"]["signed_subgroup_difference"])
+                    resolution = result.get("subgroup_resolution", resolution)
+        ax.scatter(xs, ys, s=28, alpha=0.75, label=f"seed {seed}")
+    ax.axhline(0.0, color="red", linestyle="--", linewidth=1, label="no disparity")
+    if resolution:
+        ax.axhspan(-resolution, resolution, color="grey", alpha=0.2,
+                   label=f"+/- one-person resolution ({resolution:.4f})")
+    finish(fig, ax, output_dir / "subgroup_signed_contrast.png",
+           "Signed subgroup contrast (male - female TPR@1% FPR)",
+           "male TPR@1% - female TPR@1%")
+    return written
+
+
+def run_aggregate(args: argparse.Namespace) -> None:
+    """Combine ladder-point artifacts into the final report."""
+    root = Path(__file__).resolve().parents[1]
+    input_dir = Path(args.input_dir)
+    if not input_dir.is_absolute():
+        input_dir = root / input_dir
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = root / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    log_path = output_dir / "noise_ladder.log"
+    handle = log_path.open("w", encoding="utf-8")
+
+    def log(message: str) -> None:
+        print(message, flush=True)
+        handle.write(message + "\n")
+        handle.flush()
+
+    expected = [point_label(e) for e in LADDER_EPSILONS] if args.expect_all else None
+    found: dict[str, dict[str, object]] = {}
+    for path in sorted(input_dir.rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text())
+        except json.JSONDecodeError:
+            continue
+        if payload.get("experiment") != "detectability_noise_ladder_point":
+            continue
+        found[str(payload["label"])] = payload
+        log(f"Loaded ladder point {payload['label']} from {path}")
+
+    if expected is not None:
+        missing = [label for label in expected if label not in found]
+        if missing:
+            handle.close()
+            raise SystemExit(
+                "Aggregation failed: missing ladder-point artifacts for "
+                f"{', '.join(missing)}. Every requested point must complete before the "
+                "frontier can be reported."
+            )
+
+    order = [point_label(e) for e in LADDER_EPSILONS]
+    points = [found[label] for label in order if label in found]
+    if not points:
+        handle.close()
+        raise SystemExit("Aggregation failed: no ladder-point artifacts found.")
+
+    apply_holm_across_points(points)
+    summaries = summarise_points(points)
+    frontier = detectability_frontier(summaries)
+
+    payload = {
+        "experiment": "detectability_noise_ladder",
+        "task": TASK_NAME,
+        "sensitive_attribute": SENSITIVE_ATTRIBUTE,
+        "delta": DELTA,
+        "seeds": points[0]["seeds"],
+        "num_shadows": points[0]["num_shadows"],
+        "bootstrap_reps": points[0]["bootstrap_reps"],
+        "permutation_reps": points[0]["permutation_reps"],
+        "epochs": points[0].get("epochs", EPOCHS),
+        "alpha": ALPHA,
+        "points": summaries,
+        "frontier": frontier,
+    }
+
+    (output_dir / "noise_ladder.json").write_text(json.dumps(payload, indent=2, default=float))
+    pd.DataFrame(build_rows(summaries)).to_csv(output_dir / "noise_ladder.csv", index=False)
+    (output_dir / "noise_ladder.md").write_text(render_markdown(payload))
+    figures = make_figures(summaries, output_dir)
+
+    for summary in summaries:
+        log(f"[{summary['label']}] {summary['decision']} -- {summary['basis']}")
+    log(f"Frontier: {frontier['summary']}")
+    log(f"Figures: {', '.join(figures)}")
+    log(f"Report: {output_dir / 'noise_ladder.md'}")
+    handle.close()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    point = sub.add_parser("point", help="run one ladder point across all seeds")
+    point.add_argument(
+        "--epsilon",
+        type=float,
+        default=None,
+        help="requested epsilon; omit or pass <= 0 for the non-private point",
+    )
+    point.add_argument("--seeds", nargs="+", type=int, default=list(DEFAULT_SEEDS))
+    point.add_argument("--shadows", type=int, default=DEFAULT_SHADOWS)
+    point.add_argument("--bootstrap-reps", type=int, default=DEFAULT_BOOTSTRAP_REPS)
+    point.add_argument("--permutation-reps", type=int, default=DEFAULT_PERMUTATION_REPS)
+    point.add_argument("--epochs", type=int, default=None, help="smoke-test override")
+    point.add_argument("--output-dir", default="reports/detectability_noise_ladder/points")
+    point.set_defaults(func=run_point)
+
+    aggregate = sub.add_parser("aggregate", help="combine ladder points into the report")
+    aggregate.add_argument("--input-dir", default="reports/detectability_noise_ladder/points")
+    aggregate.add_argument("--output-dir", default="reports/detectability_noise_ladder")
+    aggregate.add_argument(
+        "--expect-all",
+        action="store_true",
+        help="fail unless every requested ladder point is present",
+    )
+    aggregate.set_defaults(func=run_aggregate)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dp/attacks.py
+++ b/src/dp/attacks.py
@@ -111,6 +111,37 @@ def loss_threshold_attack(
     )
 
 
+#: Recognised per-example statistics for the online attack.
+ONLINE_VARIANTS = ("online_raw_loss", "online_logit_confidence")
+
+
+def logit_confidence_from_bce(losses: np.ndarray, eps: float = 1e-12) -> np.ndarray:
+    """Map per-example binary cross-entropy to a logit-confidence scale.
+
+    For a binary cross-entropy ``L``, the model's probability on the *true*
+    label is ``p = exp(-L)``. Carlini et al. (2022) fit their Gaussians to
+    ``logit(p) = log(p / (1 - p))`` rather than to ``p`` or to the loss itself,
+    because probabilities pile up against 0 and 1 and raw losses are
+    heavy-tailed, while the logit scale is far closer to Gaussian and has
+    roughly homogeneous per-example variance.
+
+    ``p`` is clipped away from both endpoints, so a zero loss (``p = 1``) or a
+    very large loss (``p -> 0``) yields a large finite score rather than an
+    infinity. The mapping is strictly increasing in ``p`` and therefore strictly
+    *decreasing* in the loss: a lower loss gives a higher logit confidence.
+
+    Args:
+        losses: Any shape. Per-example binary cross-entropy, non-negative.
+        eps: Clip applied to ``p`` on both sides.
+
+    Returns:
+        An array of the same shape, finite everywhere.
+    """
+    losses = np.asarray(losses, dtype=float)
+    p = np.clip(np.exp(-losses), eps, 1.0 - eps)
+    return np.log(p) - np.log1p(-p)
+
+
 def lira_offline_attack(
     target_losses: np.ndarray,
     membership: np.ndarray,
@@ -181,6 +212,7 @@ def lira_online_attack(
     shadow_out_losses: np.ndarray,
     fprs=(0.001, 0.01, 0.1),
     eps: float = 1e-12,
+    variant: str = "online_raw_loss",
 ) -> AttackResult:
     """Online Likelihood-Ratio Attack (Carlini et al. 2022, §IV).
 
@@ -209,13 +241,22 @@ def lira_online_attack(
             losses from shadow models trained *without* it.
         fprs: False-positive rates at which to report TPR.
         eps: Floor on the fitted standard deviations for numerical stability.
+        variant: Which per-example statistic the Gaussians are fitted to.
+            ``"online_raw_loss"`` (default) preserves the original behaviour and
+            fits to the raw cross-entropy losses. ``"online_logit_confidence"``
+            first maps each loss through :func:`logit_confidence_from_bce`, the
+            variance-stabilising transform Carlini et al. apply before fitting.
+            Raw BCE is heavy-tailed and its per-example spread varies widely, so
+            a likelihood ratio divided by a badly-estimated per-example sigma can
+            rank acceptably on average while calibrating poorly in the extreme
+            tail — which is where TPR at low FPR is read.
 
     Returns:
-        An :class:`AttackResult`.
+        An :class:`AttackResult`. ``method`` records which variant was used.
 
     Raises:
-        ValueError: On shape mismatches or fewer than 2 shadow samples on
-            either side.
+        ValueError: On shape mismatches, fewer than 2 shadow samples on either
+            side, or an unknown ``variant``.
 
     Reference:
         Carlini, Chien, Nasr, Song, Terzis, Tramèr (2022). "Membership
@@ -240,6 +281,16 @@ def lira_online_attack(
         raise ValueError("shadow_in_losses must be (n, k) with k >= 2 shadow models")
     if shadow_out_losses.ndim != 2 or shadow_out_losses.shape[1] < 2:
         raise ValueError("shadow_out_losses must be (n, k) with k >= 2 shadow models")
+    if variant not in ONLINE_VARIANTS:
+        raise ValueError(
+            f"unknown variant {variant!r}; expected one of {sorted(ONLINE_VARIANTS)}"
+        )
+
+    if variant == "online_logit_confidence":
+        # Applied identically to target, IN and OUT so the three are comparable.
+        target_losses = logit_confidence_from_bce(target_losses)
+        shadow_in_losses = logit_confidence_from_bce(shadow_in_losses)
+        shadow_out_losses = logit_confidence_from_bce(shadow_out_losses)
 
     mu_in = shadow_in_losses.mean(axis=1)
     sigma_in = np.maximum(shadow_in_losses.std(axis=1, ddof=1), eps)
@@ -257,5 +308,11 @@ def lira_online_attack(
         tpr_at_fpr=_tpr_at_fpr(membership, scores, fprs),
         scores=scores,
         membership=membership,
-        method="lira-online",
+        # The raw-loss variant keeps its historical name so existing callers and
+        # stored results stay valid; only the new transform gets a new label.
+        method=(
+            "lira-online"
+            if variant == "online_raw_loss"
+            else "lira-online-logit-confidence"
+        ),
     )

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -96,3 +96,125 @@ def test_lira_online_shape_validation():
         lira_online_attack(np.zeros(5), np.zeros(5), np.zeros((5, 1)), np.zeros((5, 8)))
     with pytest.raises(ValueError, match="shadow_out_losses"):
         lira_online_attack(np.zeros(5), np.zeros(5), np.zeros((5, 8)), np.zeros((5, 1)))
+
+
+# --------------------------------------------------------------------------- #
+# Online LiRA variants: raw loss vs logit-confidence transform
+# --------------------------------------------------------------------------- #
+
+
+def test_logit_confidence_is_finite_at_extreme_losses():
+    from dp.attacks import logit_confidence_from_bce
+
+    extremes = np.array([0.0, 1e-300, 1e-12, 1.0, 50.0, 700.0, 1e6, np.inf])
+    scores = logit_confidence_from_bce(extremes)
+    assert np.all(np.isfinite(scores))
+    assert not np.any(np.isnan(scores))
+
+
+def test_logit_confidence_is_strictly_decreasing_in_loss():
+    from dp.attacks import logit_confidence_from_bce
+
+    losses = np.linspace(0.0, 20.0, 200)
+    scores = logit_confidence_from_bce(losses)
+    # Lower loss (more confident on the true label) => higher logit confidence.
+    assert np.all(np.diff(scores) < 0)
+
+
+def test_logit_confidence_matches_the_specified_formula():
+    from dp.attacks import logit_confidence_from_bce
+
+    loss = 0.7
+    p = np.exp(-loss)
+    expected = np.log(p / (1 - p))
+    assert logit_confidence_from_bce(loss) == pytest.approx(expected, rel=1e-9)
+
+
+def test_logit_confidence_is_reproducible():
+    from dp.attacks import logit_confidence_from_bce
+
+    losses = np.linspace(0.01, 5.0, 50)
+    assert np.array_equal(
+        logit_confidence_from_bce(losses), logit_confidence_from_bce(losses)
+    )
+
+
+def _online_fixture(seed=0, n=200, k=12):
+    rng = np.random.default_rng(seed)
+    membership = np.array([1] * (n // 2) + [0] * (n // 2))
+    # Members have systematically lower loss under the target.
+    target = np.where(membership == 1, rng.gamma(1.0, 0.2, n), rng.gamma(2.0, 0.5, n))
+    shadow_in = rng.gamma(1.0, 0.2, size=(n, k))
+    shadow_out = rng.gamma(2.0, 0.5, size=(n, k))
+    return target, membership, shadow_in, shadow_out
+
+
+def test_both_online_variants_are_labelled_separately():
+    from dp.attacks import lira_online_attack
+
+    target, membership, sin, sout = _online_fixture()
+    raw = lira_online_attack(target, membership, sin, sout, variant="online_raw_loss")
+    transformed = lira_online_attack(
+        target, membership, sin, sout, variant="online_logit_confidence"
+    )
+    # Raw keeps the historical label; the transform gets a distinct one.
+    assert raw.method == "lira-online"
+    assert transformed.method == "lira-online-logit-confidence"
+    assert raw.method != transformed.method
+
+
+def test_online_default_variant_preserves_legacy_behaviour():
+    """The default must be byte-identical to the pre-existing raw-loss attack."""
+    from dp.attacks import lira_online_attack
+
+    target, membership, sin, sout = _online_fixture(seed=3)
+    default = lira_online_attack(target, membership, sin, sout)
+    explicit = lira_online_attack(
+        target, membership, sin, sout, variant="online_raw_loss"
+    )
+    assert np.array_equal(default.scores, explicit.scores)
+    assert default.auc == explicit.auc
+
+
+def test_online_variants_produce_finite_scores_and_correct_orientation():
+    from dp.attacks import ONLINE_VARIANTS, lira_online_attack
+
+    target, membership, sin, sout = _online_fixture(seed=5)
+    for variant in ONLINE_VARIANTS:
+        result = lira_online_attack(target, membership, sin, sout, variant=variant)
+        assert np.all(np.isfinite(result.scores))
+        # Higher score must mean more member-like.
+        assert result.scores[membership == 1].mean() > result.scores[membership == 0].mean()
+        assert result.auc > 0.5
+
+
+def test_online_variants_are_reproducible():
+    from dp.attacks import ONLINE_VARIANTS, lira_online_attack
+
+    target, membership, sin, sout = _online_fixture(seed=11)
+    for variant in ONLINE_VARIANTS:
+        first = lira_online_attack(target, membership, sin, sout, variant=variant)
+        second = lira_online_attack(target, membership, sin, sout, variant=variant)
+        assert np.array_equal(first.scores, second.scores)
+
+
+def test_online_variant_survives_zero_and_huge_losses():
+    from dp.attacks import lira_online_attack
+
+    n, k = 40, 12
+    membership = np.array([1] * 20 + [0] * 20)
+    target = np.where(membership == 1, 0.0, 500.0)
+    shadow_in = np.zeros((n, k)) + np.linspace(0, 1e-6, k)
+    shadow_out = np.full((n, k), 500.0) + np.linspace(0, 1e-6, k)
+    result = lira_online_attack(
+        target, membership, shadow_in, shadow_out, variant="online_logit_confidence"
+    )
+    assert np.all(np.isfinite(result.scores))
+
+
+def test_online_rejects_unknown_variant():
+    from dp.attacks import lira_online_attack
+
+    target, membership, sin, sout = _online_fixture()
+    with pytest.raises(ValueError, match="unknown variant"):
+        lira_online_attack(target, membership, sin, sout, variant="not-a-variant")

--- a/tests/test_detectability_noise_ladder.py
+++ b/tests/test_detectability_noise_ladder.py
@@ -1,0 +1,785 @@
+"""Unit tests for the DP-SGD detectability noise ladder.
+
+These cover the pre-registered decision logic, the Holm adjustment, the
+pairing invariants and the report/aggregation plumbing. Training even one
+ladder point is far too expensive for the unit suite, so anything that trains
+is marked ``slow``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str, relative: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relative)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+apc = _load("attack_power_control", "research/attack_power_control.py")
+ladder = _load("detectability_noise_ladder", "research/detectability_noise_ladder.py")
+
+
+# --------------------------------------------------------------------------- #
+# Holm adjustment
+# --------------------------------------------------------------------------- #
+
+
+def test_holm_adjustment_matches_worked_example():
+    # m = 4: sorted 0.01, 0.02, 0.03, 0.04 scaled by 4, 3, 2, 1.
+    adjusted = ladder.holm_adjust([0.01, 0.02, 0.03, 0.04])
+    assert adjusted == pytest.approx([0.04, 0.06, 0.06, 0.06])
+
+
+def test_holm_adjustment_is_monotone_and_clipped():
+    adjusted = ladder.holm_adjust([0.2, 0.5, 0.9, 1.0])
+    assert all(value <= 1.0 for value in adjusted)
+    # Step-down enforces non-decreasing adjusted values in sorted order.
+    assert adjusted == sorted(adjusted)
+
+
+def test_holm_adjustment_never_lowers_a_p_value():
+    raw = [0.001, 0.02, 0.3, 0.75, 0.9, 0.99]
+    adjusted = ladder.holm_adjust(raw)
+    assert all(a >= r - 1e-12 for a, r in zip(adjusted, raw))
+
+
+def test_holm_adjustment_preserves_input_order():
+    adjusted = ladder.holm_adjust([0.04, 0.01, 0.03, 0.02])
+    # Same multiset as the sorted-input case, reordered to match the input.
+    assert adjusted[1] == pytest.approx(0.04)
+    assert adjusted == pytest.approx([0.06, 0.04, 0.06, 0.06])
+
+
+def test_holm_adjustment_passes_nan_through():
+    adjusted = ladder.holm_adjust([0.01, float("nan"), 0.02])
+    assert np.isnan(adjusted[1])
+    assert np.isfinite(adjusted[0]) and np.isfinite(adjusted[2])
+
+
+def test_holm_adjustment_handles_single_value_and_empty():
+    assert ladder.holm_adjust([0.03]) == pytest.approx([0.03])
+    assert ladder.holm_adjust([]) == []
+
+
+# --------------------------------------------------------------------------- #
+# Pairing invariants
+# --------------------------------------------------------------------------- #
+
+
+def test_cohort_indices_are_identical_across_ladder_points():
+    """Cohorts derive from the target seed only, never from the privacy level."""
+    rng = np.random.default_rng(0)
+    groups = np.array(["female"] * 200 + ["male"] * 200)
+    membership = np.concatenate(
+        [
+            rng.permutation(np.array([1] * 150 + [0] * 50)),
+            rng.permutation(np.array([1] * 140 + [0] * 60)),
+        ]
+    )
+    per_point = [
+        apc.make_equalised_attack_cohort(groups, membership, seed=42)
+        for _ in ladder.LADDER_EPSILONS
+    ]
+    first_idx, first_counts = per_point[0]
+    for idx, counts in per_point[1:]:
+        assert np.array_equal(idx, first_idx)
+        assert counts == first_counts
+
+
+def test_shadow_schedules_are_identical_across_ladder_points():
+    y_pool = np.tile([0, 1], 300)
+    schedules = [
+        apc.balanced_shadow_train_sets(y_pool, train_size=400, num_shadows=32, seed=42 + 10_000)
+        for _ in ladder.LADDER_EPSILONS
+    ]
+    first_sets, first_counts = schedules[0]
+    for train_sets, counts in schedules[1:]:
+        assert len(train_sets) == len(first_sets)
+        for a, b in zip(train_sets, first_sets):
+            assert np.array_equal(a, b)
+        assert np.array_equal(counts, first_counts)
+
+
+def test_shadow_and_target_training_sizes_match():
+    y_pool = np.tile([0, 1], 300)
+    train_size = 400
+    train_sets, excluded = apc.balanced_shadow_train_sets(
+        y_pool, train_size=train_size, num_shadows=32, seed=1
+    )
+    assert all(len(idx) == train_size for idx in train_sets)
+    assert excluded.min() >= apc.MIN_GAUSSIAN_OBSERVATIONS
+
+
+def test_ladder_point_labels_are_stable_and_distinct():
+    labels = [ladder.point_label(e) for e in ladder.LADDER_EPSILONS]
+    assert labels[0] == ladder.NON_PRIVATE_LABEL
+    assert len(set(labels)) == len(labels)
+    assert labels[1:] == ["eps32", "eps16", "eps8", "eps4", "eps2"]
+
+
+# --------------------------------------------------------------------------- #
+# Privacy accounting
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("epsilon", [32.0, 16.0, 8.0, 4.0, 2.0])
+def test_noise_multiplier_solves_to_requested_epsilon(epsilon):
+    pytest.importorskip("opacus")
+    sample_rate = 64 / 856
+    noise = ladder.solve_noise_multiplier(epsilon, sample_rate, epochs=20)
+    achieved = ladder.epsilon_for_noise(noise, sample_rate, steps=20 * 14)
+    assert noise > 0
+    # The solver targets from below, so achieved must not exceed the request.
+    assert achieved <= epsilon * 1.05
+
+
+def test_noise_multiplier_is_monotonic_in_epsilon():
+    """Tighter privacy requires more noise."""
+    pytest.importorskip("opacus")
+    sample_rate = 64 / 856
+    noises = [
+        ladder.solve_noise_multiplier(eps, sample_rate, epochs=20)
+        for eps in (32.0, 16.0, 8.0, 4.0, 2.0)
+    ]
+    assert noises == sorted(noises), "noise must increase as epsilon decreases"
+    assert all(b > a for a, b in zip(noises, noises[1:]))
+
+
+def test_achieved_epsilon_decreases_as_noise_increases():
+    pytest.importorskip("opacus")
+    sample_rate = 64 / 856
+    epsilons = [
+        ladder.epsilon_for_noise(noise, sample_rate, steps=280)
+        for noise in (0.8, 1.5, 3.0, 6.0, 12.0)
+    ]
+    assert epsilons == sorted(epsilons, reverse=True)
+    assert all(b < a for a, b in zip(epsilons, epsilons[1:]))
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures for decision logic
+# --------------------------------------------------------------------------- #
+
+
+def _seed_result(
+    seed,
+    *,
+    label="eps8",
+    requested_epsilon=8.0,
+    gate=True,
+    auc=0.60,
+    holm_p=0.01,
+    signed=0.0,
+    signed_holm=1.0,
+    members=128,
+    status="completed",
+):
+    """Minimal seed result carrying only what the decision rules read."""
+    offline = None
+    if status == "completed":
+        offline = {
+            "aggregate": {
+                "auc": auc,
+                "tpr_at_fpr_0.001": 0.01,
+                "tpr_at_fpr_0.01": 0.05,
+                "tpr_at_fpr_0.1": 0.2,
+                "operating_point": {
+                    "detected_members": 6,
+                    "false_positives": 1,
+                    "n_members": members,
+                    "n_nonmembers": members,
+                },
+            },
+            "subgroups": {
+                "female": {
+                    "auc": auc,
+                    "tpr_at_fpr_0.001": 0.0,
+                    "tpr_at_fpr_0.01": 0.05,
+                    "tpr_at_fpr_0.1": 0.2,
+                    "members": members,
+                    "operating_point": {
+                        "detected_members": 3,
+                        "false_positives": 1,
+                        "n_members": members,
+                        "n_nonmembers": members,
+                    },
+                },
+                "male": {
+                    "auc": auc,
+                    "tpr_at_fpr_0.001": 0.0,
+                    "tpr_at_fpr_0.01": 0.05 + signed,
+                    "tpr_at_fpr_0.1": 0.2,
+                    "members": members,
+                    "operating_point": {
+                        "detected_members": 3,
+                        "false_positives": 1,
+                        "n_members": members,
+                        "n_nonmembers": members,
+                    },
+                },
+            },
+            "signed_subgroup_difference": signed,
+            "absolute_subgroup_gap": abs(signed),
+            "bootstrap": {
+                "aggregate": {"reps": 10, "mean": 0.05, "ci95_low": 0.02, "ci95_high": 0.09},
+                "female": {"reps": 10, "mean": 0.05, "ci95_low": 0.0, "ci95_high": 0.1},
+                "male": {"reps": 10, "mean": 0.05, "ci95_low": 0.0, "ci95_high": 0.1},
+                "signed_difference": {
+                    "reps": 10, "mean": signed, "ci95_low": -0.1, "ci95_high": 0.1
+                },
+                "absolute_gap": {"reps": 10, "mean": 0.02, "ci95_low": 0.0, "ci95_high": 0.1},
+            },
+            "permutation": {
+                "aggregate_auc": {
+                    "reps": 10, "observed": auc, "null_mean": 0.5,
+                    "null_ci95_low": 0.45, "null_ci95_high": 0.55,
+                    "alternative": "greater", "p_value": holm_p, "p_value_holm": holm_p,
+                },
+                "aggregate_tpr": {
+                    "reps": 10, "observed": 0.05, "null_mean": 0.01,
+                    "null_ci95_low": 0.0, "null_ci95_high": 0.03,
+                    "alternative": "greater", "p_value": holm_p, "p_value_holm": holm_p,
+                },
+                "signed_difference": {
+                    "reps": 10, "observed": signed, "null_mean": 0.0,
+                    "null_ci95_low": -0.04, "null_ci95_high": 0.04,
+                    "alternative": "two-sided", "p_value": signed_holm,
+                    "p_value_holm": signed_holm,
+                },
+                "absolute_gap": {
+                    "reps": 10, "observed": abs(signed), "null_mean": 0.014,
+                    "null_ci95_low": 0.0, "null_ci95_high": 0.05,
+                    "alternative": "greater", "p_value": signed_holm,
+                    "p_value_holm": signed_holm,
+                },
+                "female": {
+                    "reps": 10, "observed": 0.05, "null_mean": 0.01,
+                    "null_ci95_low": 0.0, "null_ci95_high": 0.03,
+                    "alternative": "greater", "p_value": 0.2, "p_value_holm": 0.4,
+                },
+                "male": {
+                    "reps": 10, "observed": 0.05, "null_mean": 0.01,
+                    "null_ci95_low": 0.0, "null_ci95_high": 0.03,
+                    "alternative": "greater", "p_value": 0.2, "p_value_holm": 0.4,
+                },
+            },
+        }
+    return {
+        "label": label,
+        "requested_epsilon": requested_epsilon,
+        "seed": seed,
+        "delta": ladder.DELTA,
+        "noise_multiplier": None if requested_epsilon is None else 3.5,
+        "achieved_epsilon": None if requested_epsilon is None else requested_epsilon * 0.99,
+        "epochs": 400,
+        "batch_size": 64,
+        "learning_rate": 1e-3,
+        "architecture": "test",
+        "train_size": 856,
+        "val_size": 214,
+        "test_size": 268,
+        "cohort_counts": {"female|member=1": members, "male|member=1": members},
+        "num_attack_examples": 4 * members,
+        "memorisation": {
+            "train_auc": 0.99, "test_auc": 0.90,
+            "train_loss": 0.05, "test_loss": 0.5,
+            "train_accuracy": 0.98, "test_accuracy": 0.88,
+            "auc_gap": 0.09 if gate else 0.001,
+            "loss_gap": 0.45 if gate else 0.002,
+            "accuracy_gap": 0.10 if gate else 0.001,
+        },
+        "memorisation_gate": ladder.MEMORISATION_GATE,
+        "memorisation_gate_passed": gate,
+        "attack_status": status,
+        "num_shadows": 32,
+        "min_out_observations": 11,
+        "min_in_observations": 20,
+        "subgroup_member_counts": {"female": members, "male": members},
+        "subgroup_resolution": 1.0 / members,
+        "offline": offline,
+        "online": None,
+        "online_available": False,
+        "online_unavailable_reason": "test fixture",
+    }
+
+
+def _point(label, requested_epsilon, **kwargs):
+    return {
+        "experiment": "detectability_noise_ladder_point",
+        "label": label,
+        "requested_epsilon": requested_epsilon,
+        "task": ladder.TASK_NAME,
+        "sensitive_attribute": ladder.SENSITIVE_ATTRIBUTE,
+        "delta": ladder.DELTA,
+        "seeds": [42, 43, 44],
+        "num_shadows": 32,
+        "bootstrap_reps": 10,
+        "permutation_reps": 10,
+        "epochs": 400,
+        "seed_results": [
+            _seed_result(seed, label=label, requested_epsilon=requested_epsilon, **kwargs)
+            for seed in (42, 43, 44)
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Pre-registered detection rule
+# --------------------------------------------------------------------------- #
+
+
+def test_detectable_when_all_criteria_met():
+    results = _point("eps8", 8.0, auc=0.60, holm_p=0.01)["seed_results"]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.DETECTABLE
+    assert "3/3" in basis
+
+
+def test_undetectable_when_mean_auc_below_threshold():
+    results = _point("eps4", 4.0, auc=0.52, holm_p=0.01)["seed_results"]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.UNDETECTABLE
+    assert "mean AUC" in basis
+    assert "not evidence of privacy" in basis
+
+
+def test_undetectable_when_holm_adjusted_significance_insufficient():
+    results = _point("eps4", 4.0, auc=0.60, holm_p=0.20)["seed_results"]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.UNDETECTABLE
+    assert "0/3" in basis
+
+
+def test_detection_requires_two_of_three_seeds():
+    results = [
+        _seed_result(42, auc=0.60, holm_p=0.001),
+        _seed_result(43, auc=0.60, holm_p=0.001),
+        _seed_result(44, auc=0.60, holm_p=0.90),
+    ]
+    assert ladder.classify_ladder_point(results)[0] == ladder.DETECTABLE
+
+    results[1]["offline"]["permutation"]["aggregate_auc"]["p_value_holm"] = 0.90
+    results[1]["offline"]["permutation"]["aggregate_tpr"]["p_value_holm"] = 0.90
+    assert ladder.classify_ladder_point(results)[0] == ladder.UNDETECTABLE
+
+
+def test_undetectable_when_any_seed_at_or_below_chance():
+    results = [
+        _seed_result(42, auc=0.62, holm_p=0.001),
+        _seed_result(43, auc=0.61, holm_p=0.001),
+        _seed_result(44, auc=0.48, holm_p=0.001),
+    ]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.UNDETECTABLE
+    assert "chance" in basis
+
+
+def test_failed_memorisation_gate_is_classified_not_dropped():
+    results = _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate")[
+        "seed_results"
+    ]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.DID_NOT_MEMORISE
+    assert "memorisation gate failed" in basis
+
+
+def test_partial_gate_failure_blocks_detection_claim():
+    results = [
+        _seed_result(42, auc=0.70, holm_p=0.001),
+        _seed_result(43, auc=0.70, holm_p=0.001),
+        _seed_result(44, gate=False, status="skipped_memorisation_gate"),
+    ]
+    assert ladder.classify_ladder_point(results)[0] == ladder.DID_NOT_MEMORISE
+
+
+# --------------------------------------------------------------------------- #
+# Subgroup rule
+# --------------------------------------------------------------------------- #
+
+
+def test_signed_contrast_and_resolution_arithmetic():
+    assert apc.signed_subgroup_difference({"female": 0.10, "male": 0.25}) == pytest.approx(0.15)
+    assert apc.signed_subgroup_difference({"female": 0.25, "male": 0.10}) == pytest.approx(-0.15)
+    assert apc.absolute_subgroup_gap({"female": 0.25, "male": 0.10}) == pytest.approx(0.15)
+    result = _seed_result(42, members=128)
+    assert result["subgroup_resolution"] == pytest.approx(1 / 128)
+
+
+def test_subgroup_unsupported_when_direction_unstable():
+    results = [
+        _seed_result(42, signed=0.20, signed_holm=0.001),
+        _seed_result(43, signed=-0.20, signed_holm=0.001),
+        _seed_result(44, signed=0.20, signed_holm=0.001),
+    ]
+    verdict, basis = ladder.classify_subgroup(results)
+    assert verdict == ladder.SUBGROUP_UNSUPPORTED
+    assert "direction is not stable" in basis
+
+
+def test_subgroup_unsupported_when_within_resolution():
+    tiny = 1 / 256  # below the 1/128 one-person resolution
+    results = [_seed_result(seed, signed=tiny, signed_holm=0.001) for seed in (42, 43, 44)]
+    verdict, basis = ladder.classify_subgroup(results)
+    assert verdict == ladder.SUBGROUP_UNSUPPORTED
+    assert "resolution" in basis
+
+
+def test_subgroup_unsupported_when_driven_by_one_seed():
+    results = [
+        _seed_result(42, signed=0.30, signed_holm=0.001),
+        _seed_result(43, signed=0.0, signed_holm=0.001),
+        _seed_result(44, signed=0.0, signed_holm=0.001),
+    ]
+    verdict, basis = ladder.classify_subgroup(results)
+    assert verdict == ladder.SUBGROUP_UNSUPPORTED
+    assert "single seed" in basis or "resolution" in basis
+
+
+def test_subgroup_supported_when_all_criteria_met():
+    results = [_seed_result(seed, signed=0.25, signed_holm=0.001) for seed in (42, 43, 44)]
+    verdict, basis = ladder.classify_subgroup(results)
+    assert verdict == ladder.SUBGROUP_SUPPORTED
+    assert "male" in basis
+
+
+def test_subgroup_inconclusive_without_completed_attacks():
+    results = _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate")[
+        "seed_results"
+    ]
+    assert ladder.classify_subgroup(results)[0] == ladder.SUBGROUP_INCONCLUSIVE
+
+
+# --------------------------------------------------------------------------- #
+# Frontier bracketing
+# --------------------------------------------------------------------------- #
+
+
+def _summaries(decisions):
+    points = []
+    for (label, eps), decision in zip(
+        [
+            (ladder.NON_PRIVATE_LABEL, None),
+            ("eps32", 32.0),
+            ("eps16", 16.0),
+            ("eps8", 8.0),
+            ("eps4", 4.0),
+            ("eps2", 2.0),
+        ],
+        decisions,
+    ):
+        points.append(
+            {
+                "label": label,
+                "requested_epsilon": eps,
+                "achieved_epsilon": eps,
+                "noise_multiplier": None if eps is None else 1.0,
+                "decision": decision,
+            }
+        )
+    return points
+
+
+def test_frontier_brackets_the_transition():
+    frontier = ladder.detectability_frontier(
+        _summaries(
+            [
+                ladder.DETECTABLE,
+                ladder.DETECTABLE,
+                ladder.DETECTABLE,
+                ladder.UNDETECTABLE,
+                ladder.UNDETECTABLE,
+                ladder.UNDETECTABLE,
+            ]
+        )
+    )
+    assert not frontier["non_monotonic"]
+    assert frontier["bracket"]["detectable_at"] == "eps16"
+    assert frontier["bracket"]["not_detectable_at"] == "eps8"
+    assert "transition lies between" in frontier["summary"]
+
+
+def test_frontier_flags_non_monotonic_ladders():
+    frontier = ladder.detectability_frontier(
+        _summaries(
+            [
+                ladder.DETECTABLE,
+                ladder.UNDETECTABLE,
+                ladder.DETECTABLE,  # detection returns at lower epsilon
+                ladder.UNDETECTABLE,
+                ladder.UNDETECTABLE,
+                ladder.UNDETECTABLE,
+            ]
+        )
+    )
+    assert frontier["non_monotonic"] is True
+    assert frontier["stable"] is False
+    assert frontier["bracket"] is None
+    assert "NON-MONOTONIC" in frontier["summary"]
+
+
+def test_frontier_when_every_point_stays_detectable():
+    frontier = ladder.detectability_frontier(_summaries([ladder.DETECTABLE] * 6))
+    assert frontier["bracket"] is None
+    assert "below the lowest epsilon tested" in frontier["summary"]
+
+
+def test_frontier_when_nothing_is_detectable():
+    frontier = ladder.detectability_frontier(_summaries([ladder.UNDETECTABLE] * 6))
+    assert frontier["bracket"] is None
+    assert "attack-power problem" in frontier["summary"]
+
+
+def test_frontier_ignores_points_that_did_not_memorise():
+    frontier = ladder.detectability_frontier(
+        _summaries(
+            [
+                ladder.DETECTABLE,
+                ladder.DETECTABLE,
+                ladder.DID_NOT_MEMORISE,
+                ladder.UNDETECTABLE,
+                ladder.UNDETECTABLE,
+                ladder.DID_NOT_MEMORISE,
+            ]
+        )
+    )
+    assert not frontier["non_monotonic"]
+    assert frontier["bracket"]["detectable_at"] == "eps32"
+    assert frontier["bracket"]["not_detectable_at"] == "eps8"
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation and reporting
+# --------------------------------------------------------------------------- #
+
+
+def test_holm_is_applied_across_points_within_each_seed():
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, holm_p=0.001),
+        _point("eps32", 32.0, holm_p=0.01),
+        _point("eps16", 16.0, holm_p=0.02),
+    ]
+    for point in points:
+        for result in point["seed_results"]:
+            result["offline"]["permutation"]["aggregate_auc"].pop("p_value_holm")
+
+    ladder.apply_holm_across_points(points)
+    for point in points:
+        for result in point["seed_results"]:
+            entry = result["offline"]["permutation"]["aggregate_auc"]
+            assert "p_value_holm" in entry
+            assert entry["p_value_holm"] >= entry["p_value"]
+    # Three points per seed: smallest raw p is scaled by 3.
+    assert points[0]["seed_results"][0]["offline"]["permutation"]["aggregate_auc"][
+        "p_value_holm"
+    ] == pytest.approx(0.003)
+
+
+def test_aggregation_fails_clearly_when_a_point_is_missing(tmp_path):
+    points_dir = tmp_path / "points"
+    points_dir.mkdir()
+    (points_dir / "non-private.json").write_text(
+        json.dumps(_point(ladder.NON_PRIVATE_LABEL, None), default=float)
+    )
+
+    args = ladder.argparse.Namespace(
+        input_dir=str(points_dir),
+        output_dir=str(tmp_path / "out"),
+        expect_all=True,
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        ladder.run_aggregate(args)
+    message = str(excinfo.value)
+    assert "missing ladder-point artifacts" in message
+    for label in ("eps32", "eps16", "eps8", "eps4", "eps2"):
+        assert label in message
+
+
+def test_aggregation_fails_clearly_when_no_artifacts_exist(tmp_path):
+    empty = tmp_path / "points"
+    empty.mkdir()
+    args = ladder.argparse.Namespace(
+        input_dir=str(empty), output_dir=str(tmp_path / "out"), expect_all=False
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        ladder.run_aggregate(args)
+    assert "no ladder-point artifacts" in str(excinfo.value)
+
+
+def _full_payload(decisions_holm):
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, holm_p=decisions_holm[0], auc=0.62),
+        _point("eps32", 32.0, holm_p=decisions_holm[1], auc=0.58),
+        _point("eps16", 16.0, holm_p=decisions_holm[2], auc=0.52),
+        _point("eps8", 8.0, holm_p=decisions_holm[3], auc=0.51),
+        _point("eps4", 4.0, holm_p=decisions_holm[4], auc=0.50),
+        _point("eps2", 2.0, holm_p=decisions_holm[5], auc=0.50),
+    ]
+    summaries = ladder.summarise_points(points)
+    frontier = ladder.detectability_frontier(summaries)
+    return {
+        "experiment": "detectability_noise_ladder",
+        "task": ladder.TASK_NAME,
+        "sensitive_attribute": ladder.SENSITIVE_ATTRIBUTE,
+        "delta": ladder.DELTA,
+        "seeds": [42, 43, 44],
+        "num_shadows": 32,
+        "bootstrap_reps": 10,
+        "permutation_reps": 10,
+        "epochs": 400,
+        "alpha": ladder.ALPHA,
+        "points": summaries,
+        "frontier": frontier,
+    }
+
+
+def test_report_contains_every_required_section():
+    payload = _full_payload([0.001, 0.01, 0.5, 0.6, 0.9, 0.9])
+    markdown = ladder.render_markdown(payload)
+
+    for heading in (
+        "## 1. Pre-registered question and rules",
+        "## 2. Threat model summary",
+        "## 3. Fixed experimental design",
+        "## 4. Privacy accounting",
+        "## 5. Memorisation metrics",
+        "## 6. Aggregate LiRA results",
+        "## 7. Permutation and bootstrap results",
+        "## 8. Detectability decision per ladder point",
+        "## 9. Detectability-frontier bracket",
+        "## 10. Secondary subgroup analysis",
+        "## 11. Conclusion",
+    ):
+        assert heading in markdown
+
+    for question in (
+        "Does the attack detect aggregate leakage without DP?",
+        "At which DP noise levels is aggregate leakage detectable?",
+        "Where does detection disappear?",
+        "Are subgroup differences supported?",
+        "Is the insurance dataset adequate for aggregate auditing?",
+        "Is it adequate for small subgroup-leakage comparisons?",
+    ):
+        assert question in markdown
+
+    assert "detectable at epsilon" in markdown
+    assert "never as privacy" in markdown
+
+
+def test_report_flags_non_monotonic_frontier():
+    payload = _full_payload([0.001, 0.9, 0.001, 0.9, 0.9, 0.9])
+    # Force the middle point above the AUC floor so it classifies as detectable.
+    for summary in payload["points"]:
+        if summary["label"] == "eps16":
+            for result in summary["seed_results"]:
+                result["offline"]["aggregate"]["auc"] = 0.62
+    payload["points"] = ladder.summarise_points(
+        [
+            {
+                **{k: v for k, v in point.items() if k != "seed_results"},
+                "seed_results": point["seed_results"],
+                "label": point["label"],
+                "requested_epsilon": point["requested_epsilon"],
+            }
+            for point in payload["points"]
+        ]
+    )
+    payload["frontier"] = ladder.detectability_frontier(payload["points"])
+    markdown = ladder.render_markdown(payload)
+    if payload["frontier"]["non_monotonic"]:
+        assert "NON-MONOTONIC" in markdown
+        assert "FRONTIER UNSTABLE" in markdown
+
+
+def test_report_handles_online_lira_unavailable():
+    payload = _full_payload([0.001, 0.01, 0.5, 0.6, 0.9, 0.9])
+    for summary in payload["points"]:
+        for result in summary["seed_results"]:
+            assert result["online"] is None  # fixture has online unavailable
+    markdown = ladder.render_markdown(payload)
+    assert "unavailable" in markdown
+    # The offline rows must still be present and complete.
+    assert "lira-offline" in markdown
+
+
+def test_report_keeps_points_that_did_not_memorise():
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, holm_p=0.001, auc=0.62),
+        _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate"),
+    ]
+    summaries = ladder.summarise_points(points)
+    payload = {
+        "task": ladder.TASK_NAME,
+        "sensitive_attribute": ladder.SENSITIVE_ATTRIBUTE,
+        "delta": ladder.DELTA,
+        "seeds": [42, 43, 44],
+        "num_shadows": 32,
+        "bootstrap_reps": 10,
+        "permutation_reps": 10,
+        "epochs": 400,
+        "points": summaries,
+        "frontier": ladder.detectability_frontier(summaries),
+    }
+    markdown = ladder.render_markdown(payload)
+    assert "eps2" in markdown
+    assert ladder.DID_NOT_MEMORISE in markdown
+    assert "skipped_memorisation_gate" in markdown
+
+
+def test_csv_rows_cover_every_point_and_seed():
+    payload = _full_payload([0.001, 0.01, 0.5, 0.6, 0.9, 0.9])
+    rows = ladder.build_rows(payload["points"])
+    assert len(rows) == 6 * 3  # six points, three seeds, offline only
+    assert {row["label"] for row in rows} == {
+        ladder.NON_PRIVATE_LABEL, "eps32", "eps16", "eps8", "eps4", "eps2"
+    }
+    assert all("permutation_p_auc_holm" in row for row in rows)
+    assert all("signed_gap" in row for row in rows)
+    assert all("subgroup_resolution" in row for row in rows)
+
+
+@pytest.mark.slow
+def test_figures_are_written(tmp_path):
+    pytest.importorskip("matplotlib")
+    payload = _full_payload([0.001, 0.01, 0.5, 0.6, 0.9, 0.9])
+    written = ladder.make_figures(payload["points"], tmp_path)
+    assert set(written) == {
+        "detectability_auc.png",
+        "detectability_tpr_1pct.png",
+        "memorisation_gap.png",
+        "subgroup_signed_contrast.png",
+    }
+    for name in written:
+        assert (tmp_path / name).stat().st_size > 0
+
+
+@pytest.mark.slow
+def test_smoke_ladder_point_runs(tmp_path):
+    """Two seeds, few epochs, tiny replicate counts. Still trains models."""
+    pytest.importorskip("torch")
+    pytest.importorskip("opacus")
+    ladder.main(
+        [
+            "point",
+            "--epsilon", "8",
+            "--seeds", "42",
+            "--shadows", "32",
+            "--bootstrap-reps", "50",
+            "--permutation-reps", "50",
+            "--epochs", "2",
+            "--output-dir", str(tmp_path),
+        ]
+    )
+    assert (tmp_path / "eps8.json").exists()

--- a/tests/test_detectability_noise_ladder.py
+++ b/tests/test_detectability_noise_ladder.py
@@ -194,7 +194,8 @@ def _seed_result(
             "aggregate": {
                 "auc": auc,
                 "tpr_at_fpr_0.001": 0.01,
-                "tpr_at_fpr_0.01": 0.05,
+                # Vary with auc so rank correlations are defined in fixtures.
+                "tpr_at_fpr_0.01": round(max(0.0, auc - 0.5), 4),
                 "tpr_at_fpr_0.1": 0.2,
                 "operating_point": {
                     "detected_members": 6,
@@ -341,26 +342,69 @@ def _point(label, requested_epsilon, **kwargs):
 # --------------------------------------------------------------------------- #
 
 
-def test_detectable_when_all_criteria_met():
+def test_detectable_with_memorisation():
     results = _point("eps8", 8.0, auc=0.60, holm_p=0.01)["seed_results"]
     decision, basis = ladder.classify_ladder_point(results)
-    assert decision == ladder.DETECTABLE
+    assert decision == ladder.DETECTABLE_WITH_MEMORISATION
     assert "3/3" in basis
 
 
-def test_undetectable_when_mean_auc_below_threshold():
+def test_detectable_despite_low_measured_memorisation():
+    """Amendment 1: a low-memorisation point is still attacked and can detect."""
+    results = _point("eps8", 8.0, gate=False, auc=0.60, holm_p=0.01)["seed_results"]
+    decision, basis = ladder.classify_ladder_point(results)
+    assert decision == ladder.DETECTABLE_LOW_MEMORISATION
+    assert "below" in basis
+
+
+def test_undetectable_despite_memorisation():
     results = _point("eps4", 4.0, auc=0.52, holm_p=0.01)["seed_results"]
     decision, basis = ladder.classify_ladder_point(results)
-    assert decision == ladder.UNDETECTABLE
-    assert "mean AUC" in basis
-    assert "not evidence of privacy" in basis
+    assert decision == ladder.UNDETECTABLE_WITH_MEMORISATION
+    assert "not a privacy claim" in basis
 
 
-def test_undetectable_when_holm_adjusted_significance_insufficient():
-    results = _point("eps4", 4.0, auc=0.60, holm_p=0.20)["seed_results"]
-    decision, basis = ladder.classify_ladder_point(results)
-    assert decision == ladder.UNDETECTABLE
-    assert "0/3" in basis
+def test_undetectable_with_low_memorisation():
+    results = _point("eps2", 2.0, gate=False, auc=0.50, holm_p=0.9)["seed_results"]
+    decision, _ = ladder.classify_ladder_point(results)
+    assert decision == ladder.UNDETECTABLE_LOW_MEMORISATION
+
+
+def test_all_four_statuses_are_reachable_and_distinct():
+    combinations = {
+        (True, True): ladder.DETECTABLE_WITH_MEMORISATION,
+        (True, False): ladder.DETECTABLE_LOW_MEMORISATION,
+        (False, True): ladder.UNDETECTABLE_WITH_MEMORISATION,
+        (False, False): ladder.UNDETECTABLE_LOW_MEMORISATION,
+    }
+    seen = set()
+    for (detect, memorise), expected in combinations.items():
+        results = _point(
+            "eps8", 8.0, gate=memorise,
+            auc=0.60 if detect else 0.50,
+            holm_p=0.01 if detect else 0.9,
+        )["seed_results"]
+        assert ladder.classify_ladder_point(results)[0] == expected
+        seen.add(expected)
+    assert len(seen) == 4
+
+
+def test_no_result_is_ever_labelled_private_or_safe():
+    for gate in (True, False):
+        for auc, holm in ((0.60, 0.01), (0.50, 0.9)):
+            results = _point("eps8", 8.0, gate=gate, auc=auc, holm_p=holm)["seed_results"]
+            status, basis = ladder.classify_ladder_point(results)
+            text = f"{status} {basis}".lower()
+            for banned in ("private", "safe", "verified"):
+                assert banned not in text.replace("privacy claim", "")
+
+
+def test_detection_rule_thresholds_are_unchanged_by_the_amendment():
+    """The numeric rule is identical to the original registration."""
+    assert ladder.DETECT_MEAN_AUC == 0.55
+    assert ladder.MIN_SIGNIFICANT_SEEDS == 2
+    assert ladder.ALPHA == 0.05
+    assert ladder.MEMORISATION_GATE == 0.03
 
 
 def test_detection_requires_two_of_three_seeds():
@@ -369,40 +413,45 @@ def test_detection_requires_two_of_three_seeds():
         _seed_result(43, auc=0.60, holm_p=0.001),
         _seed_result(44, auc=0.60, holm_p=0.90),
     ]
-    assert ladder.classify_ladder_point(results)[0] == ladder.DETECTABLE
+    assert ladder.aggregate_detected(results)[0] is True
 
-    results[1]["offline"]["permutation"]["aggregate_auc"]["p_value_holm"] = 0.90
-    results[1]["offline"]["permutation"]["aggregate_tpr"]["p_value_holm"] = 0.90
-    assert ladder.classify_ladder_point(results)[0] == ladder.UNDETECTABLE
+    for stat in ("aggregate_auc", "aggregate_tpr"):
+        results[1]["offline"]["permutation"][stat]["p_value_holm"] = 0.90
+    assert ladder.aggregate_detected(results)[0] is False
 
 
-def test_undetectable_when_any_seed_at_or_below_chance():
+def test_detection_requires_every_seed_above_chance():
     results = [
         _seed_result(42, auc=0.62, holm_p=0.001),
         _seed_result(43, auc=0.61, holm_p=0.001),
         _seed_result(44, auc=0.48, holm_p=0.001),
     ]
-    decision, basis = ladder.classify_ladder_point(results)
-    assert decision == ladder.UNDETECTABLE
+    detected, basis = ladder.aggregate_detected(results)
+    assert detected is False
     assert "chance" in basis
 
 
-def test_failed_memorisation_gate_is_classified_not_dropped():
-    results = _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate")[
-        "seed_results"
+def test_memorisation_present_requires_every_seed():
+    assert ladder.memorisation_present(_point("eps8", 8.0)["seed_results"]) is True
+    mixed = [
+        _seed_result(42, gate=True),
+        _seed_result(43, gate=True),
+        _seed_result(44, gate=False),
     ]
-    decision, basis = ladder.classify_ladder_point(results)
-    assert decision == ladder.DID_NOT_MEMORISE
-    assert "memorisation gate failed" in basis
+    assert ladder.memorisation_present(mixed) is False
 
 
-def test_partial_gate_failure_blocks_detection_claim():
-    results = [
-        _seed_result(42, auc=0.70, holm_p=0.001),
-        _seed_result(43, auc=0.70, holm_p=0.001),
-        _seed_result(44, gate=False, status="skipped_memorisation_gate"),
-    ]
-    assert ladder.classify_ladder_point(results)[0] == ladder.DID_NOT_MEMORISE
+def test_low_memorisation_points_still_carry_full_offline_metrics():
+    """The whole point of Amendment 1: no observation is discarded."""
+    results = _point("eps2", 2.0, gate=False)["seed_results"]
+    for result in results:
+        assert result["attack_status"] == "completed"
+        assert result["offline"] is not None
+        assert "aggregate" in result["offline"]
+        assert "permutation" in result["offline"]
+        assert "bootstrap" in result["offline"]
+        assert "subgroups" in result["offline"]
+        assert result["subgroup_resolution"] is not None
 
 
 # --------------------------------------------------------------------------- #
@@ -455,16 +504,22 @@ def test_subgroup_supported_when_all_criteria_met():
     assert "male" in basis
 
 
-def test_subgroup_inconclusive_without_completed_attacks():
-    results = _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate")[
-        "seed_results"
-    ]
+def test_subgroup_inconclusive_only_when_an_attack_genuinely_failed():
+    """Under Amendment 1 this can no longer arise from the memorisation gate."""
+    results = _point("eps2", 2.0, gate=False, status="failed")["seed_results"]
     assert ladder.classify_subgroup(results)[0] == ladder.SUBGROUP_INCONCLUSIVE
+    # A low-memorisation point that *did* complete is assessed normally.
+    completed = _point("eps2", 2.0, gate=False)["seed_results"]
+    assert ladder.classify_subgroup(completed)[0] != ladder.SUBGROUP_INCONCLUSIVE
 
 
 # --------------------------------------------------------------------------- #
 # Frontier bracketing
 # --------------------------------------------------------------------------- #
+
+
+DETECTED = ladder.DETECTABLE_WITH_MEMORISATION
+NOT_DETECTED = ladder.UNDETECTABLE_WITH_MEMORISATION
 
 
 def _summaries(decisions):
@@ -496,12 +551,12 @@ def test_frontier_brackets_the_transition():
     frontier = ladder.detectability_frontier(
         _summaries(
             [
-                ladder.DETECTABLE,
-                ladder.DETECTABLE,
-                ladder.DETECTABLE,
-                ladder.UNDETECTABLE,
-                ladder.UNDETECTABLE,
-                ladder.UNDETECTABLE,
+                DETECTED,
+                DETECTED,
+                DETECTED,
+                NOT_DETECTED,
+                NOT_DETECTED,
+                NOT_DETECTED,
             ]
         )
     )
@@ -515,12 +570,12 @@ def test_frontier_flags_non_monotonic_ladders():
     frontier = ladder.detectability_frontier(
         _summaries(
             [
-                ladder.DETECTABLE,
-                ladder.UNDETECTABLE,
-                ladder.DETECTABLE,  # detection returns at lower epsilon
-                ladder.UNDETECTABLE,
-                ladder.UNDETECTABLE,
-                ladder.UNDETECTABLE,
+                DETECTED,
+                NOT_DETECTED,
+                DETECTED,  # detection returns at lower epsilon
+                NOT_DETECTED,
+                NOT_DETECTED,
+                NOT_DETECTED,
             ]
         )
     )
@@ -531,33 +586,35 @@ def test_frontier_flags_non_monotonic_ladders():
 
 
 def test_frontier_when_every_point_stays_detectable():
-    frontier = ladder.detectability_frontier(_summaries([ladder.DETECTABLE] * 6))
+    frontier = ladder.detectability_frontier(_summaries([DETECTED] * 6))
     assert frontier["bracket"] is None
     assert "below the lowest epsilon tested" in frontier["summary"]
 
 
 def test_frontier_when_nothing_is_detectable():
-    frontier = ladder.detectability_frontier(_summaries([ladder.UNDETECTABLE] * 6))
+    frontier = ladder.detectability_frontier(_summaries([NOT_DETECTED] * 6))
     assert frontier["bracket"] is None
     assert "attack-power problem" in frontier["summary"]
 
 
-def test_frontier_ignores_points_that_did_not_memorise():
+def test_frontier_includes_low_memorisation_points():
+    """Every point is classifiable now, so none is skipped when bracketing."""
     frontier = ladder.detectability_frontier(
         _summaries(
             [
-                ladder.DETECTABLE,
-                ladder.DETECTABLE,
-                ladder.DID_NOT_MEMORISE,
-                ladder.UNDETECTABLE,
-                ladder.UNDETECTABLE,
-                ladder.DID_NOT_MEMORISE,
+                DETECTED,
+                DETECTED,
+                ladder.DETECTABLE_LOW_MEMORISATION,
+                ladder.UNDETECTABLE_LOW_MEMORISATION,
+                NOT_DETECTED,
+                ladder.UNDETECTABLE_LOW_MEMORISATION,
             ]
         )
     )
     assert not frontier["non_monotonic"]
-    assert frontier["bracket"]["detectable_at"] == "eps32"
+    assert frontier["bracket"]["detectable_at"] == "eps16"
     assert frontier["bracket"]["not_detectable_at"] == "eps8"
+    assert len(frontier["ordered_points"]) == 6
 
 
 # --------------------------------------------------------------------------- #
@@ -714,12 +771,13 @@ def test_report_handles_online_lira_unavailable():
     assert "lira-offline" in markdown
 
 
-def test_report_keeps_points_that_did_not_memorise():
+def test_report_keeps_low_memorisation_points_with_full_metrics():
     points = [
         _point(ladder.NON_PRIVATE_LABEL, None, holm_p=0.001, auc=0.62),
-        _point("eps2", 2.0, gate=False, status="skipped_memorisation_gate"),
+        _point("eps2", 2.0, gate=False, auc=0.50, holm_p=0.9),
     ]
     summaries = ladder.summarise_points(points)
+    observations = ladder.collect_observations(summaries)
     payload = {
         "task": ladder.TASK_NAME,
         "sensitive_attribute": ladder.SENSITIVE_ATTRIBUTE,
@@ -731,11 +789,145 @@ def test_report_keeps_points_that_did_not_memorise():
         "epochs": 400,
         "points": summaries,
         "frontier": ladder.detectability_frontier(summaries),
+        "observations": observations,
+        "gap_associations": ladder.gap_associations(observations, reps=20, seed=0),
+        "association_only_statement": ladder.ASSOCIATION_ONLY_STATEMENT,
     }
     markdown = ladder.render_markdown(payload)
+
     assert "eps2" in markdown
-    assert ladder.DID_NOT_MEMORISE in markdown
-    assert "skipped_memorisation_gate" in markdown
+    assert ladder.UNDETECTABLE_LOW_MEMORISATION in markdown
+    # Amendment 1: the discarded-point vocabulary must be gone entirely.
+    assert "skipped_memorisation_gate" not in markdown
+    assert "TARGET DID NOT MEMORISE" not in markdown
+    # The low-memorisation point still contributes real numbers.
+    assert len(observations) == 6
+
+
+def test_no_output_ever_contains_the_skipped_status():
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, gate=False, auc=0.50, holm_p=0.9),
+        _point("eps2", 2.0, gate=False, auc=0.50, holm_p=0.9),
+    ]
+    summaries = ladder.summarise_points(points)
+    rows = ladder.build_rows(summaries)
+    blob = json.dumps(summaries, default=float) + json.dumps(rows, default=float)
+    assert "skipped_memorisation_gate" not in blob
+    assert all(row["attack_status"] == "completed" for row in rows)
+
+
+def test_every_point_enters_holm_adjustment():
+    """Including low-memorisation points, which the old gate would have removed."""
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, holm_p=0.001),
+        _point("eps32", 32.0, gate=False, holm_p=0.01),
+        _point("eps16", 16.0, gate=False, holm_p=0.02),
+    ]
+    for point in points:
+        for result in point["seed_results"]:
+            result["offline"]["permutation"]["aggregate_auc"].pop("p_value_holm")
+    ladder.apply_holm_across_points(points)
+    for point in points:
+        for result in point["seed_results"]:
+            assert "p_value_holm" in result["offline"]["permutation"]["aggregate_auc"]
+
+
+def test_every_point_enters_the_gap_analysis():
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, auc=0.62),
+        _point("eps32", 32.0, gate=False, auc=0.55),
+        _point("eps2", 2.0, gate=False, auc=0.50),
+    ]
+    observations = ladder.collect_observations(ladder.summarise_points(points))
+    assert len(observations) == 9
+    # Low-memorisation observations are present, not filtered out.
+    assert sum(1 for o in observations if not o["memorisation_threshold_passed"]) == 6
+    assert all(np.isfinite(o["lira_auc"]) for o in observations)
+    for field in ("bce_gap", "auc_gap", "accuracy_gap", "achieved_epsilon",
+                  "noise_multiplier", "tpr_at_1pct"):
+        assert field in observations[0]
+
+
+def test_gap_associations_return_finite_ordered_intervals():
+    points = [
+        _point(ladder.NON_PRIVATE_LABEL, None, auc=0.62),
+        _point("eps32", 32.0, auc=0.58),
+        _point("eps8", 8.0, gate=False, auc=0.52),
+        _point("eps2", 2.0, gate=False, auc=0.50),
+    ]
+    observations = ladder.collect_observations(ladder.summarise_points(points))
+    associations = ladder.gap_associations(observations, reps=50, seed=1)
+
+    assert set(associations) == {
+        f"{gap}__{leak}"
+        for gap in ladder.GAP_METRICS
+        for leak in ladder.LEAKAGE_METRICS
+    }
+    for entry in associations.values():
+        assert entry["ci95_low"] <= entry["ci95_high"]
+        assert -1.0 <= entry["spearman"] <= 1.0 or np.isnan(entry["spearman"])
+        assert entry["n_observations"] == len(observations)
+
+
+def test_gap_associations_handle_degenerate_constant_inputs():
+    """A constant metric makes Spearman undefined; that must not crash."""
+    points = [_point(ladder.NON_PRIVATE_LABEL, None, auc=0.60), _point("eps8", 8.0, auc=0.60)]
+    observations = ladder.collect_observations(ladder.summarise_points(points))
+    associations = ladder.gap_associations(observations, reps=20, seed=0)
+    for entry in associations.values():
+        low, high = entry["ci95_low"], entry["ci95_high"]
+        assert np.isnan(low) or low <= high
+
+
+def test_report_contains_the_association_not_causation_statement_verbatim():
+    points = [_point(ladder.NON_PRIVATE_LABEL, None, auc=0.62), _point("eps8", 8.0)]
+    summaries = ladder.summarise_points(points)
+    observations = ladder.collect_observations(summaries)
+    payload = {
+        "task": ladder.TASK_NAME,
+        "sensitive_attribute": ladder.SENSITIVE_ATTRIBUTE,
+        "delta": ladder.DELTA,
+        "seeds": [42, 43, 44],
+        "num_shadows": 32,
+        "bootstrap_reps": 10,
+        "permutation_reps": 10,
+        "epochs": 400,
+        "points": summaries,
+        "frontier": ladder.detectability_frontier(summaries),
+        "observations": observations,
+        "gap_associations": ladder.gap_associations(observations, reps=20, seed=0),
+        "association_only_statement": ladder.ASSOCIATION_ONLY_STATEMENT,
+    }
+    markdown = ladder.render_markdown(payload)
+
+    expected = (
+        "These analyses measure association only. DP noise changes both "
+        "generalisation and leakage, so this experiment does not identify an effect "
+        "of DP on membership leakage independently of its effect on memorisation."
+    )
+    assert expected == ladder.ASSOCIATION_ONLY_STATEMENT
+    assert expected in markdown
+    for banned in ("mediation", "beyond generalisation", "causes", "causal effect"):
+        assert banned not in markdown.lower().replace(
+            'no causal, mediation or "beyond generalisation" claim', ""
+        )
+
+
+def test_preregistration_amendment_exists():
+    text = (ROOT / "docs" / "NOISE_LADDER_PREREGISTRATION.md").read_text()
+    assert "## Preregistration Amendment 1 — attack all ladder points" in text
+    for required in (
+        "execution gate",
+        "explanatory metadata",
+        ladder.DETECTABLE_WITH_MEMORISATION,
+        ladder.DETECTABLE_LOW_MEMORISATION,
+        ladder.UNDETECTABLE_WITH_MEMORISATION,
+        ladder.UNDETECTABLE_LOW_MEMORISATION,
+        "30218898999",
+        "exploratory",
+    ):
+        assert required in text
+    assert "0.55" in text and "0.03" in text
 
 
 def test_csv_rows_cover_every_point_and_seed():
@@ -783,3 +975,82 @@ def test_smoke_ladder_point_runs(tmp_path):
         ]
     )
     assert (tmp_path / "eps8.json").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Conditional canary pilot
+# --------------------------------------------------------------------------- #
+
+canary = _load("canary_pilot", "research/canary_pilot.py")
+
+
+def _canary_payload(accuracy, eps_lb):
+    entry = {
+        "construction": "label-flip",
+        "probe": "record-level membership",
+        "num_canaries": 200,
+        "duplication": 1,
+        "num_guesses": 200,
+        "num_correct": int(accuracy * 200),
+        "attacker_accuracy": accuracy,
+        "epsilon_lower_bound": eps_lb,
+        "confidence": 0.95,
+        "passes_pilot": accuracy >= canary.MIN_ATTACKER_ACCURACY
+        and eps_lb > canary.MIN_EPSILON_LOWER_BOUND,
+    }
+    passed = entry["passes_pilot"]
+    return {
+        "experiment": "canary_pilot_non_private",
+        "task": ladder.TASK_NAME,
+        "private": False,
+        "epochs": 400,
+        "architecture": "Linear(d,128->128->64->1) + ReLU",
+        "batch_size": 64,
+        "learning_rate": 1e-3,
+        "seed": 42,
+        "min_attacker_accuracy": canary.MIN_ATTACKER_ACCURACY,
+        "min_epsilon_lower_bound": canary.MIN_EPSILON_LOWER_BOUND,
+        "results": [entry],
+        "verdict": canary.PILOT_PASSED if passed else canary.UNDERPOWERED,
+        "extend_to_dp_sentinels": passed,
+    }
+
+
+def test_canary_pilot_matches_the_ladder_architecture():
+    assert canary.HIDDEN_UNITS == ladder.HIDDEN_UNITS == (128, 128, 64)
+    assert canary.BATCH_SIZE == ladder.BATCH_SIZE == 64
+    assert canary.LEARNING_RATE == ladder.LEARNING_RATE == 1e-3
+    assert canary.EPOCHS == ladder.EPOCHS == 400
+    assert canary.TASK_NAME == ladder.TASK_NAME == "high_cost"
+
+
+def test_failed_canary_pilot_blocks_further_canary_runs():
+    payload = _canary_payload(accuracy=0.55, eps_lb=0.0)
+    assert payload["verdict"] == canary.UNDERPOWERED
+    assert payload["extend_to_dp_sentinels"] is False
+
+    markdown = canary.render_markdown(payload)
+    assert canary.UNDERPOWERED in markdown
+    assert "stops here" in markdown
+    assert "never *proven private*" in markdown
+
+
+def test_canary_pilot_requires_both_thresholds():
+    # High accuracy but a zero bound is not enough.
+    assert _canary_payload(0.95, 0.0)["extend_to_dp_sentinels"] is False
+    # A positive bound with weak accuracy is not enough either.
+    assert _canary_payload(0.60, 1.2)["extend_to_dp_sentinels"] is False
+    # Both together justify extension.
+    assert _canary_payload(0.80, 1.2)["extend_to_dp_sentinels"] is True
+
+
+def test_passing_canary_pilot_does_not_auto_run_dp_points():
+    markdown = canary.render_markdown(_canary_payload(0.80, 1.2))
+    assert "does not start automatically" in markdown
+    assert "separate, explicitly requested run" in markdown
+
+
+def test_duplicated_canaries_are_labelled_as_a_group_privacy_probe():
+    markdown = canary.render_markdown(_canary_payload(0.80, 1.2))
+    assert "group-privacy" in markdown.lower()
+    assert "k*epsilon" in markdown


### PR DESCRIPTION
**Draft — do not merge.** Base is `main`. The attack-power control work is already merged into `main`, so this PR contains only the ladder.

## What this is

An **auditability ladder for a deliberately memorising neural target** — not a universal DP-SGD detectability frontier. It characterises one intentionally attackable architecture on one dataset, chosen because the attack-power control showed it is attackable at all.

| Control (from the merged attack-power work) | Outcome |
|---|---|
| Matched-capacity MLP | attack inconclusive — generalised rather than memorised |
| Deliberately memorising MLP | aggregate leakage detected |
| **This ladder** | effect of DP noise on an intentionally attackable neural target |

Six points at seeds 42/43/44 with 32 shadows: non-private, ε = 32, 16, 8, 4, 2. Only the noise multiplier varies between finite points; cohorts, shadow schedules and init seeds derive from the target seed alone.

## Pre-registration Amendment 1 — committed before the implementation change

`bcac93b` amends `docs/NOISE_LADDER_PREREGISTRATION.md`; `bf72032` implements it. That order is deliberate.

The original registration used the memorisation gate as an **execution gate**. DP noise suppresses memorisation and attack power together, so gating execution on measured memorisation removes observations non-randomly and precisely at the high-noise end the ladder exists to characterise — and it truncates the sample on a variable correlated with the outcome, making the generalisation/leakage relationship unstudyable.

Every point and seed now receives the complete matched-shadow attack. Memorisation is explanatory metadata. No output can contain `skipped_memorisation_gate`. The numerical detection rule (mean AUC ≥ 0.55, AUC > 0.5 every seed, Holm-adjusted rejection on ≥2 of 3 seeds) and the memorisation criterion (0.03) are **unchanged**.

Points are classified by combining two independent decisions:

```
DETECTABLE WITH MEMORISATION
DETECTABLE DESPITE LOW MEASURED MEMORISATION
UNDETECTABLE DESPITE MEMORISATION
UNDETECTABLE WITH LOW MEMORISATION
```

No point is ever labelled private, safe or verified.

## Generalisation-gap analysis

Every seed-level observation is retained. Spearman correlations between each gap metric (BCE, AUC, accuracy) and offline LiRA AUC / TPR@1%, with seed-stratified bootstrap intervals. Four figures — `lira_auc_vs_bce_gap.png`, `lira_auc_vs_auc_gap.png`, `lira_auc_vs_accuracy_gap.png`, `tpr_vs_bce_gap.png` — plot every point, distinguishing non-private from DP-SGD and threshold-passing from low-memorisation.

The report carries this verbatim:

> These analyses measure association only. DP noise changes both generalisation and leakage, so this experiment does not identify an effect of DP on membership leakage independently of its effect on memorisation.

No causal, mediation or "beyond generalisation" claim is made.

## Online LiRA validation

The existing implementation is preserved as `online_raw_loss` and keeps its historical `lira-online` method label, so existing callers and stored results stay valid. A new `online_logit_confidence` variant applies `logit(clip(exp(-L)))` identically to target, shadow-IN and shadow-OUT losses. Both run in the ladder. Offline LiRA remains the pre-registered primary attack, and the transform is **not** assumed to win — if low-FPR calibration stays weak it will be marked descriptive and calibration-limited.

Tests cover finiteness at extreme losses (including `L=0` and `L=inf`), strict monotonicity, formula correctness, orientation, reproducibility, and that the default path is byte-identical to the legacy attack.

## Conditional canary pilot

`research/canary_pilot.py` runs a **non-private pilot only**, matched to the ladder architecture exactly. Label-flip and duplicated canaries (the latter explicitly labelled a group-privacy probe, read against ≈k·ε). It extends to DP sentinel points only if a construction reaches attacker accuracy ≥ 0.70 **and** a positive ε lower bound; otherwise it reports `CANARY AUDITOR UNDERPOWERED FOR THIS NEURAL TARGET` and stops. No automatic canary ladder.

## Workflow correction

The full six-point matrix is now `workflow_dispatch` **only** — `if: github.event_name == 'workflow_dispatch'` on both the matrix and the aggregation job. Pull requests get a lightweight `validate` job: ruff, the non-slow test suite, and a reduced two-point smoke run, 30-minute timeout.

Run `30218898999` was launched automatically by the PR event before this amendment existed and was cancelled ~2.5 min in. It produced no ladder-point results and is recorded in the pre-registration as **exploratory/timing only**.

## Verification

- `ruff check src tests research/detectability_noise_ladder.py research/canary_pilot.py` clean.
- **224 passed, 4 deselected.** 59 ladder tests including all four statuses, low-memorisation points retaining full metrics, every point entering Holm adjustment and the gap analysis, the verbatim statement, the amendment's existence, and a failed canary pilot blocking further runs.
- Two-point smoke run (1 seed, 8 shadows, 5 epochs, 50 resamples) completes through report and all eight figures, with zero occurrences of the removed vocabulary.
- **Runtime projection:** DP timing pilot (ε=8, 1 seed, 6 shadows, 20 epochs) took 17.4 s → 0.1246 s per model-epoch → **82.2 min projected per matrix point** (3 seeds × 33 models × 400 epochs) against a 350-minute timeout — a 4.26× margin, still fitting at 2× slower CI hardware.

One deviation worth noting: the smoke run uses **8 shadows, not 4**. With 856/1338 training rows, 4 shadows yields 1 OUT observation per example and a standard deviation needs 2 — 4 shadows cannot fit any Gaussian on this pool. Smoke mode lowers the floor to 2 and stamps every artifact it produces as *not a pre-registered result*, so the real coverage guard is never weakened.

The full ladder has **not** been dispatched.