### PR TITLE
Study 2 Phase 0: natural-leakage feasibility gate (implementation only)

### DIFF
--- a/.github/workflows/study2-phase0-natural-leakage.yml
+++ b/.github/workflows/study2-phase0-natural-leakage.yml
@@ -1,0 +1,265 @@
+name: Study 2 Phase 0 natural leakage
+
+# Manual dispatch only for the real gate, plus lint/tests/smoke on pull requests
+# that touch Phase 0. Phase 0 is evaluated ONCE on the frozen ACS slice and its
+# verdict is terminal for the natural-leakage branch, so it must never start
+# from a push, a schedule, or a merge.
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: >-
+          Type RUN-PHASE-0 to confirm. The gate is evaluated once on the frozen
+          slice; a FAIL closes the natural-leakage branch permanently.
+        required: true
+        default: ""
+      permutation_reps:
+        description: Membership-permutation replicates (frozen at 1000)
+        required: false
+        default: "1000"
+  pull_request:
+    paths:
+      - research/study2_phase0_natural_leakage.py
+      - research/study2_acs_slice.py
+      - tests/test_study2_phase0.py
+      - docs/STUDY2_PHASE0_PREREGISTRATION.md
+      - .github/workflows/study2-phase0-natural-leakage.yml
+
+concurrency:
+  group: study2-phase0-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  STUDY2_ACS_CACHE: ${{ github.workspace }}/.acs-cache
+
+jobs:
+  # Pull requests get lint, unit tests and a synthetic smoke run only. The smoke
+  # run never touches the network and its report is stamped "not a Phase 0
+  # result", so a PR can never produce a gate verdict.
+  validate:
+    name: Lint, tests and smoke run
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental,dev]"
+      - name: Ruff lint
+        run: ruff check src tests research/study2_phase0_natural_leakage.py research/study2_acs_slice.py
+      - name: Unit tests
+        run: python -m pytest tests/ -q -m "not slow"
+      - name: Smoke run (synthetic slice, tiny budgets, three seeds)
+        run: |
+          set -euo pipefail
+          python research/study2_acs_slice.py prepare --output /tmp/smoke/slice.csv --smoke
+          python research/study2_acs_slice.py verify --slice /tmp/smoke/slice.csv
+          for seed in 42 43 44; do
+            python research/study2_phase0_natural_leakage.py seed \
+              --slice /tmp/smoke/slice.csv --seed "$seed" \
+              --epochs 2 --shadows 4 --permutation-reps 20 --smoke \
+              --output-dir /tmp/smoke/seeds
+          done
+          python research/study2_phase0_natural_leakage.py aggregate \
+            --input-dir /tmp/smoke/seeds --output-dir /tmp/smoke/out --expect-all \
+            | tee /tmp/smoke/out.log
+          test -f /tmp/smoke/out/phase0_gate.json
+          test -f /tmp/smoke/out/phase0_gate.csv
+          test -f /tmp/smoke/out/phase0_gate.md
+          # Per-example records are the raw design; losing them is unrecoverable.
+          test -f /tmp/smoke/out/per_example.csv
+          grep -Eq '^CONTINUATION GATE: (PASS|FAIL)$' /tmp/smoke/out.log
+          # A smoke verdict must never be readable as the Phase 0 gate.
+          grep -q 'Not a Phase 0 result' /tmp/smoke/out/phase0_gate.md
+      - name: Upload smoke output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase0-smoke
+          path: /tmp/smoke/out
+          if-no-files-found: warn
+
+  prepare-slice:
+    name: Download and verify the frozen ACS slice
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Confirm the one-shot dispatch
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "RUN-PHASE-0" ]; then
+            echo "Refusing to run: confirmation input must be exactly RUN-PHASE-0." >&2
+            exit 1
+          fi
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "."
+      - name: Cache the ACS PUMS archive
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STUDY2_ACS_CACHE }}
+          key: acs-pums-ca-2018-1year-v1
+      - name: Materialise the frozen slice
+        run: |
+          python research/study2_acs_slice.py prepare \
+            --output slice/acs_income_ca_2018.csv \
+            --cache-dir "$STUDY2_ACS_CACHE"
+      - name: Verify row count and slice metadata
+        run: |
+          set -euo pipefail
+          python research/study2_acs_slice.py verify \
+            --slice slice/acs_income_ca_2018.csv | tee slice/verification.json
+          python - <<'PY'
+          import json, pathlib
+          meta = json.loads(pathlib.Path("slice/verification.json").read_text())
+          assert meta["rows"] == 50000, meta["rows"]
+          assert meta["task"] == "ACSIncome"
+          assert (meta["survey_year"], meta["horizon"], meta["state"]) == (2018, "1-Year", "CA")
+          assert meta["sensitive_attribute"] == "SEX"
+          assert meta["sampling_seed"] == 20260822
+          assert meta["smoke"] is False
+          print("frozen slice verified:", meta["fingerprint"])
+          PY
+      - name: Upload the frozen slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase0-slice
+          path: slice
+          retention-days: 30
+
+  target-seed:
+    name: "target seed ${{ matrix.seed }}"
+    if: github.event_name == 'workflow_dispatch'
+    needs: prepare-slice
+    runs-on: ubuntu-latest
+    # 65 models per seed (one target + 64 matched shadows) at 60 epochs.
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        seed: [42, 43, 44]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[experimental]"
+      - name: Download the frozen slice
+        uses: actions/download-artifact@v4
+        with:
+          name: phase0-slice
+          path: slice
+      - name: Verify the slice before training on it
+        run: python research/study2_acs_slice.py verify --slice slice/acs_income_ca_2018.csv
+      - name: Run target seed ${{ matrix.seed }}
+        shell: bash
+        run: |
+          mkdir -p reports/study2_phase0/seeds
+          set +e
+          python research/study2_phase0_natural_leakage.py seed \
+            --slice slice/acs_income_ca_2018.csv \
+            --seed ${{ matrix.seed }} \
+            --permutation-reps "${{ github.event.inputs.permutation_reps || '1000' }}" \
+            --output-dir reports/study2_phase0/seeds \
+            2>&1 | tee reports/study2_phase0/seeds/seed_${{ matrix.seed }}.console.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" \
+            >> reports/study2_phase0/seeds/seed_${{ matrix.seed }}.console.log
+          exit "$status"
+      # Per-example attack outputs are persisted with the seed result, so the
+      # raw design survives even if aggregation is re-run later.
+      - name: Upload seed ${{ matrix.seed }} outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase0-seed-${{ matrix.seed }}
+          path: reports/study2_phase0/seeds
+          if-no-files-found: warn
+          retention-days: 90
+
+  gate:
+    name: Aggregate all seeds and evaluate the continuation gate
+    # Aggregation runs only after every seed job has finished. `--expect-all`
+    # makes a missing seed an INCOMPLETE non-zero exit rather than a gate
+    # decision taken on a partial set.
+    needs: target-seed
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "."
+      - name: Download every seed artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: phase0-seed-*
+          path: reports/study2_phase0/seeds
+          merge-multiple: true
+      - name: Aggregate and evaluate the gate
+        shell: bash
+        run: |
+          set +e
+          python research/study2_phase0_natural_leakage.py aggregate \
+            --input-dir reports/study2_phase0/seeds \
+            --output-dir reports/study2_phase0 \
+            --expect-all \
+            2>&1 | tee reports/study2_phase0/gate.console.log
+          status=${PIPESTATUS[0]}
+          echo "exit_status=$status" >> reports/study2_phase0/gate.console.log
+          exit "$status"
+      - name: Print the continuation gate
+        if: always()
+        shell: bash
+        run: |
+          verdict=$(grep -Eo '^CONTINUATION GATE: (PASS|FAIL|INCOMPLETE)$' \
+            reports/study2_phase0/gate.console.log | tail -n 1 | awk '{print $3}')
+          verdict=${verdict:-INCOMPLETE}
+          echo "$verdict"
+          {
+            echo "# Study 2 Phase 0 continuation gate: $verdict"
+            echo
+            if [ -f reports/study2_phase0/phase0_gate.md ]; then
+              cat reports/study2_phase0/phase0_gate.md
+            else
+              echo 'The gate report was not produced; see the console log artifact.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      # Results are uploaded as artifacts only. Nothing is committed back, no
+      # pull request is opened, and no downstream DP epsilon ladder workflow is
+      # triggered from here -- on either verdict. Continuation, if the gate
+      # passes, is a separate human decision and a separate manual dispatch.
+      - name: Upload the gate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: phase0-gate-report
+          path: reports/study2_phase0
+          if-no-files-found: warn
+          retention-days: 90

--- a/docs/STUDY2_PHASE0_PREREGISTRATION.md
+++ b/docs/STUDY2_PHASE0_PREREGISTRATION.md
@@ -1,0 +1,85 @@
+# Study 2, Phase 0 — natural-leakage feasibility gate (preregistration)
+
+Frozen before any Phase 0 result exists. Implemented by
+`research/study2_acs_slice.py`, `research/study2_phase0_natural_leakage.py` and
+`.github/workflows/study2-phase0-natural-leakage.yml`.
+
+## Question
+
+Does a naturally (non-privately) trained model on a real ACS slice leak
+membership strongly enough that a DP epsilon ladder built on top of it could
+measure anything? If it does not, every downstream privacy-utility comparison
+would be a comparison of noise with noise, and the ladder should not be built.
+
+Phase 0 is a **gate**, not a finding. It is not intended to be interesting.
+
+## Frozen design
+
+| Item | Value |
+| --- | --- |
+| Task | Folktables `ACSIncome` (Ding et al. 2021) |
+| Survey year / horizon | 2018 / 1-Year |
+| State | CA |
+| Sensitive attribute | `SEX` |
+| Slice | 50,000 eligible rows, sampling seed `20260822` |
+| Target seeds | 42, 43, 44 |
+| Architecture | `Linear(d,128)->ReLU->Linear(128,128)->ReLU->Linear(128,64)->ReLU->Linear(64,1)` |
+| Optimiser | Adam, lr = 1e-3 |
+| Batch size | 512 |
+| Epochs | 60 |
+| Regularisation | none — no dropout, no weight decay, no early stopping |
+| Shadows | 64, matched to the target in size, architecture and recipe |
+| Primary attack | **online LiRA** |
+| Secondary attack | offline LiRA (descriptive only; never decides the gate) |
+| Permutation replicates | 1000, membership permuted within sensitive group |
+| Target train size | 20,000 rows of the slice; the rest are non-members and the shadow pool |
+| Attack cohort | `SEX x membership` cells equalised, capped at 2,500 per cell |
+
+Feature standardisation is fitted on the whole frozen slice, so it is a property
+of the data and is identical for the target and all 64 shadows; it cannot
+itself distinguish them.
+
+## Continuation gate
+
+All three criteria must hold:
+
+1. mean online-LiRA ROC-AUC across the three seeds **>= 0.60**;
+2. online-LiRA ROC-AUC **> 0.5 on every seed**;
+3. the membership-permutation null **rejected at alpha = 0.05 on all three
+   seeds**.
+
+The gate is **strict**. There is **no reconsideration band**. A result such as
+mean AUC = 0.58 with 3/3 seeds significant is a **FAIL for continuation**; it is
+reported descriptively as measurable leakage below the predeclared continuation
+margin, and is not a basis for continuing.
+
+The gate is evaluated **once**, on this frozen slice, and only after all three
+seeds complete. A missing seed yields `INCOMPLETE`, never a verdict.
+
+## On failure
+
+A FAIL is **terminal** for the natural-leakage Folktables/ACS branch of Study 2:
+
+- stop;
+- do **not** launch the DP epsilon ladder;
+- do **not** tune the target for more leakage;
+- do **not** retry another state, year, task, architecture, epoch budget or
+  model after seeing the result;
+- report that the natural-leakage branch is closed.
+
+The preregistered fallback direction is **canary-based auditing**. It is
+*identified* here only. It is not implemented and not run until its own estimand
+and analysis plan are frozen separately.
+
+## On success
+
+A PASS licenses the DP epsilon ladder on this slice. Nothing downstream is
+triggered automatically: the workflow uploads artifacts, commits nothing, and
+never dispatches a ladder workflow on either verdict.
+
+## Running it
+
+Manual dispatch only (`workflow_dispatch`, confirmation input `RUN-PHASE-0`).
+Pull requests run lint, unit tests and a synthetic smoke run that never touches
+the network; smoke and any budget-deviating run is stamped "Not a Phase 0
+result" in its report and can never be read as the gate.

--- a/research/study2_acs_slice.py
+++ b/research/study2_acs_slice.py
@@ -1,0 +1,334 @@
+"""Frozen ACS/Folktables data slice for Study 2, Phase 0.
+
+Phase 0 asks one question only: does a *naturally* trained (non-private) model
+on real ACS data leak membership strongly enough to be worth building a DP
+epsilon ladder on top of? A question of that kind is only answerable once, and
+only if the data it is asked about cannot drift. Everything the slice depends
+on is therefore frozen here as a module constant, and the runner refuses to
+proceed unless the materialised slice reproduces the frozen fingerprint:
+
+* task ``ACSIncome`` as defined by Ding et al. (2021) ("Retiring Adult"),
+* ACS PUMS survey year 2018, 1-Year horizon, state CA,
+* the sensitive attribute is ``SEX``,
+* exactly 50,000 eligible rows, drawn with the fixed sampling seed 20260822.
+
+The eligibility filter and the feature/target definitions below are the
+Folktables ``ACSIncome`` definitions restated in full rather than imported, so
+that the frozen slice does not silently change if an upstream package changes
+its defaults. 2018 is a ``RELP`` year -- ``RELSHIPP`` only replaces it from 2019
+-- which is one more reason the year is frozen rather than parameterised.
+
+Nothing here trains anything. It downloads, caches, filters, samples, verifies
+and reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+# --------------------------------------------------------------------------- #
+# Frozen slice definition
+# --------------------------------------------------------------------------- #
+
+TASK = "ACSIncome"
+SURVEY_YEAR = 2018
+HORIZON = "1-Year"
+STATE = "CA"
+SENSITIVE_ATTRIBUTE = "SEX"
+SAMPLE_ROWS = 50_000
+SAMPLING_SEED = 20260822
+
+#: ACSIncome features, in the frozen column order. ``SEX`` is both a model
+#: feature (as in the published task) and the sensitive attribute the attack is
+#: analysed by; it is not dropped, because dropping it would change the task.
+FEATURES = (
+    "AGEP",
+    "COW",
+    "SCHL",
+    "MAR",
+    "OCCP",
+    "POBP",
+    "RELP",
+    "WKHP",
+    "SEX",
+    "RAC1P",
+)
+TARGET_COLUMN = "PINCP"
+TARGET_THRESHOLD = 50_000
+
+#: Census PUMS person-file location. State FIPS 06 = California.
+PUMS_URL = (
+    "https://www2.census.gov/programs-surveys/acs/data/pums/"
+    f"{SURVEY_YEAR}/{HORIZON}/csv_p{STATE.lower()}.zip"
+)
+PUMS_MEMBER = "psam_p06.csv"
+
+DEFAULT_CACHE_DIR = Path(
+    os.environ.get("STUDY2_ACS_CACHE", Path.home() / ".cache" / "dp-insurance" / "acs")
+)
+
+REQUIRED_COLUMNS = tuple(FEATURES) + (TARGET_COLUMN, "PWGTP")
+
+
+def eligible_rows(frame: pd.DataFrame) -> pd.DataFrame:
+    """The ACSIncome eligibility filter (Ding et al. 2021).
+
+    Employed-age adults with a positive reported income, positive usual hours
+    worked and a valid person weight.
+    """
+    mask = (
+        (frame["AGEP"] > 16)
+        & (frame[TARGET_COLUMN] > 100)
+        & (frame["WKHP"] > 0)
+        & (frame["PWGTP"] >= 1)
+    )
+    return frame.loc[mask]
+
+
+def build_slice(raw: pd.DataFrame) -> pd.DataFrame:
+    """Filter, drop incomplete rows, sample deterministically, freeze order.
+
+    The sample is drawn with :data:`SAMPLING_SEED` from the eligible rows sorted
+    by ``SERIALNO``/index, so the selection depends on the data alone and not on
+    the order the CSV happened to arrive in.
+    """
+    missing = [column for column in REQUIRED_COLUMNS if column not in raw.columns]
+    if missing:
+        raise ValueError(f"PUMS frame is missing required columns: {', '.join(missing)}")
+
+    frame = eligible_rows(raw)
+    frame = frame.dropna(subset=list(REQUIRED_COLUMNS))
+    frame = frame.sort_index(kind="stable")
+    if len(frame) < SAMPLE_ROWS:
+        raise ValueError(
+            f"only {len(frame)} eligible rows; the frozen slice needs {SAMPLE_ROWS}"
+        )
+
+    rng = np.random.default_rng(SAMPLING_SEED)
+    positions = np.sort(rng.choice(len(frame), size=SAMPLE_ROWS, replace=False))
+    sampled = frame.iloc[positions]
+
+    out = pd.DataFrame(index=range(SAMPLE_ROWS))
+    for column in FEATURES:
+        out[column] = sampled[column].to_numpy(dtype=float)
+    out["y"] = (sampled[TARGET_COLUMN].to_numpy(dtype=float) > TARGET_THRESHOLD).astype(int)
+    out["group"] = np.where(out["SEX"].to_numpy() == 1, "male", "female")
+    return out
+
+
+def slice_fingerprint(frame: pd.DataFrame) -> str:
+    """SHA-256 over the slice's contents in its exact row and column order.
+
+    Row order is part of the design: shadow schedules and per-example records
+    are keyed by cohort position, so a reordered slice is a different slice even
+    when it holds the same rows.
+    """
+    digest = hashlib.sha256()
+    digest.update(",".join(frame.columns).encode())
+    values = frame[list(FEATURES) + ["y"]].to_numpy(dtype=float)
+    digest.update(np.ascontiguousarray(values).tobytes())
+    digest.update(",".join(frame["group"].astype(str)).encode())
+    return digest.hexdigest()
+
+
+def slice_metadata(frame: pd.DataFrame) -> dict[str, object]:
+    """Machine-readable description of a materialised slice."""
+    groups = frame["group"].astype(str)
+    return {
+        "task": TASK,
+        "survey_year": SURVEY_YEAR,
+        "horizon": HORIZON,
+        "state": STATE,
+        "sensitive_attribute": SENSITIVE_ATTRIBUTE,
+        "sampling_seed": SAMPLING_SEED,
+        "expected_rows": SAMPLE_ROWS,
+        "rows": int(len(frame)),
+        "features": list(FEATURES),
+        "target": f"{TARGET_COLUMN} > {TARGET_THRESHOLD}",
+        "positive_rate": float(frame["y"].mean()),
+        "group_counts": {
+            group: int((groups == group).sum()) for group in sorted(groups.unique())
+        },
+        "fingerprint": slice_fingerprint(frame),
+        "source_url": PUMS_URL,
+    }
+
+
+def verify_slice(frame: pd.DataFrame, metadata: dict[str, object] | None = None) -> dict[str, object]:
+    """Raise unless ``frame`` is the frozen slice.
+
+    Checks the row count, the frozen column set, both sensitive groups being
+    present with both label classes, and -- when ``metadata`` from an earlier
+    materialisation is supplied -- that the content fingerprint is unchanged.
+    """
+    if len(frame) != SAMPLE_ROWS:
+        raise ValueError(f"slice has {len(frame)} rows; frozen slice is {SAMPLE_ROWS}")
+    expected_columns = list(FEATURES) + ["y", "group"]
+    if list(frame.columns) != expected_columns:
+        raise ValueError(
+            "slice columns differ from the frozen definition: "
+            f"{list(frame.columns)} != {expected_columns}"
+        )
+    if frame.isna().any().any():
+        raise ValueError("slice contains missing values")
+    groups = frame["group"].astype(str)
+    if set(groups.unique()) != {"male", "female"}:
+        raise ValueError(f"slice sensitive groups are {sorted(groups.unique())}")
+    for group in ("male", "female"):
+        labels = frame.loc[groups == group, "y"]
+        if labels.nunique() != 2:
+            raise ValueError(f"group {group!r} does not carry both label classes")
+
+    current = slice_metadata(frame)
+    if metadata is not None and str(metadata.get("fingerprint")) != current["fingerprint"]:
+        raise ValueError(
+            "slice fingerprint does not match the recorded metadata; the frozen "
+            "slice has changed and Phase 0 must not be run against it"
+        )
+    return current
+
+
+# --------------------------------------------------------------------------- #
+# Download / cache / smoke
+# --------------------------------------------------------------------------- #
+
+
+def download_pums(cache_dir: Path = DEFAULT_CACHE_DIR) -> Path:
+    """Fetch (or reuse) the cached CA 2018 1-Year PUMS person archive."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive = cache_dir / f"csv_p{STATE.lower()}_{SURVEY_YEAR}_{HORIZON}.zip"
+    if archive.exists() and archive.stat().st_size > 0:
+        return archive
+    tmp = archive.with_suffix(".zip.partial")
+    with urllib.request.urlopen(PUMS_URL) as response, tmp.open("wb") as handle:
+        while chunk := response.read(1 << 20):
+            handle.write(chunk)
+    tmp.replace(archive)
+    return archive
+
+
+def read_pums_archive(archive: Path) -> pd.DataFrame:
+    """Read the person CSV out of a PUMS zip archive."""
+    with zipfile.ZipFile(archive) as bundle:
+        names = [name for name in bundle.namelist() if name.lower().endswith(".csv")]
+        if not names:
+            raise ValueError(f"no CSV member in {archive}")
+        member = PUMS_MEMBER if PUMS_MEMBER in names else names[0]
+        with bundle.open(member) as handle:
+            return pd.read_csv(
+                io.BytesIO(handle.read()),
+                usecols=list(REQUIRED_COLUMNS),
+                low_memory=False,
+            )
+
+
+def smoke_slice(rows: int = 4_000, seed: int = SAMPLING_SEED) -> pd.DataFrame:
+    """A synthetic ACS-shaped frame for CI.
+
+    Smoke mode never touches the network and is never a Phase 0 result: it
+    exists so the workflow can exercise download-free plumbing end to end. Every
+    artifact produced from it is stamped ``smoke: true``.
+    """
+    rng = np.random.default_rng(seed)
+    frame = pd.DataFrame(index=range(rows))
+    frame["AGEP"] = rng.integers(17, 90, rows).astype(float)
+    frame["COW"] = rng.integers(1, 9, rows).astype(float)
+    frame["SCHL"] = rng.integers(1, 25, rows).astype(float)
+    frame["MAR"] = rng.integers(1, 6, rows).astype(float)
+    frame["OCCP"] = rng.integers(10, 9800, rows).astype(float)
+    frame["POBP"] = rng.integers(1, 60, rows).astype(float)
+    frame["RELP"] = rng.integers(0, 18, rows).astype(float)
+    frame["WKHP"] = rng.integers(1, 80, rows).astype(float)
+    frame["SEX"] = rng.integers(1, 3, rows).astype(float)
+    frame["RAC1P"] = rng.integers(1, 10, rows).astype(float)
+    logits = (
+        0.04 * (frame["AGEP"] - 40)
+        + 0.10 * (frame["SCHL"] - 12)
+        + 0.03 * (frame["WKHP"] - 40)
+        + rng.normal(0, 1.0, rows)
+    )
+    frame["y"] = (logits > 0).astype(int)
+    frame["group"] = np.where(frame["SEX"].to_numpy() == 1, "male", "female")
+    return frame[list(FEATURES) + ["y", "group"]]
+
+
+def materialise(
+    output: Path,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    smoke: bool = False,
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Produce the slice CSV plus its metadata JSON next to it."""
+    if smoke:
+        frame = smoke_slice()
+        metadata = slice_metadata(frame)
+        metadata.update({"smoke": True, "expected_rows": int(len(frame))})
+    else:
+        raw = read_pums_archive(download_pums(cache_dir))
+        frame = build_slice(raw)
+        metadata = verify_slice(frame)
+        metadata["smoke"] = False
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(output, index=False)
+    output.with_suffix(".metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    return frame, metadata
+
+
+def load_slice(path: Path) -> tuple[pd.DataFrame, dict[str, object]]:
+    """Load a materialised slice and its metadata."""
+    frame = pd.read_csv(path)
+    meta_path = path.with_suffix(".metadata.json")
+    metadata = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    return frame, metadata
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    prepare = sub.add_parser("prepare", help="download, build and write the frozen slice")
+    prepare.add_argument("--output", type=Path, required=True)
+    prepare.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    prepare.add_argument("--smoke", action="store_true")
+
+    verify = sub.add_parser("verify", help="verify a materialised slice against its metadata")
+    verify.add_argument("--slice", dest="slice_path", type=Path, required=True)
+    verify.add_argument(
+        "--smoke",
+        action="store_true",
+        help="allow a synthetic smoke slice (row count check relaxed to its metadata)",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "prepare":
+        _, metadata = materialise(args.output, args.cache_dir, smoke=args.smoke)
+        print(json.dumps(metadata, indent=2))
+        return 0
+
+    frame, metadata = load_slice(args.slice_path)
+    if args.smoke or metadata.get("smoke"):
+        expected = int(metadata.get("expected_rows", len(frame)))
+        if len(frame) != expected:
+            raise SystemExit(f"smoke slice has {len(frame)} rows; expected {expected}")
+        print(json.dumps({**metadata, "verified": "smoke"}, indent=2))
+        return 0
+    verified = verify_slice(frame, metadata or None)
+    print(json.dumps({**verified, "smoke": False, "verified": "frozen"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/research/study2_phase0_natural_leakage.py
+++ b/research/study2_phase0_natural_leakage.py
@@ -1,0 +1,820 @@
+"""Study 2, Phase 0: natural-leakage feasibility gate on ACS/Folktables.
+
+Phase 0 is a *gate*, not an experiment with an interesting outcome. It asks
+whether a naturally (non-privately) trained model on the frozen ACSIncome slice
+leaks membership strongly enough that a DP epsilon ladder built on top of it
+could measure anything at all. If the answer is no, there is nothing for a
+ladder to attenuate, and every downstream comparison would be a comparison of
+noise with noise.
+
+The continuation gate, frozen before any result exists:
+
+1. mean online-LiRA ROC-AUC across the three target seeds >= 0.60,
+2. online-LiRA ROC-AUC > 0.5 on *every* seed,
+3. the stratified membership-permutation null rejected at alpha = 0.05 on all
+   three seeds.
+
+All three must hold. There is deliberately no reconsideration band: a result
+such as mean AUC = 0.58 with 3/3 seeds significant is a **FAIL for
+continuation** and is reported descriptively as measurable leakage below the
+predeclared continuation margin -- not as a near-miss to be argued up.
+
+The gate is evaluated **once**, on the frozen slice defined in
+``research/study2_acs_slice.py``. A FAIL is terminal for the natural-leakage
+Folktables/ACS branch: no other state, year, task, architecture, epoch budget
+or model may be tried after seeing the result, no DP epsilon ladder is launched,
+and the target is not tuned for more leakage. The preregistered fallback
+direction is canary-based auditing, which is *identified* on failure and not
+implemented or run until its own estimand and analysis plan are frozen
+separately.
+
+Online LiRA is the primary attack for this gate; offline LiRA is reported as a
+secondary descriptive measure and never decides the gate.
+
+Subcommands:
+    ``seed``       run one target seed and persist its per-example records;
+    ``aggregate``  combine all seeds, evaluate the gate, print PASS or FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# The attack-power control is this repository's tested implementation of every
+# statistic used below. Reuse it rather than growing a second framework.
+from attack_power_control import (  # noqa: E402
+    ATTACK_FPRS,
+    HEADLINE_FPR,
+    balanced_shadow_train_sets,
+    build_mlp,
+    memorisation_metrics,
+    per_example_bce,
+    stratified_membership_permutation_test,
+    tpr_at_fpr,
+)
+from study2_acs_slice import (  # noqa: E402
+    FEATURES,
+    SAMPLING_SEED,
+    SENSITIVE_ATTRIBUTE,
+    load_slice,
+    slice_metadata,
+    verify_slice,
+)
+
+# --------------------------------------------------------------------------- #
+# Frozen configuration
+# --------------------------------------------------------------------------- #
+
+STUDY = "study2-phase0-natural-leakage"
+TARGET_SEEDS = (42, 43, 44)
+HIDDEN_UNITS = (128, 128, 64)
+LEARNING_RATE = 1e-3
+BATCH_SIZE = 512
+EPOCHS = 60
+NUM_SHADOWS = 64
+PERMUTATION_REPS = 1000
+ALPHA = 0.05
+
+#: Target training-set size; the remainder of the frozen slice supplies
+#: non-members and the shadow pool. Shadow training sets are the same size, so
+#: shadow and target models are matched in every respect except which rows they
+#: saw.
+TRAIN_SIZE = 20_000
+
+#: Cap per ``group x membership`` cell in the attack cohort. Equalising the four
+#: cells keeps the aggregate AUC free of composition effects; the cap bounds the
+#: cost of 1000 permutation replicates without materially affecting the
+#: precision of an AUC estimated from 10,000 examples.
+COHORT_PER_CELL = 2_500
+
+#: LiRA needs a usable Gaussian fit per example on each side.
+MIN_GAUSSIAN_OBSERVATIONS = 10
+
+#: The primary attack for the gate. Offline LiRA is secondary and descriptive.
+PRIMARY_ATTACK = "online"
+SECONDARY_ATTACK = "offline"
+
+#: Gate thresholds. Strict: no reconsideration band.
+GATE_MEAN_AUC = 0.60
+GATE_PER_SEED_AUC = 0.50
+
+PASS = "PASS"
+FAIL = "FAIL"
+
+CONTINUATION_ON_FAIL = (
+    "The natural-leakage Folktables/ACS branch of Study 2 is closed. Do not "
+    "launch the DP epsilon ladder, do not tune the target for more leakage, and "
+    "do not retry another state, year, task, architecture, epoch budget or "
+    "model. The preregistered fallback direction is canary-based auditing, "
+    "which is identified here only; it is not implemented or run until its own "
+    "estimand and analysis plan are frozen separately."
+)
+
+
+def frozen_config(
+    epochs: int = EPOCHS,
+    shadows: int = NUM_SHADOWS,
+    permutation_reps: int = PERMUTATION_REPS,
+    smoke: bool = False,
+) -> dict[str, object]:
+    """The training and attack recipe, plus any deviation from the frozen one."""
+    config = {
+        "study": STUDY,
+        "task": "ACSIncome",
+        "sensitive_attribute": SENSITIVE_ATTRIBUTE,
+        "architecture": "Linear(d,128)->ReLU->Linear(128,128)->ReLU->Linear(128,64)->ReLU->Linear(64,1)",
+        "optimiser": "Adam",
+        "learning_rate": LEARNING_RATE,
+        "batch_size": BATCH_SIZE,
+        "epochs": epochs,
+        "regularisation": "none (no dropout, no weight decay, no early stopping)",
+        "train_size": TRAIN_SIZE,
+        "num_shadows": shadows,
+        "target_seeds": list(TARGET_SEEDS),
+        "sampling_seed": SAMPLING_SEED,
+        "permutation_reps": permutation_reps,
+        "alpha": ALPHA,
+        "primary_attack": PRIMARY_ATTACK,
+        "secondary_attack": SECONDARY_ATTACK,
+        "cohort_per_cell": COHORT_PER_CELL,
+        "smoke": bool(smoke),
+    }
+    deviations = {
+        key: value
+        for key, value, frozen in (
+            ("epochs", epochs, EPOCHS),
+            ("num_shadows", shadows, NUM_SHADOWS),
+            ("permutation_reps", permutation_reps, PERMUTATION_REPS),
+        )
+        if value != frozen
+    }
+    config["deviates_from_frozen"] = deviations
+    return config
+
+
+def is_preregistered(config: dict[str, object]) -> bool:
+    """True only for a run that may be read as a Phase 0 result."""
+    return not config.get("smoke") and not config.get("deviates_from_frozen")
+
+
+# --------------------------------------------------------------------------- #
+# Design construction (pure; no torch needed, so the tests stay cheap)
+# --------------------------------------------------------------------------- #
+
+
+def standardise(features: np.ndarray) -> np.ndarray:
+    """Z-score every column using the whole frozen slice.
+
+    Deliberately fitted on the slice rather than on a split: the scaler is then
+    a property of the frozen data, identical for the target and all 64 shadows,
+    so it cannot itself become a channel that distinguishes them.
+    """
+    features = np.asarray(features, dtype=float)
+    mean = features.mean(axis=0)
+    scale = features.std(axis=0)
+    scale[scale == 0] = 1.0
+    return (features - mean) / scale
+
+
+def split_membership(n_rows: int, train_size: int, seed: int) -> tuple[np.ndarray, np.ndarray]:
+    """Target training indices and the 0/1 membership vector over the slice.
+
+    The permutation is seeded by the *target* seed, so each seed trains on a
+    different subset of the same frozen slice -- the seeds are replicates of the
+    experiment, not three readings of one draw.
+    """
+    if train_size >= n_rows:
+        raise ValueError("train_size must be smaller than the slice")
+    rng = np.random.default_rng(seed)
+    permutation = rng.permutation(n_rows)
+    train_idx = np.sort(permutation[:train_size])
+    membership = np.zeros(n_rows, dtype=int)
+    membership[train_idx] = 1
+    return train_idx, membership
+
+
+def equalised_cohort(
+    groups: np.ndarray,
+    membership: np.ndarray,
+    seed: int,
+    per_cell_cap: int = COHORT_PER_CELL,
+) -> tuple[np.ndarray, dict[str, int]]:
+    """Equal-sized ``group x membership`` cells, capped at ``per_cell_cap``.
+
+    Equal cells mean the aggregate AUC cannot be moved by group composition,
+    and the cap keeps the permutation null affordable at 1000 replicates.
+    """
+    rng = np.random.default_rng(seed)
+    groups = np.asarray(groups).astype(str)
+    membership = np.asarray(membership).astype(int)
+    cells: dict[tuple[str, int], np.ndarray] = {}
+    for group in sorted(np.unique(groups)):
+        for member in (0, 1):
+            idx = np.flatnonzero((groups == group) & (membership == member))
+            if idx.size == 0:
+                raise RuntimeError(f"empty attack cell group={group!r}, membership={member}")
+            cells[(group, member)] = idx
+
+    per_cell = min(per_cell_cap, min(len(idx) for idx in cells.values()))
+    selected: list[int] = []
+    counts: dict[str, int] = {}
+    for (group, member), idx in sorted(cells.items()):
+        chosen = rng.choice(idx, size=per_cell, replace=False)
+        selected.extend(chosen.tolist())
+        counts[f"{group}|member={member}"] = int(per_cell)
+    return np.asarray(sorted(selected), dtype=int), counts
+
+
+def attack_summary(
+    membership: np.ndarray,
+    groups: np.ndarray,
+    scores: np.ndarray,
+    permutation_reps: int,
+    seed: int,
+) -> dict[str, object]:
+    """AUC, TPR at the reported FPRs, per-group AUC and the permutation null."""
+    from sklearn.metrics import roc_auc_score
+
+    membership = np.asarray(membership).astype(int)
+    groups = np.asarray(groups).astype(str)
+    scores = np.asarray(scores, dtype=float)
+
+    permutation = stratified_membership_permutation_test(
+        groups, membership, scores, HEADLINE_FPR, permutation_reps, seed
+    )
+    return {
+        "auc": float(roc_auc_score(membership, scores)),
+        **{f"tpr_at_fpr_{fpr}": tpr_at_fpr(membership, scores, fpr) for fpr in ATTACK_FPRS},
+        "subgroup_auc": {
+            group: float(roc_auc_score(membership[groups == group], scores[groups == group]))
+            for group in sorted(np.unique(groups))
+        },
+        "permutation": permutation,
+        "permutation_p_value": float(permutation["aggregate_auc"]["p_value"]),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Gate evaluation (pure)
+# --------------------------------------------------------------------------- #
+
+
+def evaluate_gate(
+    seed_results: Sequence[dict[str, object]],
+    expected_seeds: Sequence[int] = TARGET_SEEDS,
+) -> dict[str, object]:
+    """Evaluate the three continuation criteria. Never partially evaluated.
+
+    A missing seed is not a smaller experiment: the gate is defined over all
+    three, so an incomplete set is an ``INCOMPLETE`` verdict rather than a gate
+    decision taken on what happened to finish.
+    """
+    by_seed = {int(result["seed"]): result for result in seed_results}
+    missing = [seed for seed in expected_seeds if seed not in by_seed]
+    aucs = [float(by_seed[seed][PRIMARY_ATTACK]["auc"]) for seed in expected_seeds if seed in by_seed]
+    p_values = [
+        float(by_seed[seed][PRIMARY_ATTACK]["permutation_p_value"])
+        for seed in expected_seeds
+        if seed in by_seed
+    ]
+    mean_auc = float(np.mean(aucs)) if aucs else float("nan")
+    significant = [p < ALPHA for p in p_values]
+
+    criteria = [
+        {
+            "id": "mean_auc",
+            "description": f"mean online-LiRA ROC-AUC >= {GATE_MEAN_AUC}",
+            "observed": mean_auc,
+            "threshold": GATE_MEAN_AUC,
+            "passed": bool(aucs) and mean_auc >= GATE_MEAN_AUC,
+        },
+        {
+            "id": "per_seed_auc",
+            "description": f"online-LiRA ROC-AUC > {GATE_PER_SEED_AUC} on every seed",
+            "observed": aucs,
+            "threshold": GATE_PER_SEED_AUC,
+            "passed": bool(aucs) and all(auc > GATE_PER_SEED_AUC for auc in aucs),
+        },
+        {
+            "id": "permutation",
+            "description": f"membership-permutation null rejected at alpha={ALPHA} on all seeds",
+            "observed": p_values,
+            "threshold": ALPHA,
+            "passed": bool(p_values) and all(significant),
+        },
+    ]
+
+    if missing:
+        verdict = "INCOMPLETE"
+        rationale = (
+            "Gate not evaluated: results missing for seed(s) "
+            f"{', '.join(str(seed) for seed in missing)}. The gate is defined over "
+            "all three target seeds and is never evaluated on a partial set."
+        )
+    elif all(item["passed"] for item in criteria):
+        verdict = PASS
+        rationale = (
+            f"All three criteria met (mean online AUC {mean_auc:.4f}, "
+            f"{sum(significant)}/{len(significant)} seeds significant)."
+        )
+    else:
+        verdict = FAIL
+        rationale = (
+            f"Mean online AUC {mean_auc:.4f}; "
+            f"{sum(significant)}/{len(significant)} seeds reject the permutation null. "
+            + " ".join(
+                f"Criterion {item['id']} failed."
+                for item in criteria
+                if not item["passed"]
+            )
+        )
+
+    descriptive = None
+    if verdict == FAIL and any(significant):
+        descriptive = (
+            f"Measurable membership leakage is present ({sum(significant)}/"
+            f"{len(significant)} seeds reject the permutation null at alpha={ALPHA}, "
+            f"mean online-LiRA AUC {mean_auc:.4f}) but below the predeclared "
+            f"continuation margin of {GATE_MEAN_AUC}. This is reported "
+            "descriptively and is not a basis for continuation."
+        )
+
+    return {
+        "verdict": verdict,
+        "gate": PASS if verdict == PASS else FAIL if verdict == FAIL else "INCOMPLETE",
+        "mean_online_auc": mean_auc,
+        "per_seed_online_auc": aucs,
+        "per_seed_permutation_p": p_values,
+        "seeds_significant": int(sum(significant)),
+        "criteria": criteria,
+        "missing_seeds": [int(seed) for seed in missing],
+        "rationale": rationale,
+        "descriptive_note": descriptive,
+        "continuation": (
+            "Continuation criteria met for the natural-leakage branch."
+            if verdict == PASS
+            else CONTINUATION_ON_FAIL
+            if verdict == FAIL
+            else "No continuation decision: the gate was not evaluated."
+        ),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Training and one-seed execution
+# --------------------------------------------------------------------------- #
+
+
+def train_target_model(X: np.ndarray, y: np.ndarray, seed: int, epochs: int, batch_size: int):
+    """Train one non-private model with the frozen recipe."""
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, TensorDataset
+
+    torch.manual_seed(seed)
+    X = np.asarray(X, dtype=np.float32)
+    y = np.asarray(y, dtype=np.float32)
+    dataset = TensorDataset(torch.from_numpy(X), torch.from_numpy(y))
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        dataset,
+        batch_size=min(batch_size, len(dataset)),
+        shuffle=True,
+        generator=generator,
+    )
+    model = build_mlp(X.shape[1], HIDDEN_UNITS, seed)
+    optimiser = torch.optim.Adam(model.parameters(), lr=LEARNING_RATE)
+    loss_fn = nn.BCEWithLogitsLoss()
+    model.train()
+    for _ in range(epochs):
+        for xb, yb in loader:
+            optimiser.zero_grad()
+            loss = loss_fn(model(xb).squeeze(-1), yb)
+            loss.backward()
+            optimiser.step()
+    return model
+
+
+def predict_probability(model, X: np.ndarray, chunk: int = 8192) -> np.ndarray:
+    """Positive-class probabilities, evaluated in chunks to bound memory."""
+    import torch
+
+    model.eval()
+    X = np.asarray(X, dtype=np.float32)
+    out = np.empty(len(X), dtype=float)
+    with torch.no_grad():
+        for start in range(0, len(X), chunk):
+            batch = torch.from_numpy(X[start : start + chunk])
+            out[start : start + chunk] = torch.sigmoid(model(batch).squeeze(-1)).cpu().numpy()
+    return out
+
+
+def run_seed(
+    features: np.ndarray,
+    labels: np.ndarray,
+    groups: np.ndarray,
+    seed: int,
+    epochs: int,
+    shadows: int,
+    permutation_reps: int,
+    batch_size: int,
+    train_size: int,
+    smoke: bool,
+    log,
+) -> dict[str, object]:
+    """Train one target and its matched shadow ensemble, then attack."""
+    from dp.attacks import lira_offline_attack, lira_online_attack
+
+    min_observations = 2 if smoke else MIN_GAUSSIAN_OBSERVATIONS
+    n_rows = len(labels)
+    train_idx, membership = split_membership(n_rows, train_size, seed)
+    nonmember_idx = np.flatnonzero(membership == 0)
+    cohort_idx, cohort_counts = equalised_cohort(groups, membership, seed)
+
+    target = train_target_model(
+        features[train_idx], labels[train_idx], seed=seed, epochs=epochs, batch_size=batch_size
+    )
+    target_prob = predict_probability(target, features)
+    metrics = memorisation_metrics(
+        labels[train_idx],
+        target_prob[train_idx],
+        labels[nonmember_idx],
+        target_prob[nonmember_idx],
+    )
+
+    # Shadow schedule seeded by the target seed alone, so it is reproducible
+    # from the seed and the frozen slice and nothing else.
+    schedule_seed = seed + 10_000
+    train_sets, excluded_counts = balanced_shadow_train_sets(
+        labels, train_size=train_size, num_shadows=shadows, seed=schedule_seed
+    )
+
+    target_losses = per_example_bce(labels[cohort_idx], target_prob[cohort_idx])
+    in_losses: list[list[float]] = [[] for _ in cohort_idx]
+    out_losses: list[list[float]] = [[] for _ in cohort_idx]
+
+    for shadow_id, shadow_train_idx in enumerate(train_sets):
+        if len(shadow_train_idx) != train_size:
+            raise AssertionError("shadow and target train sizes differ")
+        shadow = train_target_model(
+            features[shadow_train_idx],
+            labels[shadow_train_idx],
+            seed=schedule_seed + shadow_id + 1,
+            epochs=epochs,
+            batch_size=batch_size,
+        )
+        shadow_losses = per_example_bce(
+            labels[cohort_idx], predict_probability(shadow, features[cohort_idx])
+        )
+        in_mask = np.zeros(n_rows, dtype=bool)
+        in_mask[shadow_train_idx] = True
+        for position, is_in in enumerate(in_mask[cohort_idx]):
+            (in_losses if is_in else out_losses)[position].append(float(shadow_losses[position]))
+        if shadow_id == 0 or (shadow_id + 1) % 8 == 0:
+            log(f"[seed={seed}] shadow {shadow_id + 1}/{shadows}")
+
+    min_in = min(len(v) for v in in_losses)
+    min_out = min(len(v) for v in out_losses)
+    if min_out != int(excluded_counts[cohort_idx].min()):
+        raise AssertionError("recorded OUT observations do not match the shadow schedule")
+    if min_in < min_observations or min_out < min_observations:
+        raise RuntimeError(
+            f"LiRA needs >= {min_observations} IN and OUT observations per example; "
+            f"got IN={min_in}, OUT={min_out}"
+        )
+
+    in_matrix = np.vstack([np.asarray(v[:min_in], dtype=float) for v in in_losses])
+    out_matrix = np.vstack([np.asarray(v[:min_out], dtype=float) for v in out_losses])
+    cohort_membership = membership[cohort_idx]
+    cohort_groups = groups[cohort_idx].astype(str)
+
+    online = lira_online_attack(
+        target_losses, cohort_membership, in_matrix, out_matrix, fprs=ATTACK_FPRS
+    )
+    offline = lira_offline_attack(target_losses, cohort_membership, out_matrix, fprs=ATTACK_FPRS)
+
+    result: dict[str, object] = {
+        "study": STUDY,
+        "seed": int(seed),
+        "smoke": bool(smoke),
+        "epochs": int(epochs),
+        "batch_size": int(batch_size),
+        "num_shadows": int(shadows),
+        "train_size": int(train_size),
+        "permutation_reps": int(permutation_reps),
+        "cohort_counts": cohort_counts,
+        "num_attack_examples": int(len(cohort_idx)),
+        "min_in_observations": int(min_in),
+        "min_out_observations": int(min_out),
+        "memorisation": metrics,
+        "attack_status": "completed",
+        # Primary. The gate reads this and only this.
+        "online": attack_summary(
+            cohort_membership, cohort_groups, online.scores, permutation_reps, seed + 30_000
+        ),
+        # Secondary, descriptive. Never decides the gate.
+        "offline": attack_summary(
+            cohort_membership, cohort_groups, offline.scores, permutation_reps, seed + 40_000
+        ),
+        "per_example": [
+            {
+                "study": STUDY,
+                "seed": int(seed),
+                "cohort_position": int(position),
+                "example_index": int(example_index),
+                "group": str(cohort_groups[position]),
+                "membership": int(cohort_membership[position]),
+                "target_loss": float(target_losses[position]),
+                "online_score": float(online.scores[position]),
+                "offline_score": float(offline.scores[position]),
+                "in_observations": int(len(in_losses[position])),
+                "out_observations": int(len(out_losses[position])),
+            }
+            for position, example_index in enumerate(cohort_idx)
+        ],
+    }
+    log(
+        f"[seed={seed}] online AUC={result['online']['auc']:.4f} "
+        f"p={result['online']['permutation_p_value']:.4f} | "
+        f"offline AUC={result['offline']['auc']:.4f} "
+        f"(train_auc={metrics['train_auc']:.4f} test_auc={metrics['test_auc']:.4f})"
+    )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+
+def _fmt(value: object, digits: int = 4) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, float):
+        return "n/a" if not np.isfinite(value) else f"{value:.{digits}f}"
+    return str(value)
+
+
+def build_rows(payload: dict[str, object]) -> list[dict[str, object]]:
+    """One flat row per seed for the machine-readable CSV."""
+    rows = []
+    for result in payload["seeds"]:
+        row = {
+            "study": STUDY,
+            "seed": result["seed"],
+            "smoke": result["smoke"],
+            "num_shadows": result["num_shadows"],
+            "epochs": result["epochs"],
+            "num_attack_examples": result["num_attack_examples"],
+            "train_auc": result["memorisation"]["train_auc"],
+            "test_auc": result["memorisation"]["test_auc"],
+            "auc_gap": result["memorisation"]["auc_gap"],
+            "loss_gap": result["memorisation"]["loss_gap"],
+        }
+        for attack in (PRIMARY_ATTACK, SECONDARY_ATTACK):
+            summary = result[attack]
+            row[f"{attack}_auc"] = summary["auc"]
+            row[f"{attack}_tpr_at_fpr_{HEADLINE_FPR}"] = summary[f"tpr_at_fpr_{HEADLINE_FPR}"]
+            row[f"{attack}_permutation_p"] = summary["permutation_p_value"]
+        rows.append(row)
+    return rows
+
+
+def render_markdown(payload: dict[str, object]) -> str:
+    """Human-readable gate report."""
+    gate = payload["gate"]
+    config = payload["config"]
+    lines = [
+        "# Study 2 - Phase 0: natural-leakage feasibility gate",
+        "",
+        f"- Generated: {payload['generated_at']}",
+        f"- Slice: {config['task']} {payload['slice']['state']} "
+        f"{payload['slice']['survey_year']} {payload['slice']['horizon']}, "
+        f"{payload['slice']['rows']} rows, fingerprint `{payload['slice']['fingerprint'][:16]}`",
+        f"- Sensitive attribute: `{config['sensitive_attribute']}`",
+        f"- Recipe: {config['architecture']}, Adam lr={config['learning_rate']}, "
+        f"batch={config['batch_size']}, epochs={config['epochs']}, "
+        f"{config['regularisation']}",
+        f"- Shadows per seed: {config['num_shadows']}; permutation replicates: "
+        f"{config['permutation_reps']}",
+        "- Primary attack: online LiRA. Secondary (descriptive): offline LiRA.",
+        "",
+    ]
+    if not payload["preregistered"]:
+        lines += [
+            "> **Not a Phase 0 result.** This run is a smoke run or deviates from the "
+            "frozen configuration "
+            f"(`{json.dumps(config['deviates_from_frozen'])}`, smoke={config['smoke']}). "
+            "Its numbers must not be read as the gate.",
+            "",
+        ]
+
+    lines += [
+        f"## Gate: {gate['gate']}",
+        "",
+        gate["rationale"],
+        "",
+        "| Criterion | Threshold | Observed | Result |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in gate["criteria"]:
+        observed = (
+            ", ".join(_fmt(v) for v in item["observed"])
+            if isinstance(item["observed"], list)
+            else _fmt(item["observed"])
+        )
+        lines.append(
+            f"| {item['description']} | {_fmt(item['threshold'])} | {observed} | "
+            f"{'met' if item['passed'] else 'not met'} |"
+        )
+
+    lines += [
+        "",
+        "## Per-seed results",
+        "",
+        "| Seed | online AUC | online TPR@1%FPR | online perm p | offline AUC | "
+        "offline perm p | train AUC | test AUC |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for result in payload["seeds"]:
+        online, offline = result[PRIMARY_ATTACK], result[SECONDARY_ATTACK]
+        lines.append(
+            f"| {result['seed']} | {_fmt(online['auc'])} | "
+            f"{_fmt(online[f'tpr_at_fpr_{HEADLINE_FPR}'])} | "
+            f"{_fmt(online['permutation_p_value'])} | {_fmt(offline['auc'])} | "
+            f"{_fmt(offline['permutation_p_value'])} | "
+            f"{_fmt(result['memorisation']['train_auc'])} | "
+            f"{_fmt(result['memorisation']['test_auc'])} |"
+        )
+
+    if gate.get("descriptive_note"):
+        lines += ["", "## Descriptive reading", "", gate["descriptive_note"]]
+
+    lines += ["", "## Continuation", "", gate["continuation"], ""]
+    return "\n".join(lines)
+
+
+def write_outputs(payload: dict[str, object], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "phase0_gate.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+    rows = build_rows(payload)
+    with (output_dir / "phase0_gate.csv").open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]) if rows else ["seed"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    per_example = [record for result in payload["seeds"] for record in result.get("per_example", [])]
+    if per_example:
+        with (output_dir / "per_example.csv").open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=list(per_example[0]))
+            writer.writeheader()
+            writer.writerows(per_example)
+
+    (output_dir / "phase0_gate.md").write_text(render_markdown(payload) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _prepare_arrays(slice_path: Path, smoke: bool) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict]:
+    frame, metadata = load_slice(slice_path)
+    if smoke or metadata.get("smoke"):
+        metadata = {**slice_metadata(frame), "smoke": True}
+    else:
+        metadata = {**verify_slice(frame, metadata or None), "smoke": False}
+    features = standardise(frame[list(FEATURES)].to_numpy(dtype=float))
+    labels = frame["y"].to_numpy(dtype=int)
+    groups = frame["group"].astype(str).to_numpy()
+    return features, labels, groups, metadata
+
+
+def run_seed_command(args: argparse.Namespace) -> int:
+    log = print
+    features, labels, groups, slice_meta = _prepare_arrays(args.slice_path, args.smoke)
+    # The frozen slice is 50,000 rows, so this is exactly TRAIN_SIZE there; the
+    # min() only bites on a smaller smoke slice, which is never a Phase 0 result.
+    train_size = args.train_size or min(TRAIN_SIZE, len(labels) // 2)
+    config = frozen_config(args.epochs, args.shadows, args.permutation_reps, args.smoke)
+    result = run_seed(
+        features,
+        labels,
+        groups,
+        seed=args.seed,
+        epochs=args.epochs,
+        shadows=args.shadows,
+        permutation_reps=args.permutation_reps,
+        batch_size=args.batch_size,
+        train_size=train_size,
+        smoke=args.smoke,
+        log=log,
+    )
+    result["config"] = config
+    result["slice"] = slice_meta
+    result["preregistered"] = is_preregistered(config)
+    result["generated_at"] = datetime.now(timezone.utc).isoformat()
+    result["python"] = platform.python_version()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    destination = args.output_dir / f"seed_{args.seed}.json"
+    destination.write_text(json.dumps(result, indent=2) + "\n")
+    log(f"wrote {destination}")
+    return 0
+
+
+def aggregate_command(args: argparse.Namespace) -> int:
+    seed_files = sorted(args.input_dir.glob("seed_*.json"))
+    results = [json.loads(path.read_text()) for path in seed_files]
+    results.sort(key=lambda result: int(result["seed"]))
+    if not results:
+        raise SystemExit(f"no seed_*.json results under {args.input_dir}")
+
+    fingerprints = {str(result["slice"]["fingerprint"]) for result in results}
+    if len(fingerprints) != 1:
+        raise SystemExit(
+            "seed results were produced from different data slices; the gate is "
+            "defined on a single frozen slice and cannot be aggregated across them"
+        )
+
+    gate = evaluate_gate(results)
+    if args.expect_all and gate["verdict"] == "INCOMPLETE":
+        # Aggregate only after every seed completes: a gate decision taken on a
+        # partial set is not the preregistered gate.
+        write_outputs(
+            {
+                "study": STUDY,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "config": results[0]["config"],
+                "slice": results[0]["slice"],
+                "preregistered": all(result["preregistered"] for result in results),
+                "seeds": results,
+                "gate": gate,
+            },
+            args.output_dir,
+        )
+        print(gate["rationale"])
+        print(f"CONTINUATION GATE: {gate['gate']}")
+        return 1
+
+    payload = {
+        "study": STUDY,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "config": results[0]["config"],
+        "slice": results[0]["slice"],
+        "preregistered": all(result["preregistered"] for result in results),
+        "seeds": results,
+        "gate": gate,
+    }
+    write_outputs(payload, args.output_dir)
+
+    print(render_markdown(payload))
+    # The single machine-readable line the workflow greps for.
+    print(f"CONTINUATION GATE: {gate['gate']}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    seed = sub.add_parser("seed", help="run one target seed")
+    seed.add_argument("--slice", dest="slice_path", type=Path, required=True)
+    seed.add_argument("--seed", type=int, required=True)
+    seed.add_argument("--epochs", type=int, default=EPOCHS)
+    seed.add_argument("--shadows", type=int, default=NUM_SHADOWS)
+    seed.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    seed.add_argument("--train-size", type=int, default=None)
+    seed.add_argument("--permutation-reps", type=int, default=PERMUTATION_REPS)
+    seed.add_argument("--output-dir", type=Path, required=True)
+    seed.add_argument("--smoke", action="store_true")
+
+    aggregate = sub.add_parser("aggregate", help="combine seeds and evaluate the gate")
+    aggregate.add_argument("--input-dir", type=Path, required=True)
+    aggregate.add_argument("--output-dir", type=Path, required=True)
+    aggregate.add_argument(
+        "--expect-all",
+        action="store_true",
+        help="fail if any of the three frozen target seeds is missing",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "seed":
+        return run_seed_command(args)
+    return aggregate_command(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/test_study2_phase0.py
+++ b/tests/test_study2_phase0.py
@@ -1,0 +1,369 @@
+"""Tests for Study 2 Phase 0: the frozen slice and the continuation gate.
+
+The gate logic is where a mistake would be worst -- a strict, once-only,
+terminal decision -- so it is tested exhaustively against the four ways it can
+be reached, including the case the preregistration singles out: measurable
+leakage that still fails continuation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+RESEARCH = Path(__file__).resolve().parents[1] / "research"
+sys.path.insert(0, str(RESEARCH))
+
+import study2_acs_slice as acs  # noqa: E402
+import study2_phase0_natural_leakage as phase0  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Frozen slice
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_constants_match_the_preregistration():
+    assert (acs.TASK, acs.SURVEY_YEAR, acs.HORIZON, acs.STATE) == (
+        "ACSIncome",
+        2018,
+        "1-Year",
+        "CA",
+    )
+    assert acs.SENSITIVE_ATTRIBUTE == "SEX"
+    assert (acs.SAMPLE_ROWS, acs.SAMPLING_SEED) == (50_000, 20260822)
+    assert phase0.TARGET_SEEDS == (42, 43, 44)
+    assert phase0.HIDDEN_UNITS == (128, 128, 64)
+    assert (phase0.LEARNING_RATE, phase0.BATCH_SIZE, phase0.EPOCHS) == (1e-3, 512, 60)
+    assert (phase0.NUM_SHADOWS, phase0.PERMUTATION_REPS, phase0.ALPHA) == (64, 1000, 0.05)
+    assert (phase0.GATE_MEAN_AUC, phase0.GATE_PER_SEED_AUC) == (0.60, 0.50)
+    assert phase0.PRIMARY_ATTACK == "online"
+
+
+def _raw_pums(rows: int = 60_000, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    frame = pd.DataFrame(
+        {
+            "AGEP": rng.integers(10, 90, rows),
+            "COW": rng.integers(1, 9, rows),
+            "SCHL": rng.integers(1, 25, rows),
+            "MAR": rng.integers(1, 6, rows),
+            "OCCP": rng.integers(10, 9800, rows),
+            "POBP": rng.integers(1, 60, rows),
+            "RELP": rng.integers(0, 18, rows),
+            "WKHP": rng.integers(0, 80, rows),
+            "SEX": rng.integers(1, 3, rows),
+            "RAC1P": rng.integers(1, 10, rows),
+            "PINCP": rng.integers(0, 200_000, rows),
+            "PWGTP": rng.integers(1, 100, rows),
+        }
+    )
+    return frame
+
+
+def test_eligibility_filter_matches_the_acsincome_definition():
+    raw = _raw_pums()
+    kept = acs.eligible_rows(raw)
+    assert (kept["AGEP"] > 16).all()
+    assert (kept["PINCP"] > 100).all()
+    assert (kept["WKHP"] > 0).all()
+    assert (kept["PWGTP"] >= 1).all()
+    # Nothing eligible was dropped.
+    dropped = raw.drop(index=kept.index)
+    assert not (
+        (dropped["AGEP"] > 16)
+        & (dropped["PINCP"] > 100)
+        & (dropped["WKHP"] > 0)
+        & (dropped["PWGTP"] >= 1)
+    ).any()
+
+
+def test_build_slice_is_deterministic_and_exactly_fifty_thousand_rows():
+    raw = _raw_pums()
+    first = acs.build_slice(raw)
+    second = acs.build_slice(raw)
+    assert len(first) == acs.SAMPLE_ROWS
+    assert list(first.columns) == list(acs.FEATURES) + ["y", "group"]
+    pd.testing.assert_frame_equal(first, second)
+    assert acs.slice_fingerprint(first) == acs.slice_fingerprint(second)
+
+
+def test_build_slice_refuses_a_pool_smaller_than_the_frozen_sample():
+    with pytest.raises(ValueError, match="eligible rows"):
+        acs.build_slice(_raw_pums(rows=1_000))
+
+
+def test_verify_slice_rejects_a_changed_slice():
+    frame = acs.build_slice(_raw_pums())
+    metadata = acs.verify_slice(frame)
+    assert metadata["rows"] == acs.SAMPLE_ROWS
+
+    tampered = frame.copy()
+    tampered.loc[0, "AGEP"] = tampered.loc[0, "AGEP"] + 1
+    with pytest.raises(ValueError, match="fingerprint"):
+        acs.verify_slice(tampered, metadata)
+
+    with pytest.raises(ValueError, match="rows"):
+        acs.verify_slice(frame.iloc[:-1], metadata)
+
+
+def test_verify_slice_rejects_reordered_rows():
+    frame = acs.build_slice(_raw_pums())
+    metadata = acs.verify_slice(frame)
+    reordered = frame.iloc[::-1].reset_index(drop=True)
+    with pytest.raises(ValueError, match="fingerprint"):
+        acs.verify_slice(reordered, metadata)
+
+
+def test_smoke_slice_is_stamped_and_never_mistaken_for_the_frozen_slice(tmp_path):
+    output = tmp_path / "slice.csv"
+    frame, metadata = acs.materialise(output, tmp_path / "cache", smoke=True)
+    assert metadata["smoke"] is True
+    assert len(frame) != acs.SAMPLE_ROWS
+    assert acs.main(["verify", "--slice", str(output)]) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Design construction
+# --------------------------------------------------------------------------- #
+
+
+def test_split_membership_is_seed_dependent_and_exact():
+    train_a, membership_a = phase0.split_membership(1_000, 400, seed=42)
+    train_b, _ = phase0.split_membership(1_000, 400, seed=43)
+    assert len(train_a) == 400
+    assert membership_a.sum() == 400
+    assert membership_a[train_a].all()
+    assert not np.array_equal(train_a, train_b)
+    # Reproducible from the seed alone.
+    assert np.array_equal(train_a, phase0.split_membership(1_000, 400, seed=42)[0])
+
+
+def test_equalised_cohort_balances_every_group_by_membership_cell():
+    rng = np.random.default_rng(0)
+    groups = np.where(rng.random(2_000) < 0.4, "female", "male")
+    membership = (rng.random(2_000) < 0.3).astype(int)
+    idx, counts = phase0.equalised_cohort(groups, membership, seed=42, per_cell_cap=50)
+    assert set(counts.values()) == {50}
+    assert len(idx) == 200
+    for group in ("male", "female"):
+        for member in (0, 1):
+            cell = (groups[idx] == group) & (membership[idx] == member)
+            assert cell.sum() == 50
+
+
+def test_standardise_leaves_zero_variance_columns_finite():
+    features = np.column_stack([np.arange(10.0), np.ones(10)])
+    scaled = phase0.standardise(features)
+    assert np.isfinite(scaled).all()
+    assert scaled[:, 1].std() == 0
+
+
+# --------------------------------------------------------------------------- #
+# The continuation gate
+# --------------------------------------------------------------------------- #
+
+
+def _seed_result(seed: int, auc: float, p_value: float) -> dict:
+    return {
+        "seed": seed,
+        "smoke": False,
+        "epochs": phase0.EPOCHS,
+        "num_shadows": phase0.NUM_SHADOWS,
+        "num_attack_examples": 10_000,
+        "memorisation": {
+            "train_auc": 0.9,
+            "test_auc": 0.8,
+            "auc_gap": 0.1,
+            "loss_gap": 0.1,
+        },
+        "online": {
+            "auc": auc,
+            f"tpr_at_fpr_{phase0.HEADLINE_FPR}": 0.02,
+            "permutation_p_value": p_value,
+        },
+        "offline": {
+            "auc": auc - 0.02,
+            f"tpr_at_fpr_{phase0.HEADLINE_FPR}": 0.015,
+            "permutation_p_value": p_value,
+        },
+    }
+
+
+def test_gate_passes_only_when_all_three_criteria_hold():
+    gate = phase0.evaluate_gate(
+        [_seed_result(42, 0.64, 0.001), _seed_result(43, 0.61, 0.001), _seed_result(44, 0.62, 0.001)]
+    )
+    assert gate["gate"] == phase0.PASS
+    assert all(item["passed"] for item in gate["criteria"])
+    assert gate["descriptive_note"] is None
+
+
+def test_measurable_leakage_below_the_margin_is_still_a_fail():
+    # The case the preregistration singles out: AUC 0.58, 3/3 significant.
+    gate = phase0.evaluate_gate(
+        [_seed_result(42, 0.58, 0.001), _seed_result(43, 0.58, 0.001), _seed_result(44, 0.58, 0.001)]
+    )
+    assert gate["gate"] == phase0.FAIL
+    assert gate["seeds_significant"] == 3
+    # It is nevertheless reported descriptively rather than as "no leakage".
+    assert "below the predeclared continuation margin" in gate["descriptive_note"]
+    assert "canary" in gate["continuation"]
+    assert "epsilon ladder" in gate["continuation"]
+
+
+def test_high_mean_auc_fails_if_one_seed_is_not_significant():
+    gate = phase0.evaluate_gate(
+        [_seed_result(42, 0.70, 0.001), _seed_result(43, 0.70, 0.001), _seed_result(44, 0.70, 0.20)]
+    )
+    assert gate["gate"] == phase0.FAIL
+    failed = [item["id"] for item in gate["criteria"] if not item["passed"]]
+    assert failed == ["permutation"]
+
+
+def test_high_mean_auc_fails_if_one_seed_is_at_or_below_chance():
+    gate = phase0.evaluate_gate(
+        [_seed_result(42, 0.85, 0.001), _seed_result(43, 0.85, 0.001), _seed_result(44, 0.50, 0.001)]
+    )
+    assert gate["gate"] == phase0.FAIL
+    assert "per_seed_auc" in [item["id"] for item in gate["criteria"] if not item["passed"]]
+
+
+def test_gate_is_incomplete_rather_than_decided_on_a_partial_seed_set():
+    gate = phase0.evaluate_gate([_seed_result(42, 0.9, 0.001), _seed_result(43, 0.9, 0.001)])
+    assert gate["verdict"] == "INCOMPLETE"
+    assert gate["missing_seeds"] == [44]
+    assert "No continuation decision" in gate["continuation"]
+
+
+def test_failure_continuation_text_closes_the_branch_without_launching_the_ladder():
+    gate = phase0.evaluate_gate(
+        [_seed_result(seed, 0.51, 0.9) for seed in phase0.TARGET_SEEDS]
+    )
+    assert gate["gate"] == phase0.FAIL
+    text = gate["continuation"].lower()
+    assert "do not launch the dp epsilon ladder" in text
+    assert "do not tune the target" in text
+    assert "not implemented or run until its own estimand" in text
+
+
+# --------------------------------------------------------------------------- #
+# Reporting and provenance
+# --------------------------------------------------------------------------- #
+
+
+def _payload(gate_results) -> dict:
+    return {
+        "study": phase0.STUDY,
+        "generated_at": "2026-08-22T00:00:00+00:00",
+        "config": phase0.frozen_config(),
+        "slice": {
+            "state": "CA",
+            "survey_year": 2018,
+            "horizon": "1-Year",
+            "rows": 50_000,
+            "fingerprint": "0" * 64,
+        },
+        "preregistered": True,
+        "seeds": gate_results,
+        "gate": phase0.evaluate_gate(gate_results),
+    }
+
+
+def test_markdown_report_states_the_gate_and_every_criterion():
+    payload = _payload([_seed_result(seed, 0.58, 0.001) for seed in phase0.TARGET_SEEDS])
+    markdown = phase0.render_markdown(payload)
+    assert "## Gate: FAIL" in markdown
+    assert "mean online-LiRA ROC-AUC >= 0.6" in markdown
+    assert "Descriptive reading" in markdown
+
+
+def test_smoke_and_deviating_runs_are_never_presented_as_phase_0_results():
+    frozen = phase0.frozen_config()
+    assert phase0.is_preregistered(frozen)
+    assert not phase0.is_preregistered(phase0.frozen_config(smoke=True))
+    assert not phase0.is_preregistered(phase0.frozen_config(epochs=5))
+
+    payload = _payload([_seed_result(seed, 0.9, 0.001) for seed in phase0.TARGET_SEEDS])
+    payload["preregistered"] = False
+    payload["config"] = phase0.frozen_config(epochs=5, smoke=True)
+    assert "Not a Phase 0 result" in phase0.render_markdown(payload)
+
+
+def test_write_outputs_emits_json_csv_and_markdown(tmp_path):
+    payload = _payload([_seed_result(seed, 0.62, 0.001) for seed in phase0.TARGET_SEEDS])
+    for result in payload["seeds"]:
+        result["per_example"] = [
+            {
+                "study": phase0.STUDY,
+                "seed": result["seed"],
+                "cohort_position": 0,
+                "example_index": 3,
+                "group": "male",
+                "membership": 1,
+                "target_loss": 0.1,
+                "online_score": 1.2,
+                "offline_score": 0.8,
+                "in_observations": 32,
+                "out_observations": 32,
+            }
+        ]
+    phase0.write_outputs(payload, tmp_path)
+    stored = json.loads((tmp_path / "phase0_gate.json").read_text())
+    assert stored["gate"]["gate"] == phase0.PASS
+    assert (tmp_path / "phase0_gate.csv").read_text().splitlines()[0].startswith("study,seed")
+    assert "## Gate: PASS" in (tmp_path / "phase0_gate.md").read_text()
+    # Per-example records are the raw design; losing them is unrecoverable.
+    assert (tmp_path / "per_example.csv").exists()
+
+
+def test_aggregate_refuses_to_mix_slices(tmp_path):
+    inputs = tmp_path / "in"
+    inputs.mkdir()
+    for offset, seed in enumerate(phase0.TARGET_SEEDS):
+        result = _seed_result(seed, 0.7, 0.001)
+        result["config"] = phase0.frozen_config()
+        result["preregistered"] = True
+        result["slice"] = {"fingerprint": f"{offset}" * 64, "state": "CA"}
+        (inputs / f"seed_{seed}.json").write_text(json.dumps(result))
+    args = ["aggregate", "--input-dir", str(inputs), "--output-dir", str(tmp_path / "out")]
+    with pytest.raises(SystemExit, match="different data slices"):
+        phase0.main(args)
+
+
+@pytest.mark.slow
+def test_seed_command_runs_end_to_end_in_smoke_mode(tmp_path):
+    pytest.importorskip("torch")
+    slice_path = tmp_path / "slice.csv"
+    acs.materialise(slice_path, tmp_path / "cache", smoke=True)
+    out = tmp_path / "seeds"
+    assert (
+        phase0.main(
+            [
+                "seed",
+                "--slice",
+                str(slice_path),
+                "--seed",
+                "42",
+                "--epochs",
+                "2",
+                "--shadows",
+                "4",
+                "--permutation-reps",
+                "20",
+                "--output-dir",
+                str(out),
+                "--smoke",
+            ]
+        )
+        == 0
+    )
+    stored = json.loads((out / "seed_42.json").read_text())
+    assert stored["attack_status"] == "completed"
+    assert stored["preregistered"] is False
+    assert stored["online"]["auc"] > 0
+    assert len(stored["per_example"]) == stored["num_attack_examples"]


### PR DESCRIPTION
Implements Study 2 Phase 0 and nothing downstream of it. **No Phase 0 results are produced in this PR** — the gate runs by manual dispatch only.

## What Phase 0 is

A once-only gate: does a naturally (non-privately) trained model on a frozen ACS slice leak membership strongly enough that a DP epsilon ladder could measure anything? If not, every downstream privacy-utility comparison is noise against noise.

## Frozen design

ACSIncome · 2018 · 1-Year · CA · sensitive attribute `SEX` · 50,000 eligible rows at sampling seed `20260822` · target seeds 42/43/44 · `Linear(d,128)->ReLU->128->ReLU->64->ReLU->1` · Adam lr 1e-3 · batch 512 · 60 epochs · no dropout/weight decay/early stopping · 64 matched shadows · online LiRA primary, offline LiRA secondary · 1000 permutation replicates.

## Continuation gate

All three must hold: mean online-LiRA AUC ≥ 0.60; AUC > 0.5 on every seed; membership-permutation null rejected at α=.05 on all three seeds.

Strict, with no reconsideration band. AUC=.58 with 3/3 significant is a **FAIL for continuation**, reported descriptively as measurable leakage below the predeclared margin. A partial seed set yields `INCOMPLETE`, never a verdict. On FAIL the report closes the natural-leakage branch, forbids the epsilon ladder and any retry on another slice/architecture/budget, and names canary-based auditing as the fallback direction without implementing it.

## Changes

- `research/study2_acs_slice.py` — download/cache the PUMS archive, restate the ACSIncome eligibility and feature definitions in full rather than importing them, deterministic 50,000-row sample, content fingerprint over rows *in order* (position is part of the design), verification that refuses a changed or reordered slice.
- `research/study2_phase0_natural_leakage.py` — `seed` and `aggregate` subcommands. Reuses the tested statistics in `research/attack_power_control.py` and the LiRA implementations in `src/dp/attacks.py` rather than growing a second framework. Persists per-example attack outputs; refuses to aggregate seeds produced from different slices.
- `.github/workflows/study2-phase0-natural-leakage.yml` — manual dispatch gated on an explicit `RUN-PHASE-0` confirmation; caches and verifies the slice (row count and metadata asserted), matrixes the three seeds, aggregates only after all seeds finish, emits JSON/CSV/Markdown and prints exactly `CONTINUATION GATE: PASS|FAIL`. Nothing is committed back and no downstream ladder is dispatched on either verdict.
- `tests/test_study2_phase0.py` — 21 tests covering the frozen constants, the eligibility filter, slice determinism and tamper/reorder detection, cohort construction, every path through the gate (including the AUC-.58-but-significant case), report provenance stamping, and a `slow`-marked end-to-end smoke run.
- `docs/STUDY2_PHASE0_PREREGISTRATION.md`.

## Smoke mode

PR CI runs a network-free synthetic slice with tiny budgets across all three seeds and the full aggregation path. Any smoke or budget-deviating run is stamped "Not a Phase 0 result" in its own report, so CI can never produce a gate verdict.

## Validation

`ruff check src tests research/study2_*.py` clean; `pytest -m "not slow"` → 313 passed, 10 skipped; the `slow` end-to-end smoke test passes locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Af2XXqzFHyW7ucVKhtYAP)_