### PR TITLE
Add Streamlit benchmark results explorer

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,10 @@
+[theme]
+base = "dark"
+primaryColor = "#6C8CFF"
+backgroundColor = "#0E1117"
+secondaryBackgroundColor = "#171D2B"
+textColor = "#F4F7FB"
+font = "sans serif"
+
+[server]
+headless = true

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,31 @@
+# Streamlit results explorer
+
+The dashboard is a read-only interface over the benchmark outputs in
+`reports/generated/summary.csv`. It does not train models, accept uploaded data,
+or provide insurance pricing.
+
+## Run locally
+
+```bash
+pip install -e ".[app]"
+streamlit run streamlit_app.py
+```
+
+To regenerate every displayed result first:
+
+```bash
+pip install -e ".[experimental,dev,app]"
+python -m dp.benchmark --task all --seeds 0 1 2 3 4 --output-dir reports/generated
+python -m dp.reporting --results reports/generated --reports-dir reports
+streamlit run streamlit_app.py
+```
+
+## Deploy on Streamlit Community Cloud
+
+1. Connect the GitHub repository.
+2. Select `streamlit_app.py` as the entrypoint.
+3. Use Python 3.10 or newer.
+4. The root `requirements.txt` installs the package and dashboard dependencies.
+
+The app intentionally uses committed, versioned outputs so deployment remains
+fast, deterministic and inexpensive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ experimental = [
     "torch>=2.0",
     "opacus>=1.4",
 ]
+app = [
+    "streamlit>=1.36",
+    "altair>=5.2",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+-e .[app]
+
 # Known-good pinned versions (verified by executing the full notebook and test
 # suite). For flexible ranges, install via `pip install -e .` instead.
 numpy==1.24.3

--- a/src/dp/dashboard.py
+++ b/src/dp/dashboard.py
@@ -1,0 +1,194 @@
+"""Data preparation helpers for the Streamlit benchmark explorer.
+
+The dashboard is deliberately read-only: it visualises versioned benchmark
+outputs and never retrains models or accepts sensitive user data.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+REQUIRED_SUMMARY_COLUMNS = {
+    "task",
+    "model",
+    "epsilon",
+    "metric",
+    "mean",
+    "ci_lower",
+    "ci_upper",
+    "n_runs",
+}
+
+NONPRIVATE_MODELS = ("dummy", "logistic", "svm", "gradient_boosting", "neural")
+UTILITY_METRICS = ("roc_auc", "pr_auc", "macro_f1", "brier", "ece")
+FAIRNESS_METRICS = (
+    "demographic_parity_difference",
+    "equalized_odds_difference",
+)
+AUDIT_METRICS = ("mia_loss_threshold_auc", "mia_tpr_at_fpr_0.01")
+
+TASK_LABELS = {
+    "high_cost": "High-cost classification",
+    "smoker_without_charges": "Smoker prediction — charges removed",
+    "smoker_with_charges_legacy": "Smoker prediction — legacy proxy task",
+}
+MODEL_LABELS = {
+    "dummy": "Dummy baseline",
+    "logistic": "Logistic regression",
+    "svm": "RBF SVM",
+    "gradient_boosting": "Histogram gradient boosting",
+    "neural": "Neural network",
+    "dpsgd": "DP-SGD neural network",
+}
+METRIC_LABELS = {
+    "roc_auc": "ROC-AUC",
+    "pr_auc": "PR-AUC",
+    "macro_f1": "Macro F1",
+    "brier": "Brier score",
+    "ece": "Expected calibration error",
+    "demographic_parity_difference": "Demographic parity difference",
+    "equalized_odds_difference": "Equalized odds difference",
+    "mia_loss_threshold_auc": "Membership-inference AUC",
+    "mia_tpr_at_fpr_0.01": "MIA TPR at 1% FPR",
+}
+
+
+def load_summary(path: str | Path) -> pd.DataFrame:
+    """Load and validate the generated benchmark summary."""
+    summary_path = Path(path)
+    if not summary_path.exists():
+        raise FileNotFoundError(
+            f"Benchmark summary not found at {summary_path}. "
+            "Run `python -m dp.benchmark` and `python -m dp.reporting` first."
+        )
+
+    frame = pd.read_csv(summary_path)
+    missing = REQUIRED_SUMMARY_COLUMNS.difference(frame.columns)
+    if missing:
+        raise ValueError(f"Summary is missing required columns: {sorted(missing)}")
+
+    numeric = ["epsilon", "mean", "ci_lower", "ci_upper", "n_runs"]
+    for column in numeric:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+
+    if frame[["mean", "ci_lower", "ci_upper"]].isna().all(axis=None):
+        raise ValueError("Summary contains no numeric metric estimates.")
+
+    return frame.sort_values(["task", "metric", "model", "epsilon"]).reset_index(drop=True)
+
+
+def metric_rows(
+    summary: pd.DataFrame,
+    *,
+    task: str,
+    metric: str,
+    models: Iterable[str] | None = None,
+) -> pd.DataFrame:
+    """Return one task/metric slice with presentation labels."""
+    subset = summary[(summary["task"] == task) & (summary["metric"] == metric)].copy()
+    if models is not None:
+        subset = subset[subset["model"].isin(tuple(models))]
+
+    subset["task_label"] = subset["task"].map(TASK_LABELS).fillna(subset["task"])
+    subset["model_label"] = subset["model"].map(MODEL_LABELS).fillna(subset["model"])
+    subset["metric_label"] = METRIC_LABELS.get(metric, metric.replace("_", " ").title())
+    subset["epsilon_label"] = subset["epsilon"].map(
+        lambda value: f"{value:.3f}" if np.isfinite(value) else "Non-private"
+    )
+    subset["configuration"] = subset.apply(configuration_label, axis=1)
+    return subset.reset_index(drop=True)
+
+
+def configuration_label(row: pd.Series) -> str:
+    """Human-readable model label including achieved epsilon for private runs."""
+    model = MODEL_LABELS.get(str(row["model"]), str(row["model"]))
+    epsilon = float(row["epsilon"])
+    if np.isfinite(epsilon):
+        return f"{model} (ε={epsilon:.2f})"
+    return model
+
+
+def best_nonprivate(summary: pd.DataFrame, task: str, metric: str = "roc_auc") -> pd.Series:
+    """Return the strongest non-private, non-dummy configuration for a metric."""
+    subset = metric_rows(
+        summary,
+        task=task,
+        metric=metric,
+        models=("logistic", "svm", "gradient_boosting", "neural"),
+    )
+    if subset.empty:
+        raise ValueError(f"No non-private rows found for task={task!r}, metric={metric!r}")
+
+    lower_is_better = metric in {"brier", "ece"}
+    index = subset["mean"].idxmin() if lower_is_better else subset["mean"].idxmax()
+    return subset.loc[index]
+
+
+def dp_budget_row(
+    summary: pd.DataFrame,
+    task: str,
+    metric: str = "roc_auc",
+    *,
+    strictest: bool = True,
+) -> pd.Series:
+    """Return the strictest or loosest available DP-SGD budget row."""
+    subset = metric_rows(summary, task=task, metric=metric, models=("dpsgd",))
+    subset = subset[np.isfinite(subset["epsilon"])]
+    if subset.empty:
+        raise ValueError(f"No DP-SGD rows found for task={task!r}, metric={metric!r}")
+    index = subset["epsilon"].idxmin() if strictest else subset["epsilon"].idxmax()
+    return subset.loc[index]
+
+
+def headline_statistics(summary: pd.DataFrame) -> dict[str, float | str]:
+    """Compute the dashboard's headline values from generated results."""
+    legacy = best_nonprivate(summary, "smoker_with_charges_legacy")
+    corrected = best_nonprivate(summary, "smoker_without_charges")
+    high_cost_best = best_nonprivate(summary, "high_cost")
+    high_cost_dp = dp_budget_row(summary, "high_cost", strictest=True)
+
+    fairness = metric_rows(
+        summary,
+        task="smoker_without_charges",
+        metric="demographic_parity_difference",
+        models=("dpsgd",),
+    ).sort_values("epsilon")
+    fairness_change = np.nan
+    if len(fairness) >= 2:
+        fairness_change = float(fairness.iloc[-1]["mean"] - fairness.iloc[0]["mean"])
+
+    return {
+        "legacy_roc_auc": float(legacy["mean"]),
+        "corrected_roc_auc": float(corrected["mean"]),
+        "proxy_drop": float(corrected["mean"] - legacy["mean"]),
+        "high_cost_best_roc_auc": float(high_cost_best["mean"]),
+        "high_cost_dp_roc_auc": float(high_cost_dp["mean"]),
+        "high_cost_dp_epsilon": float(high_cost_dp["epsilon"]),
+        "high_cost_retention": float(high_cost_dp["mean"] / high_cost_best["mean"]),
+        "fairness_change": fairness_change,
+        "best_high_cost_model": str(high_cost_best["model_label"]),
+    }
+
+
+def available_metrics(summary: pd.DataFrame, candidates: Iterable[str]) -> list[str]:
+    """Return candidate metrics that are present in the current results."""
+    present = set(summary["metric"].dropna().astype(str))
+    return [metric for metric in candidates if metric in present]
+
+
+def group_rate_rows(summary: pd.DataFrame, task: str, rate: str) -> pd.DataFrame:
+    """Return female/male DP-SGD TPR or FPR rows with a group column."""
+    if rate not in {"tpr", "fpr"}:
+        raise ValueError("rate must be 'tpr' or 'fpr'")
+
+    metrics = [f"{rate}_group_female", f"{rate}_group_male"]
+    subset = summary[
+        (summary["task"] == task)
+        & (summary["model"] == "dpsgd")
+        & summary["metric"].isin(metrics)
+    ].copy()
+    subset["group"] = subset["metric"].str.rsplit("_", n=1).str[-1].str.title()
+    return subset.sort_values(["group", "epsilon"]).reset_index(drop=True)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,460 @@
+"""Interactive results explorer for the differential-privacy benchmark."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import altair as alt
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+from dp.dashboard import (
+    AUDIT_METRICS,
+    FAIRNESS_METRICS,
+    METRIC_LABELS,
+    MODEL_LABELS,
+    TASK_LABELS,
+    UTILITY_METRICS,
+    available_metrics,
+    best_nonprivate,
+    dp_budget_row,
+    group_rate_rows,
+    headline_statistics,
+    load_summary,
+    metric_rows,
+)
+
+ROOT = Path(__file__).resolve().parent
+SUMMARY_PATH = ROOT / "reports" / "generated" / "summary.csv"
+
+st.set_page_config(
+    page_title="DP Insurance Benchmark",
+    page_icon="🔐",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+st.markdown(
+    """
+    <style>
+      .block-container {max-width: 1240px; padding-top: 1.8rem; padding-bottom: 3rem;}
+      [data-testid="stMetric"] {border: 1px solid rgba(128,128,128,.22); border-radius: 12px; padding: 14px;}
+      .small-note {font-size: .92rem; opacity: .78;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+
+@st.cache_data(show_spinner=False)
+def cached_summary(path: str, modified_ns: int) -> pd.DataFrame:
+    del modified_ns
+    return load_summary(path)
+
+
+def format_value(metric: str, value: float) -> str:
+    if pd.isna(value):
+        return "n/a"
+    return f"{value:.3f}"
+
+
+def interval_tooltips(metric: str) -> list[alt.Tooltip]:
+    return [
+        alt.Tooltip("configuration:N", title="Configuration"),
+        alt.Tooltip("epsilon_label:N", title="Achieved ε"),
+        alt.Tooltip("mean:Q", title=METRIC_LABELS.get(metric, metric), format=".3f"),
+        alt.Tooltip("ci_lower:Q", title="CI lower", format=".3f"),
+        alt.Tooltip("ci_upper:Q", title="CI upper", format=".3f"),
+        alt.Tooltip("n_runs:Q", title="Seeds"),
+    ]
+
+
+def privacy_curve(frame: pd.DataFrame, metric: str, baseline: pd.Series | None = None) -> alt.Chart:
+    y_title = METRIC_LABELS.get(metric, metric.replace("_", " ").title())
+    base = alt.Chart(frame).encode(
+        x=alt.X("epsilon:Q", title="Achieved privacy budget ε", scale=alt.Scale(zero=False)),
+        color=alt.Color("model_label:N", title="Model"),
+        tooltip=interval_tooltips(metric),
+    )
+    line = base.mark_line(point=True).encode(
+        y=alt.Y("mean:Q", title=y_title, scale=alt.Scale(zero=False))
+    )
+    error = base.mark_errorbar(ticks=True).encode(
+        y=alt.Y("ci_lower:Q", title=y_title, scale=alt.Scale(zero=False)),
+        y2="ci_upper:Q",
+    )
+    chart: alt.Chart = line + error
+    if baseline is not None:
+        ref = pd.DataFrame(
+            {
+                "baseline": [float(baseline["mean"])],
+                "label": [str(baseline["model_label"])],
+            }
+        )
+        rule = alt.Chart(ref).mark_rule(strokeDash=[7, 5]).encode(
+            y="baseline:Q",
+            tooltip=[
+                alt.Tooltip("label:N", title="Reference"),
+                alt.Tooltip("baseline:Q", title=y_title, format=".3f"),
+            ],
+        )
+        chart = chart + rule
+    return chart.properties(height=430).interactive()
+
+
+def comparison_chart(frame: pd.DataFrame, metric: str) -> alt.Chart:
+    order = frame.sort_values("mean", ascending=False)["configuration"].tolist()
+    base = alt.Chart(frame).encode(
+        y=alt.Y("configuration:N", sort=order, title=None),
+        tooltip=interval_tooltips(metric),
+    )
+    bars = base.mark_bar().encode(
+        x=alt.X("mean:Q", title=METRIC_LABELS.get(metric, metric), scale=alt.Scale(zero=False)),
+        color=alt.Color("model:N", legend=None),
+    )
+    error = base.mark_errorbar(ticks=True).encode(x="ci_lower:Q", x2="ci_upper:Q")
+    return (bars + error).properties(height=max(320, 36 * len(frame)))
+
+
+def render_data_table(frame: pd.DataFrame) -> None:
+    columns = [
+        "task_label",
+        "configuration",
+        "mean",
+        "ci_lower",
+        "ci_upper",
+        "n_runs",
+    ]
+    available = [column for column in columns if column in frame.columns]
+    st.dataframe(frame[available], use_container_width=True, hide_index=True)
+
+
+try:
+    summary = cached_summary(str(SUMMARY_PATH), SUMMARY_PATH.stat().st_mtime_ns)
+except (FileNotFoundError, ValueError) as exc:
+    st.error(str(exc))
+    st.code(
+        "python -m dp.benchmark --task all --seeds 0 1 2 3 4 --output-dir reports/generated\n"
+        "python -m dp.reporting --results reports/generated --reports-dir reports"
+    )
+    st.stop()
+
+stats = headline_statistics(summary)
+
+st.title("Differential Privacy in Machine Learning")
+st.subheader("An interactive insurance benchmark for privacy, utility, calibration and fairness")
+st.caption(
+    "Read-only explorer over versioned benchmark outputs. No model training, data upload, "
+    "or insurance pricing is performed in this app."
+)
+
+with st.sidebar:
+    st.header("Benchmark scope")
+    st.markdown(
+        "**Dataset:** public 1,338-row teaching dataset  \n"
+        "**Evaluation:** leakage-safe train/validation/test pipeline  \n"
+        "**Uncertainty:** repeated-seed 95% t-intervals  \n"
+        "**Privacy:** achieved ε from the Opacus RDP accountant"
+    )
+    st.divider()
+    st.markdown("[View source repository](https://github.com/Ghobi-A/dp-insurance)")
+    st.caption("Results shown here are research/portfolio evidence, not clinical or actuarial advice.")
+
+overview_tab, utility_tab, proxy_tab, fairness_tab, audit_tab, methods_tab = st.tabs(
+    ["Overview", "Privacy–utility", "Proxy leakage", "Fairness", "Privacy audits", "Methodology"]
+)
+
+with overview_tab:
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric(
+        "Legacy smoker ROC-AUC",
+        f"{stats['legacy_roc_auc']:.3f}",
+        help="Best non-private, non-dummy model when charges is available.",
+    )
+    c2.metric(
+        "Proxy-safe smoker ROC-AUC",
+        f"{stats['corrected_roc_auc']:.3f}",
+        delta=f"{stats['proxy_drop']:+.3f}",
+        help="Best non-private result after removing charges.",
+    )
+    c3.metric(
+        "Strict-DP high-cost ROC-AUC",
+        f"{stats['high_cost_dp_roc_auc']:.3f}",
+        delta=f"{stats['high_cost_retention']:.1%} retained",
+        help=f"DP-SGD at achieved ε={stats['high_cost_dp_epsilon']:.2f} against the best non-private model.",
+    )
+    c4.metric(
+        "Fairness-gap change",
+        "n/a" if np.isnan(stats["fairness_change"]) else f"{stats['fairness_change']:+.3f}",
+        help="Change in DP-SGD demographic-parity difference from the strictest to loosest budget on the proxy-safe smoker task.",
+    )
+
+    st.markdown("### What the benchmark establishes")
+    left, right = st.columns(2)
+    with left:
+        st.info(
+            "**The original smoker task was dominated by a proxy.** Removing `charges` "
+            "reduces the best ROC-AUC from near-perfect discrimination to approximately chance-level performance."
+        )
+        st.success(
+            "**DP-SGD can preserve useful signal.** On high-cost classification, the strictest "
+            "tested budget retains most of the strongest non-private model's ROC-AUC."
+        )
+    with right:
+        st.warning(
+            "**Privacy and fairness move together.** Noise can suppress both predictive signal "
+            "and measured group disparity; a smaller gap is not automatically a fairer useful model."
+        )
+        st.info(
+            "**Empirical attacks are diagnostics, not certificates.** Formal privacy comes from "
+            "the accountant; attack results provide practical leakage evidence and lower bounds."
+        )
+
+    task = st.selectbox(
+        "Inspect a task",
+        options=sorted(summary["task"].unique()),
+        format_func=lambda value: TASK_LABELS.get(value, value),
+        key="overview_task",
+    )
+    rows = metric_rows(summary, task=task, metric="roc_auc")
+    st.altair_chart(comparison_chart(rows, "roc_auc"), use_container_width=True)
+    with st.expander("Show result rows"):
+        render_data_table(rows)
+
+with utility_tab:
+    st.markdown("### Privacy–utility explorer")
+    col_task, col_metric, col_baseline = st.columns([1.25, 1, 1.25])
+    task = col_task.selectbox(
+        "Task",
+        options=sorted(summary["task"].unique()),
+        format_func=lambda value: TASK_LABELS.get(value, value),
+        key="utility_task",
+    )
+    utility_metrics = available_metrics(summary, UTILITY_METRICS)
+    metric = col_metric.selectbox(
+        "Metric",
+        options=utility_metrics,
+        format_func=lambda value: METRIC_LABELS.get(value, value),
+        key="utility_metric",
+    )
+    baseline_options = [
+        model
+        for model in ("logistic", "svm", "gradient_boosting", "neural")
+        if not metric_rows(summary, task=task, metric=metric, models=(model,)).empty
+    ]
+    default_baseline = best_nonprivate(summary, task, metric)["model"]
+    baseline_model = col_baseline.selectbox(
+        "Non-private reference",
+        options=baseline_options,
+        index=baseline_options.index(default_baseline),
+        format_func=lambda value: MODEL_LABELS.get(value, value),
+        key="utility_baseline",
+    )
+
+    dp_rows = metric_rows(summary, task=task, metric=metric, models=("dpsgd",))
+    dp_rows = dp_rows[np.isfinite(dp_rows["epsilon"])].sort_values("epsilon")
+    baseline = metric_rows(summary, task=task, metric=metric, models=(baseline_model,)).iloc[0]
+    st.altair_chart(privacy_curve(dp_rows, metric, baseline), use_container_width=True)
+
+    strict = dp_budget_row(summary, task, metric, strictest=True)
+    loose = dp_budget_row(summary, task, metric, strictest=False)
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Strictest tested ε", f"{strict['epsilon']:.3f}")
+    c2.metric("Metric at strictest ε", format_value(metric, strict["mean"]))
+    c3.metric("Metric at loosest ε", format_value(metric, loose["mean"]))
+    st.caption(
+        "For ROC-AUC, PR-AUC and macro F1, higher is better. For Brier score and ECE, lower is better. "
+        "Intervals describe pipeline run-to-run variation across seeds."
+    )
+    with st.expander("Show plotted data"):
+        render_data_table(dp_rows)
+
+with proxy_tab:
+    st.markdown("### Proxy leakage demonstration")
+    st.write(
+        "The legacy smoker classifier can use insurance charges, which are tightly associated with smoking. "
+        "The corrected task removes that feature before splitting and evaluation."
+    )
+    proxy_metric = st.selectbox(
+        "Metric",
+        options=[m for m in ("roc_auc", "pr_auc", "macro_f1") if m in set(summary["metric"])],
+        format_func=lambda value: METRIC_LABELS.get(value, value),
+        key="proxy_metric",
+    )
+    models = ("logistic", "svm", "gradient_boosting", "neural")
+    legacy = metric_rows(
+        summary,
+        task="smoker_with_charges_legacy",
+        metric=proxy_metric,
+        models=models,
+    )
+    corrected = metric_rows(
+        summary,
+        task="smoker_without_charges",
+        metric=proxy_metric,
+        models=models,
+    )
+    proxy_rows = pd.concat([legacy, corrected], ignore_index=True)
+    proxy_rows["task_short"] = proxy_rows["task"].map(
+        {
+            "smoker_with_charges_legacy": "Charges available",
+            "smoker_without_charges": "Charges removed",
+        }
+    )
+    chart = (
+        alt.Chart(proxy_rows)
+        .mark_bar()
+        .encode(
+            x=alt.X("model_label:N", title=None, axis=alt.Axis(labelAngle=-20)),
+            xOffset="task_short:N",
+            y=alt.Y("mean:Q", title=METRIC_LABELS.get(proxy_metric, proxy_metric), scale=alt.Scale(zero=False)),
+            color=alt.Color("task_short:N", title="Task design"),
+            tooltip=[
+                alt.Tooltip("model_label:N", title="Model"),
+                alt.Tooltip("task_short:N", title="Task"),
+                alt.Tooltip("mean:Q", title=METRIC_LABELS.get(proxy_metric, proxy_metric), format=".3f"),
+                alt.Tooltip("ci_lower:Q", title="CI lower", format=".3f"),
+                alt.Tooltip("ci_upper:Q", title="CI upper", format=".3f"),
+            ],
+        )
+        .properties(height=430)
+    )
+    st.altair_chart(chart, use_container_width=True)
+    legacy_best = legacy.loc[legacy["mean"].idxmax()]
+    corrected_best = corrected.loc[corrected["mean"].idxmax()]
+    st.metric(
+        "Best-model change after removing charges",
+        f"{corrected_best['mean'] - legacy_best['mean']:+.3f}",
+        help=f"{legacy_best['model_label']} vs {corrected_best['model_label']} on {METRIC_LABELS.get(proxy_metric, proxy_metric)}.",
+    )
+    st.caption(
+        "This is a benchmark-design finding, not evidence that the remaining features can support a useful smoker classifier."
+    )
+
+with fairness_tab:
+    st.markdown("### Privacy–fairness explorer")
+    fairness_tasks = [
+        task
+        for task in sorted(summary["task"].unique())
+        if not metric_rows(
+            summary,
+            task=task,
+            metric="demographic_parity_difference",
+            models=("dpsgd",),
+        ).empty
+    ]
+    task = st.selectbox(
+        "Task",
+        options=fairness_tasks,
+        format_func=lambda value: TASK_LABELS.get(value, value),
+        key="fairness_task",
+    )
+    fairness_metric = st.radio(
+        "Gap metric",
+        options=available_metrics(summary, FAIRNESS_METRICS),
+        format_func=lambda value: METRIC_LABELS.get(value, value),
+        horizontal=True,
+    )
+    fairness_rows = metric_rows(summary, task=task, metric=fairness_metric, models=("dpsgd",))
+    fairness_rows = fairness_rows[np.isfinite(fairness_rows["epsilon"])].sort_values("epsilon")
+    st.altair_chart(privacy_curve(fairness_rows, fairness_metric), use_container_width=True)
+
+    rate = st.radio("Group-rate detail", options=["tpr", "fpr"], format_func=str.upper, horizontal=True)
+    group_rows = group_rate_rows(summary, task, rate)
+    if group_rows.empty:
+        st.info("Group-rate rows are unavailable for this task.")
+    else:
+        group_rows["configuration"] = group_rows["group"]
+        group_chart = (
+            alt.Chart(group_rows)
+            .mark_line(point=True)
+            .encode(
+                x=alt.X("epsilon:Q", title="Achieved privacy budget ε", scale=alt.Scale(zero=False)),
+                y=alt.Y("mean:Q", title=f"{rate.upper()} by group", scale=alt.Scale(zero=False)),
+                color=alt.Color("group:N", title="Group"),
+                tooltip=[
+                    alt.Tooltip("group:N", title="Group"),
+                    alt.Tooltip("epsilon:Q", title="Achieved ε", format=".3f"),
+                    alt.Tooltip("mean:Q", title=rate.upper(), format=".3f"),
+                    alt.Tooltip("ci_lower:Q", title="CI lower", format=".3f"),
+                    alt.Tooltip("ci_upper:Q", title="CI upper", format=".3f"),
+                ],
+            )
+            .properties(height=360)
+            .interactive()
+        )
+        st.altair_chart(group_chart, use_container_width=True)
+    st.warning(
+        "A smaller measured gap can result from a model becoming less informative for everyone. "
+        "Interpret fairness jointly with utility, group rates and sample sizes."
+    )
+
+with audit_tab:
+    st.markdown("### Empirical privacy diagnostics")
+    a1, a2, a3 = st.columns(3)
+    a1.info("**Formal accounting**\n\nThe RDP accountant provides the claimed upper-bound guarantee at δ=1e-5.")
+    a2.info("**Auditor lower bounds**\n\nCanary-based tests try to prove the implementation leaks at least some ε.")
+    a3.info("**Attack performance**\n\nMembership-inference metrics estimate practical distinguishability for a chosen attack.")
+
+    audit_metrics = available_metrics(summary, AUDIT_METRICS)
+    if not audit_metrics:
+        st.info("No membership-inference summary metrics were found.")
+    else:
+        col1, col2 = st.columns(2)
+        task = col1.selectbox(
+            "Task",
+            options=sorted(summary["task"].unique()),
+            format_func=lambda value: TASK_LABELS.get(value, value),
+            key="audit_task",
+        )
+        metric = col2.selectbox(
+            "Attack metric",
+            options=audit_metrics,
+            format_func=lambda value: METRIC_LABELS.get(value, value),
+            key="audit_metric",
+        )
+        audit_rows = metric_rows(summary, task=task, metric=metric, models=("dpsgd",))
+        audit_rows = audit_rows[np.isfinite(audit_rows["epsilon"])].sort_values("epsilon")
+        chart = privacy_curve(audit_rows, metric)
+        if metric == "mia_loss_threshold_auc":
+            chance = alt.Chart(pd.DataFrame({"chance": [0.5]})).mark_rule(strokeDash=[4, 4]).encode(
+                y="chance:Q",
+                tooltip=[alt.Tooltip("chance:Q", title="Chance AUC", format=".1f")],
+            )
+            chart = chart + chance
+        st.altair_chart(chart, use_container_width=True)
+        st.caption(
+            "Chance-level attack performance means this attack did not distinguish members from non-members; "
+            "it does not verify the formal differential-privacy guarantee."
+        )
+        with st.expander("Show attack result rows"):
+            render_data_table(audit_rows)
+
+with methods_tab:
+    st.markdown("### Experimental design")
+    st.markdown(
+        """
+        1. **Leakage-safe task construction:** preprocessing is fit on the training partition only.  
+        2. **Validation-only decisions:** thresholds, early stopping and tuning use validation data.  
+        3. **Single test evaluation:** the test partition is touched once per run.  
+        4. **Repeated seeds:** reported intervals quantify split, initialisation and training variability.  
+        5. **Achieved privacy budgets:** ε is taken from the Opacus RDP accountant rather than copied from a requested target.  
+        6. **Defence in depth:** formal accounting is supplemented with canaries, membership-inference attacks and privacy regression tests.
+        """
+    )
+    st.markdown("### Important limitations")
+    st.markdown(
+        """
+        - The dataset is a small public teaching dataset, not real clinical or actuarial evidence.
+        - Repeated-seed intervals are not independent-sample confidence guarantees.
+        - Fairness analysis is limited to a binary `sex` attribute and can be unstable for small groups.
+        - The proxy-safe smoker task has little remaining predictive signal.
+        - Empirical attacks on a small dataset have limited power to certify small ε values.
+        """
+    )
+    st.code(
+        "python -m dp.benchmark --task all --seeds 0 1 2 3 4 --output-dir reports/generated\n"
+        "python -m dp.reporting --results reports/generated --reports-dir reports\n"
+        "streamlit run streamlit_app.py",
+        language="bash",
+    )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from dp.dashboard import (
+    best_nonprivate,
+    configuration_label,
+    dp_budget_row,
+    group_rate_rows,
+    headline_statistics,
+    load_summary,
+)
+
+
+def _summary() -> pd.DataFrame:
+    rows = []
+
+    def add(task: str, model: str, epsilon: float, metric: str, mean: float) -> None:
+        rows.append(
+            {
+                "task": task,
+                "model": model,
+                "epsilon": epsilon,
+                "metric": metric,
+                "mean": mean,
+                "ci_lower": mean - 0.01,
+                "ci_upper": mean + 0.01,
+                "n_runs": 5,
+            }
+        )
+
+    add("smoker_with_charges_legacy", "gradient_boosting", float("inf"), "roc_auc", 0.99)
+    add("smoker_without_charges", "logistic", float("inf"), "roc_auc", 0.54)
+    add("high_cost", "gradient_boosting", float("inf"), "roc_auc", 0.95)
+    add("high_cost", "dpsgd", 0.5, "roc_auc", 0.93)
+    add("high_cost", "dpsgd", 6.0, "roc_auc", 0.94)
+    add("smoker_without_charges", "dpsgd", 0.5, "demographic_parity_difference", 0.06)
+    add("smoker_without_charges", "dpsgd", 6.0, "demographic_parity_difference", 0.21)
+    add("high_cost", "dpsgd", 0.5, "tpr_group_female", 0.80)
+    add("high_cost", "dpsgd", 0.5, "tpr_group_male", 0.84)
+    return pd.DataFrame(rows)
+
+
+def test_load_summary_validates_required_columns(tmp_path):
+    path = tmp_path / "summary.csv"
+    pd.DataFrame({"task": ["high_cost"]}).to_csv(path, index=False)
+    with pytest.raises(ValueError, match="missing required columns"):
+        load_summary(path)
+
+
+def test_best_nonprivate_and_dp_budget_selection():
+    summary = _summary()
+    assert best_nonprivate(summary, "high_cost")["mean"] == pytest.approx(0.95)
+    assert dp_budget_row(summary, "high_cost", strictest=True)["epsilon"] == pytest.approx(0.5)
+    assert dp_budget_row(summary, "high_cost", strictest=False)["epsilon"] == pytest.approx(6.0)
+
+
+def test_headline_statistics_are_computed_from_rows():
+    stats = headline_statistics(_summary())
+    assert stats["proxy_drop"] == pytest.approx(-0.45)
+    assert stats["high_cost_retention"] == pytest.approx(0.93 / 0.95)
+    assert stats["fairness_change"] == pytest.approx(0.15)
+
+
+def test_group_rate_rows_extracts_group_name():
+    rows = group_rate_rows(_summary(), "high_cost", "tpr")
+    assert set(rows["group"]) == {"Female", "Male"}
+
+
+def test_configuration_label_includes_achieved_epsilon():
+    label = configuration_label(pd.Series({"model": "dpsgd", "epsilon": 1.9979}))
+    assert label == "DP-SGD neural network (ε=2.00)"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
@@ -71,3 +73,11 @@ def test_group_rate_rows_extracts_group_name():
 def test_configuration_label_includes_achieved_epsilon():
     label = configuration_label(pd.Series({"model": "dpsgd", "epsilon": 1.9979}))
     assert label == "DP-SGD neural network (ε=2.00)"
+
+
+def test_committed_summary_supports_dashboard_headlines():
+    root = Path(__file__).resolve().parents[1]
+    summary = load_summary(root / "reports" / "generated" / "summary.csv")
+    stats = headline_statistics(summary)
+    assert stats["legacy_roc_auc"] > stats["corrected_roc_auc"]
+    assert 0.0 < stats["high_cost_retention"] <= 1.05


### PR DESCRIPTION
## Summary
- add a read-only Streamlit dashboard over `reports/generated/summary.csv`
- surface headline privacy–utility findings, proxy leakage, fairness curves and membership-inference diagnostics
- keep model training and uploaded data out of the deployed app
- add reusable dashboard data helpers with unit tests
- add Streamlit theme, dependencies and deployment documentation

## Validation
- `python -m py_compile src/dp/dashboard.py streamlit_app.py tests/test_dashboard.py`
- `PYTHONPATH=src pytest -q tests/test_dashboard.py` — 5 passed

## Deployment
Use `streamlit_app.py` as the Streamlit Community Cloud entrypoint. The app reads the committed benchmark outputs and does not require rerunning DP-SGD during deployment.